### PR TITLE
Implement calendar add-event modal and fix modal scope bug

### DIFF
--- a/Blood Optimization Platform - v0.4.2.html
+++ b/Blood Optimization Platform - v0.4.2.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blood Optimization Platform v0.3.9 - Megedition | Hemo bioscience</title>
+    <title>Blood Optimization Platform v0.4.2 - Megedition | Hemo bioscience</title>
     <style>
       * {
         margin: 0;
@@ -1730,7 +1730,7 @@
       <!-- Header Bar -->
       <header class="header-bar">
         <div class="header-left">
-          <div class="version-badge">v0.3.9 - Megedition</div>
+          <div class="version-badge">v0.4.2 - Megedition</div>
           <div class="active-users" id="active-users" style="display: none">
             <span>👤 Active:</span>
             <span id="active-user-list">-</span>
@@ -2704,126 +2704,6 @@
                 </div>
               </div>
             </div>
-
-            <div class="card">
-              <div class="card-header">
-                <h3 class="card-title">Add Calendar Entry</h3>
-              </div>
-
-              <div class="form-grid">
-                <div class="form-group">
-                  <label class="form-label">Date</label>
-                  <input type="date" class="form-input" id="calendar-date" />
-                </div>
-                <div class="form-group">
-                  <label class="form-label">Entry Type</label>
-                  <select
-                    class="form-select"
-                    id="calendar-type"
-                    onchange="handleTypeChange('manual')"
-                  >
-                    <!-- Will be populated by JavaScript -->
-                  </select>
-                </div>
-                <div class="form-group">
-                  <label class="form-label">Description</label>
-                  <input
-                    type="text"
-                    class="form-input"
-                    id="calendar-description"
-                    placeholder="e.g., C3/HQC, WSLH PT24-01"
-                  />
-                </div>
-              </div>
-
-              <!-- Recurrence Settings (hidden by default) -->
-              <div id="manual-recurrence-settings" style="display: none">
-                <h4 style="margin-top: 1.5rem; margin-bottom: 1rem">Recurrence Settings</h4>
-                <div class="form-grid">
-                  <div class="form-group">
-                    <label class="form-label">Repeat Every</label>
-                    <div style="display: flex; gap: 0.5rem">
-                      <input
-                        type="number"
-                        class="form-input"
-                        id="manual-recurrence-interval"
-                        style="width: 80px"
-                        min="1"
-                        value="1"
-                      />
-                      <select
-                        class="form-select"
-                        id="manual-recurrence-unit"
-                        onchange="handleUnitChange('manual')"
-                      >
-                        <option value="days">Days</option>
-                        <option value="weeks">Weeks</option>
-                        <option value="months">Months</option>
-                        <option value="custom">Custom</option>
-                      </select>
-                    </div>
-                  </div>
-                  <div class="form-group" id="manual-custom-pattern-group" style="display: none">
-                    <label class="form-label">Custom Pattern</label>
-                    <input
-                      type="text"
-                      class="form-input"
-                      id="manual-custom-pattern"
-                      placeholder="e.g., First Monday of month"
-                    />
-                  </div>
-                  <div class="form-group">
-                    <label class="form-label">End Condition</label>
-                    <select
-                      class="form-select"
-                      id="manual-recurrence-end-type"
-                      onchange="handleEndTypeChange('manual')"
-                    >
-                      <option value="never">Never</option>
-                      <option value="count">After occurrences</option>
-                      <option value="date">On date</option>
-                    </select>
-                  </div>
-                  <div class="form-group" id="manual-end-count-group" style="display: none">
-                    <label class="form-label">Number of Occurrences</label>
-                    <input
-                      type="number"
-                      class="form-input"
-                      id="manual-end-count"
-                      min="1"
-                      value="10"
-                    />
-                  </div>
-                  <div class="form-group" id="manual-end-date-group" style="display: none">
-                    <label class="form-label">End Date</label>
-                    <input type="date" class="form-input" id="manual-end-date" />
-                  </div>
-                </div>
-              </div>
-
-              <button class="btn btn-primary" onclick="addCalendarEntry()">Add Entry</button>
-            </div>
-
-            <div class="card">
-              <div class="card-header">
-                <h3 class="card-title">Import Schedule</h3>
-              </div>
-              <div class="upload-area" onclick="document.getElementById('schedule-csv').click()">
-                <input
-                  type="file"
-                  id="schedule-csv"
-                  class="upload-input"
-                  accept=".csv"
-                  onchange="handleScheduleCSV(event)"
-                />
-                <div class="upload-icon">📅</div>
-                <div>Click to upload schedule CSV file</div>
-                <div style="font-size: 0.875rem; color: var(--gray); margin-top: 0.5rem">
-                  Format: customer, type, event, bleed_date, ship_date, expiration_date
-                </div>
-              </div>
-              <div id="schedule-import-status"></div>
-            </div>
           </div>
           <!-- closes .content-body -->
         </div>
@@ -3285,18 +3165,18 @@
       </div>
     </div>
 
-    <!-- Calendar Entry Modal -->
-    <div id="calendar-entry-modal" class="modal">
+    <!-- Calendar Add Event Modal -->
+    <div id="calendar-add-event-modal" class="modal">
       <div class="modal-content">
         <div class="modal-header">
-          <h3 class="modal-title" id="calendar-entry-modal-title">Edit Calendar Entry</h3>
-          <button class="close-btn" onclick="closeCalendarEntryModal()">×</button>
+          <h3 class="modal-title" id="calendar-add-event-modal-title">Add Event</h3>
+          <button class="close-btn" onclick="closeCalendarAddEventModal()">×</button>
         </div>
         <div class="modal-body">
           <div class="form-grid">
             <div class="form-group">
               <label class="form-label">Date <span class="required">*</span></label>
-              <input type="date" class="form-input" id="modal-calendar-date" />
+              <input type="date" class="form-input" id="modal-calendar-date" readonly />
             </div>
             <div class="form-group">
               <label class="form-label">Entry Type <span class="required">*</span></label>
@@ -3309,81 +3189,28 @@
               </select>
             </div>
             <div class="form-group">
-              <label class="form-label">Description <span class="required">*</span></label>
-              <input
-                type="text"
-                class="form-input"
-                id="modal-calendar-description"
-                placeholder="e.g., WSLH PT24-01, John Smith PTO"
-              />
-            </div>
-          </div>
-
-          <!-- Recurrence Settings (hidden by default) -->
-          <div id="modal-recurrence-settings" style="display: none">
-            <h4 style="margin-top: 1.5rem; margin-bottom: 1rem">Recurrence Settings</h4>
-            <div class="form-grid">
-              <div class="form-group">
-                <label class="form-label">Repeat Every</label>
-                <div style="display: flex; gap: 0.5rem">
-                  <input
-                    type="number"
-                    class="form-input"
-                    id="modal-recurrence-interval"
-                    style="width: 80px"
-                    min="1"
-                    value="1"
-                  />
-                  <select
-                    class="form-select"
-                    id="modal-recurrence-unit"
-                    onchange="handleUnitChange('modal')"
-                  >
-                    <option value="days">Days</option>
-                    <option value="weeks">Weeks</option>
-                    <option value="months">Months</option>
-                    <option value="custom">Custom</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group" id="modal-custom-pattern-group" style="display: none">
-                <label class="form-label">Custom Pattern</label>
-                <input
-                  type="text"
-                  class="form-input"
-                  id="modal-custom-pattern"
-                  placeholder="e.g., First Monday of month"
-                />
-              </div>
-              <div class="form-group">
-                <label class="form-label">End Condition</label>
-                <select
-                  class="form-select"
-                  id="modal-recurrence-end-type"
-                  onchange="handleEndTypeChange('modal')"
-                >
-                  <option value="never">Never</option>
-                  <option value="count">After occurrences</option>
-                  <option value="date">On date</option>
-                </select>
-              </div>
-              <div class="form-group" id="modal-end-count-group" style="display: none">
-                <label class="form-label">Number of Occurrences</label>
-                <input type="number" class="form-input" id="modal-end-count" min="1" value="10" />
-              </div>
-              <div class="form-group" id="modal-end-date-group" style="display: none">
-                <label class="form-label">End Date</label>
-                <input type="date" class="form-input" id="modal-end-date" />
-              </div>
+              <label class="form-label">Notes</label>
+              <textarea
+                class="form-textarea"
+                id="modal-calendar-notes"
+                placeholder="Add optional notes..."
+              ></textarea>
             </div>
           </div>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-danger" onclick="deleteCalendarEntry()" style="margin-right: auto">
-            Delete Entry
+          <button
+            class="btn btn-danger"
+            id="modal-delete-event-btn"
+            onclick="deleteCalendarEvent()"
+            style="margin-right: auto; display: none;"
+          >
+            Delete Event
           </button>
-          <button class="btn btn-outline" onclick="closeCalendarEntryModal()">Cancel</button>
-          <button class="btn btn-primary" onclick="saveCalendarEntry()">Save Changes</button>
+          <button class="btn btn-outline" onclick="closeCalendarAddEventModal()">Cancel</button>
+          <button class="btn btn-primary" id="calendar-add-event-submit" onclick="addCalendarEvent()">
+            Add Event
+          </button>
         </div>
       </div>
     </div>
@@ -3393,7 +3220,7 @@
       // ===============================
 
       const APP_STATE = {
-        version: '0.3.9', // Update version
+        version: '0.4.2', // Update version
         customers: [],
         sampleDefinitions: [],
         customerSpecs: [],
@@ -3456,6 +3283,8 @@
         },
         bupSelectedPool: new Set(), // Stores selected event keys
       };
+
+      let editingCalendarEntryId = null;
 
       // Constants
       const RBC_UNIT_ML = 180.0;
@@ -4793,7 +4622,13 @@
 
         // switch panels
         document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
-        document.getElementById(`${panelName}-panel`).classList.add('active');
+        const panelElement = document.getElementById(`${panelName}-panel`);
+        if (panelElement) {
+          panelElement.classList.add('active');
+        }
+        if (panelName === 'calendar') {
+          renderCalendar();
+        }
         if (panelName === 'activity') {
           // default to All Activity on open; refresh Decisions as well
           showActivitySection('all');
@@ -7581,7 +7416,7 @@
           // Get events for this day
           const events = APP_STATE.manufacturingCalendar.filter((event) => event.date === dateStr);
 
-          html += `<div class="calendar-day" data-date="${dateStr}" onclick="handleCalendarDayClick(event, '${dateStr}')">
+          html += `<div class="calendar-day" data-date="${dateStr}" onclick="openAddEventModal('${dateStr}')">
                                                 <div class="calendar-day-number">${day}</div>`;
 
           events.forEach((event) => {
@@ -7601,24 +7436,118 @@
         document.getElementById('calendar-grid').innerHTML = html;
       }
 
-      function handleCalendarDayClick(event, dateStr) {
-        // If clicking on an event, don't open new entry modal
-        if (event.target.classList.contains('calendar-event')) {
+      function resetCalendarAddEventModal() {
+        editingCalendarEntryId = null;
+        const submitButton = document.getElementById('calendar-add-event-submit');
+        if (submitButton) {
+          submitButton.textContent = 'Add Event';
+          submitButton.onclick = addCalendarEvent;
+        }
+
+        const title = document.getElementById('calendar-add-event-modal-title');
+        if (title) {
+          title.textContent = 'Add Event';
+        }
+
+        const deleteButton = document.getElementById('modal-delete-event-btn');
+        if (deleteButton) {
+          deleteButton.style.display = 'none';
+        }
+      }
+
+      function openAddEventModal(dateStr) {
+        resetCalendarAddEventModal();
+
+        const modal = document.getElementById('calendar-add-event-modal');
+        if (!modal) return;
+
+        const deleteButton = document.getElementById('modal-delete-event-btn');
+        if (deleteButton) {
+          deleteButton.style.display = 'none';
+        }
+
+        const dateInput = document.getElementById('modal-calendar-date');
+        if (dateInput) {
+          dateInput.value = dateStr;
+        }
+
+        const typeSelect = document.getElementById('modal-calendar-type');
+        if (typeSelect) {
+          typeSelect.selectedIndex = -1;
+          typeSelect.value = '';
+        }
+
+        const notesField = document.getElementById('modal-calendar-notes');
+        if (notesField) {
+          notesField.value = '';
+        }
+
+        modal.classList.add('active');
+      }
+
+      function closeCalendarAddEventModal() {
+        const modal = document.getElementById('calendar-add-event-modal');
+        if (modal) {
+          modal.classList.remove('active');
+        }
+
+        resetCalendarAddEventModal();
+      }
+
+      function getCalendarTypeLabel(type) {
+        for (const items of Object.values(CALENDAR_CATEGORIES)) {
+          const match = items.find((item) => item.value === type);
+          if (match) {
+            return match.label;
+          }
+        }
+        return type;
+      }
+
+      function buildCalendarDescription(type, notes) {
+        const trimmedNotes = notes ? notes.trim() : '';
+        if (trimmedNotes) {
+          return trimmedNotes;
+        }
+        return getCalendarTypeLabel(type);
+      }
+
+      function addCalendarEvent() {
+        const dateInput = document.getElementById('modal-calendar-date');
+        const typeSelect = document.getElementById('modal-calendar-type');
+        const notesField = document.getElementById('modal-calendar-notes');
+
+        const date = dateInput ? dateInput.value : '';
+        const type = typeSelect ? typeSelect.value : '';
+        const notes = notesField ? notesField.value.trim() : '';
+
+        if (!date || !type) {
+          showAlert('error', 'Please select a date and event type');
           return;
         }
 
-        // Open modal for new entry with date pre-filled
-        openCalendarEntryForNewDate(dateStr);
-      }
+        const description = buildCalendarDescription(type, notes);
 
-      function openCalendarEntryForNewDate(dateStr) {
-        document.getElementById('modal-calendar-date').value = dateStr;
-        document.getElementById('modal-calendar-type').value = 'blood-arrival';
-        document.getElementById('modal-calendar-description').value = '';
-        document.getElementById('calendar-entry-modal-title').textContent = 'Add Calendar Entry';
+        const newEvent = {
+          id: 'cal_' + Date.now(),
+          date: date,
+          type: type,
+          description: description,
+        };
 
-        editingCalendarEntryId = null;
-        document.getElementById('calendar-entry-modal').classList.add('active');
+        if (notes) {
+          newEvent.notes = notes;
+        }
+
+        APP_STATE.manufacturingCalendar.push(newEvent);
+
+        logActivity('Added calendar event', description);
+        showAlert('success', 'Calendar event added');
+
+        renderCalendar();
+        autoSave();
+
+        closeCalendarAddEventModal();
       }
 
       function previousMonth() {
@@ -7646,81 +7575,6 @@
         renderCalendar();
       }
 
-      function addCalendarEntry() {
-        const date = document.getElementById('calendar-date').value;
-        const type = document.getElementById('calendar-type').value;
-        const description = document.getElementById('calendar-description').value;
-
-        if (!date || !description) {
-          showAlert('error', 'Please fill in required fields');
-          return;
-        }
-
-        // Check if this is a recurring type
-        const isRecurring = CALENDAR_CATEGORIES[RECURRENCE_ENABLED_CATEGORY]?.some(
-          (item) => item.value === type
-        );
-
-        if (isRecurring) {
-          // Get recurrence settings
-          const recurrenceSettings = {
-            enabled: true,
-            interval: parseInt(document.getElementById('manual-recurrence-interval').value) || 1,
-            unit: document.getElementById('manual-recurrence-unit').value,
-            customPattern:
-              document.getElementById('manual-recurrence-unit').value === 'custom'
-                ? document.getElementById('manual-custom-pattern').value
-                : null,
-            endType: document.getElementById('manual-recurrence-end-type').value,
-            endCount:
-              document.getElementById('manual-recurrence-end-type').value === 'count'
-                ? parseInt(document.getElementById('manual-end-count').value)
-                : null,
-            endDate:
-              document.getElementById('manual-recurrence-end-type').value === 'date'
-                ? document.getElementById('manual-end-date').value
-                : null,
-          };
-
-          // Generate recurring instances
-          const instances = generateRecurringInstances(
-            { date, type, description },
-            recurrenceSettings
-          );
-          APP_STATE.manufacturingCalendar.push(...instances);
-
-          logActivity(
-            'Added recurring calendar entry',
-            `${description} (${instances.length} instances)`
-          );
-          showAlert('success', `Created ${instances.length} recurring entries`);
-        } else {
-          // Single entry
-          APP_STATE.manufacturingCalendar.push({
-            id: 'cal_' + Date.now(),
-            date: date,
-            type: type,
-            description: description,
-          });
-
-          logActivity('Added calendar entry', description);
-          showAlert('success', 'Calendar entry added');
-        }
-
-        renderCalendar();
-        autoSave();
-
-        // Clear form
-        document.getElementById('calendar-date').value = '';
-        document.getElementById('calendar-description').value = '';
-        // Reset recurrence settings
-        document.getElementById('manual-recurrence-interval').value = '1';
-        document.getElementById('manual-recurrence-unit').value = 'days';
-        document.getElementById('manual-recurrence-end-type').value = 'never';
-        document.getElementById('manual-recurrence-settings').style.display = 'none';
-      }
-      let editingCalendarEntryId = null;
-
       function openCalendarEntry(event, entryId) {
         // Stop event propagation to prevent day click
         if (event) {
@@ -7730,27 +7584,42 @@
         const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === entryId);
 
         if (entry) {
-          document.getElementById('modal-calendar-date').value = entry.date;
-          document.getElementById('modal-calendar-type').value = entry.type;
-          document.getElementById('modal-calendar-description').value = entry.description;
-          document.getElementById('calendar-entry-modal-title').textContent = 'Edit Calendar Entry';
+          const dateInput = document.getElementById('modal-calendar-date');
+          const typeSelect = document.getElementById('modal-calendar-type');
+          const notesField = document.getElementById('modal-calendar-notes');
+          const title = document.getElementById('calendar-add-event-modal-title');
+          const submitButton = document.getElementById('calendar-add-event-submit');
+          const deleteButton = document.getElementById('modal-delete-event-btn');
+
+          if (dateInput) dateInput.value = entry.date;
+          if (typeSelect) typeSelect.value = entry.type;
+          if (notesField) notesField.value = entry.notes ?? entry.description ?? '';
+          if (title) title.textContent = 'Edit Event';
+          if (submitButton) {
+            submitButton.textContent = 'Save Changes';
+            submitButton.onclick = saveCalendarEntry;
+          }
+          if (deleteButton) {
+            deleteButton.style.display = 'block';
+          }
 
           editingCalendarEntryId = entry.id;
-          document.getElementById('calendar-entry-modal').classList.add('active');
+          document.getElementById('calendar-add-event-modal').classList.add('active');
         }
       }
 
       function closeCalendarEntryModal() {
-        document.getElementById('calendar-entry-modal').classList.remove('active');
-        editingCalendarEntryId = null;
+        closeCalendarAddEventModal();
       }
 
       function saveCalendarEntry() {
         const date = document.getElementById('modal-calendar-date').value;
         const type = document.getElementById('modal-calendar-type').value;
-        const description = document.getElementById('modal-calendar-description').value;
+        const notesField = document.getElementById('modal-calendar-notes');
+        const notes = notesField ? notesField.value.trim() : '';
+        const description = buildCalendarDescription(type, notes);
 
-        if (!date || !type || !description) {
+        if (!date || !type) {
           showAlert('error', 'Please fill in all required fields');
           return;
         }
@@ -7762,14 +7631,17 @@
           );
 
           if (entryIndex > -1) {
-            APP_STATE.manufacturingCalendar[entryIndex] = {
-              id: editingCalendarEntryId,
-              date: date,
-              type: type,
-              description: description,
-            };
-            logActivity('Updated calendar entry', description);
-            showAlert('success', 'Calendar entry updated');
+            const existing = APP_STATE.manufacturingCalendar[entryIndex];
+            existing.date = date;
+            existing.type = type;
+            existing.description = description;
+            if (notes) {
+              existing.notes = notes;
+            } else {
+              delete existing.notes;
+            }
+            logActivity('Updated calendar event', description);
+            showAlert('success', 'Calendar event updated');
           }
         } else {
           // Creating new entry
@@ -7779,9 +7651,12 @@
             type: type,
             description: description,
           };
+          if (notes) {
+            newEntry.notes = notes;
+          }
           APP_STATE.manufacturingCalendar.push(newEntry);
-          logActivity('Added calendar entry', description);
-          showAlert('success', 'Calendar entry added');
+          logActivity('Added calendar event', description);
+          showAlert('success', 'Calendar event added');
         }
 
         renderCalendar();
@@ -7789,27 +7664,30 @@
         closeCalendarEntryModal();
       }
 
-      function deleteCalendarEntry() {
-        const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === editingCalendarEntryId);
-        if (!entry) return;
-
-        // Check if this is a recurring entry
-        if (entry.recurrence) {
-          showRecurrenceModificationDialog('delete');
-        } else {
-          // Single entry - normal delete
-          if (confirm('Are you sure you want to delete this entry?')) {
-            APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
-              (e) => e.id !== editingCalendarEntryId
-            );
-
-            logActivity('Deleted calendar entry', entry.description);
-            showAlert('success', 'Calendar entry deleted');
-            renderCalendar();
-            autoSave();
-            closeCalendarEntryModal();
-          }
+      function deleteCalendarEvent() {
+        if (!editingCalendarEntryId) {
+          return;
         }
+
+        const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === editingCalendarEntryId);
+        if (!entry) {
+          return;
+        }
+
+        const confirmed = confirm('Are you sure you want to delete this event?');
+        if (!confirmed) {
+          return;
+        }
+
+        APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+          (e) => e.id !== editingCalendarEntryId
+        );
+
+        logActivity('Deleted calendar event', entry.description ?? entry.type ?? '');
+        showAlert('success', 'Calendar event deleted');
+        renderCalendar();
+        autoSave();
+        closeCalendarAddEventModal();
       }
       // ===============================
       // Sharing Analysis

--- a/Blood Optimization Platform - v0.4.3.html
+++ b/Blood Optimization Platform - v0.4.3.html
@@ -1,0 +1,10340 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blood Optimization Platform v0.4.3 - Megedition | Hemo bioscience</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      :root {
+        --hemo-blue: #0073cf;
+        --hemo-blue-dark: #005299;
+        --hemo-blue-light: #e6f2ff;
+        --hemo-blue-lighter: #f0f8ff;
+        --success: #16a34a;
+        --warning: #f59e0b;
+        --danger: #dc2626;
+        --info: #3b82f6;
+        --dark: #1f2937;
+        --gray: #6b7280;
+        --gray-light: #9ca3af;
+        --light: #f9fafb;
+        --border: #e5e7eb;
+        --white: #ffffff;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
+      }
+
+      /* Dark mode variables */
+      [data-theme='dark'] {
+        --dark: #f9fafb;
+        --gray: #d1d5db;
+        --gray-light: #9ca3af;
+        --light: #1f2937;
+        --border: #374151;
+        --white: #111827;
+        --hemo-blue-light: #1a3a52;
+        --hemo-blue-lighter: #0f2536;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.3);
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+          sans-serif;
+        background: var(--light);
+        color: var(--dark);
+        line-height: 1.6;
+        transition: background 0.3s ease, color 0.3s ease;
+      }
+
+      /* Layout */
+      .app-container {
+        display: flex;
+        height: 100vh;
+      }
+
+      /* Header Bar */
+      .header-bar {
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 280px;
+        background: var(--white);
+        padding: 0.75rem 2rem;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        z-index: 100;
+        transition: all 0.3s ease;
+      }
+
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .version-badge {
+        background: var(--hemo-blue-light);
+        color: var(--hemo-blue);
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.875rem;
+        font-weight: 500;
+      }
+
+      .header-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .storage-status {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+        color: var(--gray);
+      }
+
+      .storage-status .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--warning);
+        animation: pulse 2s infinite;
+      }
+
+      .storage-status.connected .dot {
+        background: var(--success);
+        animation: none;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+
+        50% {
+          opacity: 0.5;
+        }
+      }
+
+      .user-info {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 8px;
+        font-size: 0.875rem;
+      }
+
+      .user-avatar {
+        width: 28px;
+        height: 28px;
+        background: var(--hemo-blue);
+        color: white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+      }
+
+      .active-users {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.375rem 0.75rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        color: var(--gray);
+      }
+
+      /* Theme Toggle */
+      .theme-toggle {
+        background: var(--hemo-blue-lighter);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        padding: 4px;
+        cursor: pointer;
+        width: 60px;
+        height: 32px;
+        position: relative;
+        transition: all 0.3s ease;
+      }
+
+      .theme-toggle-slider {
+        position: absolute;
+        width: 24px;
+        height: 24px;
+        background: var(--white);
+        border-radius: 50%;
+        transition: transform 0.3s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+
+      [data-theme='dark'] .theme-toggle-slider {
+        transform: translateX(28px);
+      }
+
+      /* Sidebar */
+      .sidebar {
+        width: 280px;
+        background: var(--white);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        position: fixed;
+        height: 100vh;
+        transition: all 0.3s ease;
+        overflow-y: auto;
+        z-index: 200; /* ADD THIS LINE */
+      }
+
+      .sidebar-header {
+        padding: 1.5rem;
+        border-bottom: 1px solid var(--border);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .logo {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .logo-icon {
+        width: 48px;
+        height: 48px;
+        background: var(--hemo-blue);
+        color: white;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        font-weight: bold;
+        box-shadow: 0 4px 12px rgba(0, 115, 207, 0.2);
+      }
+
+      .logo-text {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .logo-main {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      .logo-sub {
+        font-size: 0.75rem;
+        color: var(--gray);
+        font-style: italic;
+      }
+
+      .nav-menu {
+        flex: 1;
+        padding: 1rem 0;
+        overflow-y: auto;
+      }
+
+      .nav-section {
+        margin-bottom: 1.5rem;
+      }
+
+      .nav-section-title {
+        padding: 0.5rem 1.5rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--gray-light);
+      }
+
+      .nav-item {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 1.5rem;
+        color: var(--gray);
+        text-decoration: none;
+        transition: all 0.2s;
+        cursor: pointer;
+        border: none;
+        background: none;
+        width: 100%;
+        text-align: left;
+        font-size: 0.95rem;
+      }
+
+      .nav-item:hover {
+        background: var(--hemo-blue-lighter);
+        color: var(--dark);
+      }
+
+      .nav-item.active {
+        background: var(--hemo-blue-light);
+        color: var(--hemo-blue);
+        border-left: 3px solid var(--hemo-blue);
+        font-weight: 500;
+      }
+
+      .nav-item.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .nav-item.placeholder {
+        font-style: italic;
+        opacity: 0.7;
+      }
+
+      .nav-icon {
+        width: 20px;
+        text-align: center;
+      }
+
+      /* Main Content */
+      .main-content {
+        flex: 1;
+        margin-left: 280px;
+        margin-top: 60px;
+        overflow-y: auto;
+        background: var(--light);
+        transition: all 0.3s ease;
+      }
+
+      .content-header {
+        background: var(--white);
+        padding: 1.5rem 2rem;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .content-title {
+        font-size: 1.75rem;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        color: var(--dark);
+      }
+
+      .content-subtitle {
+        color: var(--gray);
+        font-size: 0.95rem;
+      }
+
+      .content-body {
+        padding: 2rem;
+      }
+
+      /* Panels */
+      .panel {
+        display: none;
+      }
+
+      .panel.active {
+        display: block;
+        animation: fadeIn 0.3s ease;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Cards */
+      .card {
+        background: var(--white);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      .card:hover {
+        box-shadow: var(--shadow-lg);
+      }
+
+      .card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+      }
+
+      .card-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      /* Tabs */
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        border-bottom: 2px solid var(--border);
+        margin-bottom: 1.5rem;
+        overflow-x: auto;
+      }
+
+      .tab {
+        padding: 0.75rem 1.25rem;
+        background: none;
+        border: none;
+        color: var(--gray);
+        font-size: 0.95rem;
+        cursor: pointer;
+        border-bottom: 3px solid transparent;
+        margin-bottom: -2px;
+        transition: all 0.2s;
+        white-space: nowrap;
+      }
+
+      .tab:hover {
+        color: var(--dark);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .tab.active {
+        color: var(--hemo-blue);
+        border-bottom-color: var(--hemo-blue);
+        font-weight: 500;
+      }
+
+      .tab-content {
+        display: none;
+      }
+
+      .tab-content.active {
+        display: block;
+      }
+
+      /* Forms */
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1rem;
+      }
+
+      .form-group {
+        margin-bottom: 1rem;
+      }
+
+      .form-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--dark);
+        margin-bottom: 0.5rem;
+      }
+
+      .form-label .required {
+        color: var(--danger);
+      }
+
+      .form-input,
+      .form-select,
+      .form-textarea {
+        width: 100%;
+        padding: 0.625rem;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-size: 0.95rem;
+        transition: all 0.2s;
+        background: var(--white);
+        color: var(--dark);
+      }
+
+      .form-input:focus,
+      .form-select:focus,
+      .form-textarea:focus {
+        outline: none;
+        border-color: var(--hemo-blue);
+        box-shadow: 0 0 0 3px rgba(0, 115, 207, 0.1);
+      }
+
+      .form-textarea {
+        resize: vertical;
+        min-height: 100px;
+      }
+
+      .form-hint {
+        font-size: 0.8125rem;
+        color: var(--gray-light);
+        margin-top: 0.25rem;
+      }
+
+      /* Buttons */
+      .btn {
+        padding: 0.625rem 1.25rem;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
+
+      .btn:active {
+        transform: translateY(0);
+      }
+
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .btn-primary {
+        background: var(--hemo-blue);
+        color: white;
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        background: var(--hemo-blue-dark);
+      }
+
+      .btn-success {
+        background: var(--success);
+        color: white;
+      }
+
+      .btn-danger {
+        background: var(--danger);
+        color: white;
+      }
+
+      .btn-warning {
+        background: var(--warning);
+        color: white;
+      }
+
+      .btn-secondary {
+        background: var(--gray);
+        color: white;
+      }
+
+      .btn-outline {
+        background: var(--white);
+        border: 1px solid var(--border);
+        color: var(--dark);
+      }
+
+      .btn-outline:hover {
+        background: var(--hemo-blue-lighter);
+        border-color: var(--hemo-blue);
+        color: var(--hemo-blue);
+      }
+
+      .btn-sm {
+        padding: 0.375rem 0.875rem;
+        font-size: 0.8125rem;
+      }
+
+      .btn-group {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      /* Tables */
+      .table-container {
+        overflow-x: auto;
+        background: var(--white);
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th {
+        background: var(--hemo-blue-lighter);
+        padding: 0.875rem;
+        text-align: left;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--dark);
+        border-bottom: 2px solid var(--border);
+        white-space: nowrap;
+      }
+
+      td {
+        padding: 0.875rem;
+        border-bottom: 1px solid var(--border);
+        font-size: 0.875rem;
+        color: var(--dark);
+      }
+
+      tbody tr:hover {
+        background: var(--hemo-blue-lighter);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      /* File Upload */
+      .upload-area {
+        border: 2px dashed var(--border);
+        border-radius: 8px;
+        padding: 2rem;
+        text-align: center;
+        transition: all 0.2s;
+        cursor: pointer;
+        margin-bottom: 1rem;
+        background: var(--white);
+      }
+
+      .upload-area:hover {
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .upload-area.dragging {
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-light);
+      }
+
+      .upload-input {
+        display: none;
+      }
+
+      .upload-icon {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+        color: var(--hemo-blue);
+      }
+
+      /* Metrics */
+      .metrics-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .metric-card {
+        background: var(--white);
+        padding: 1.5rem;
+        border-radius: 12px;
+        border-left: 4px solid var(--hemo-blue);
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      .metric-card:hover {
+        box-shadow: var(--shadow-lg);
+        transform: translateY(-2px);
+      }
+
+      .metric-value {
+        font-size: 2rem;
+        font-weight: bold;
+        color: var(--hemo-blue);
+      }
+
+      .metric-label {
+        font-size: 0.875rem;
+        color: var(--gray);
+        margin-top: 0.25rem;
+      }
+
+      .metric-change {
+        font-size: 0.8125rem;
+        margin-top: 0.5rem;
+      }
+
+      .metric-change.positive {
+        color: var(--success);
+      }
+
+      .metric-change.negative {
+        color: var(--danger);
+      }
+
+      /* Status Messages */
+      .alert {
+        padding: 1rem;
+        border-radius: 6px;
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        animation: slideIn 0.3s ease;
+      }
+
+      @keyframes slideIn {
+        from {
+          transform: translateX(-20px);
+          opacity: 0;
+        }
+
+        to {
+          transform: translateX(0);
+          opacity: 1;
+        }
+      }
+
+      .alert-success {
+        background: #dcfce7;
+        color: #166534;
+        border-left: 4px solid var(--success);
+      }
+
+      .alert-warning {
+        background: #fef3c7;
+        color: #92400e;
+        border-left: 4px solid var(--warning);
+      }
+
+      .alert-error {
+        background: #fee2e2;
+        color: #991b1b;
+        border-left: 4px solid var(--danger);
+      }
+
+      .alert-info {
+        background: var(--hemo-blue-lighter);
+        color: var(--hemo-blue);
+        border-left: 4px solid var(--hemo-blue);
+      }
+
+      /* Blood Type Tags */
+      .blood-tag {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin-right: 0.25rem;
+      }
+
+      .blood-tag.o-pos {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .blood-tag.o-neg {
+        background: #fef2f2;
+        color: #7f1d1d;
+      }
+
+      .blood-tag.a-pos {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+
+      .blood-tag.a-neg {
+        background: #e0e7ff;
+        color: #312e81;
+      }
+
+      .blood-tag.b-pos {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .blood-tag.b-neg {
+        background: #f0fdf4;
+        color: #14532d;
+      }
+
+      .blood-tag.ab-pos {
+        background: #f3e8ff;
+        color: #581c87;
+      }
+
+      .blood-tag.ab-neg {
+        background: #faf5ff;
+        color: #4c1d95;
+      }
+
+      /* Status Tags */
+      .status-tag {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.8125rem;
+        font-weight: 500;
+      }
+
+      .status-tag.available {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .status-tag.limited {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      .status-tag.discontinued {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      /* Customer Cards */
+      .customer-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .customer-card {
+        background: var(--white);
+        padding: 1.25rem;
+        padding-top: 2.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        transition: all 0.2s;
+        position: relative;
+        min-height: 120px;
+      }
+
+      .customer-card:hover {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        transform: translateY(-2px);
+        border-color: var(--hemo-blue);
+      }
+
+      .customer-header {
+        margin-bottom: 1rem;
+      }
+
+      .customer-name {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+        margin-bottom: 0.25rem;
+      }
+
+      .customer-code {
+        font-size: 0.875rem;
+        color: var(--gray);
+        font-family: monospace;
+      }
+
+      .customer-info {
+        font-size: 0.875rem;
+        color: var(--gray);
+        margin-bottom: 0.5rem;
+      }
+
+      .customer-contacts {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border);
+      }
+
+      .contact-item {
+        display: flex;
+        gap: 0.5rem;
+        font-size: 0.8125rem;
+        margin-bottom: 0.25rem;
+      }
+
+      .customer-actions {
+        position: absolute;
+        top: 0.75rem;
+        right: 0.75rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .customer-actions button {
+        padding: 0.375rem;
+        background: var(--white);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        cursor: pointer;
+        color: var(--gray);
+        transition: all 0.2s;
+        font-size: 0.875rem;
+      }
+
+      .customer-actions button:hover {
+        color: var(--hemo-blue);
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      /* Antibody Cards */
+      .antibody-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .antibody-card {
+        background: var(--white);
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        padding: 1.25rem;
+        transition: all 0.2s;
+      }
+
+      .antibody-card:hover {
+        box-shadow: var(--shadow-lg);
+        border-color: var(--hemo-blue);
+      }
+
+      .antibody-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+        margin-bottom: 1rem;
+      }
+
+      .antibody-name {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      .antibody-type {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        background: var(--hemo-blue-lighter);
+        color: var(--hemo-blue);
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+
+      .antibody-details {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.75rem;
+        font-size: 0.875rem;
+      }
+
+      .antibody-detail {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .antibody-detail-label {
+        color: var(--gray-light);
+        font-size: 0.75rem;
+        margin-bottom: 0.125rem;
+      }
+
+      .antibody-detail-value {
+        color: var(--dark);
+        font-weight: 500;
+      }
+
+      .antibody-inventory {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .inventory-status {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .inventory-bar {
+        width: 120px;
+        height: 8px;
+        background: var(--border);
+        border-radius: 4px;
+        overflow: hidden;
+      }
+
+      .inventory-fill {
+        height: 100%;
+        background: var(--success);
+        transition: width 0.3s ease;
+      }
+
+      .inventory-fill.low {
+        background: var(--warning);
+      }
+
+      .inventory-fill.critical {
+        background: var(--danger);
+      }
+
+      .antibody-cost {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--border);
+      }
+
+      .cost-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .cost-item {
+        text-align: center;
+      }
+
+      .cost-label {
+        font-size: 0.75rem;
+        color: var(--gray-light);
+        margin-bottom: 0.25rem;
+      }
+
+      .cost-value {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      /* Modals */
+      .modal {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1000;
+        animation: fadeIn 0.2s ease;
+      }
+
+      .modal.active {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .modal-content {
+        background: var(--white);
+        border-radius: 12px;
+        max-width: 700px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+        animation: slideUp 0.3s ease;
+      }
+
+      @keyframes slideUp {
+        from {
+          transform: translateY(20px);
+          opacity: 0;
+        }
+
+        to {
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+
+      .modal-header {
+        padding: 1.5rem;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--hemo-blue-lighter);
+      }
+
+      .modal-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      .modal-body {
+        padding: 1.5rem;
+      }
+
+      .modal-footer {
+        padding: 1rem 1.5rem;
+        border-top: 1px solid var(--border);
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        background: var(--light);
+      }
+
+      .close-btn {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: var(--gray);
+        transition: color 0.2s;
+      }
+
+      .close-btn:hover {
+        color: var(--hemo-blue);
+      }
+
+      /* Setup Wizard Modal */
+      .setup-modal {
+        z-index: 2000;
+      }
+
+      .setup-steps {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 2rem;
+        padding: 1rem;
+        background: var(--light);
+        border-radius: 8px;
+      }
+
+      .setup-step {
+        flex: 1;
+        text-align: center;
+        padding: 0.5rem;
+        position: relative;
+      }
+
+      .setup-step:not(:last-child)::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: -50%;
+        width: 100%;
+        height: 2px;
+        background: var(--border);
+      }
+
+      .setup-step.active .step-number {
+        background: var(--hemo-blue);
+        color: white;
+      }
+
+      .setup-step.completed .step-number {
+        background: var(--success);
+        color: white;
+      }
+
+      .step-number {
+        width: 32px;
+        height: 32px;
+        background: var(--border);
+        color: var(--gray);
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 0.5rem;
+        font-weight: 600;
+      }
+
+      .step-label {
+        font-size: 0.875rem;
+        color: var(--gray);
+      }
+
+      .setup-step.active .step-label {
+        color: var(--dark);
+        font-weight: 500;
+      }
+
+      .setup-content {
+        min-height: 200px;
+      }
+
+      /* Instructions Panel */
+      .instructions-panel {
+        max-height: 400px;
+        overflow-y: auto;
+        background: var(--light);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .instructions-panel h4 {
+        color: var(--hemo-blue);
+        margin-top: 1rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .instructions-panel ul {
+        margin-left: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .instructions-panel li {
+        margin-bottom: 0.25rem;
+      }
+
+      /* Activity Log */
+      .activity-item {
+        display: flex;
+        gap: 1rem;
+        padding: 0.75rem;
+        border-left: 3px solid var(--hemo-blue-lighter);
+        margin-bottom: 0.5rem;
+        background: var(--white);
+        border-radius: 4px;
+        transition: all 0.2s;
+      }
+
+      .activity-item:hover {
+        border-left-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .activity-time {
+        font-size: 0.8125rem;
+        color: var(--gray-light);
+        min-width: 80px;
+      }
+
+      .activity-user {
+        font-weight: 500;
+        color: var(--hemo-blue);
+        min-width: 100px;
+      }
+
+      .activity-action {
+        flex: 1;
+        color: var(--dark);
+      }
+
+      /* Calculation Results */
+      .calculation-results {
+        margin-top: 1.5rem;
+        padding: 1rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 8px;
+        border: 1px solid var(--hemo-blue);
+      }
+
+      .result-item {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem 0;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .result-item:last-child {
+        border-bottom: none;
+      }
+
+      .result-label {
+        font-weight: 500;
+        color: var(--dark);
+      }
+
+      .result-value {
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      /* Sharing Window Display */
+      .sharing-window-display {
+        background: var(--hemo-blue-lighter);
+        border-left: 4px solid var(--hemo-blue);
+        padding: 1rem;
+        margin: 1rem 0;
+        border-radius: 4px;
+      }
+
+      .sharing-window-display h4 {
+        margin-bottom: 0.5rem;
+        color: var(--hemo-blue);
+      }
+
+      .sharing-window-dates {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+        margin-top: 0.5rem;
+      }
+
+      .sharing-date-item {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .sharing-date-label {
+        font-size: 0.75rem;
+        color: var(--gray);
+        margin-bottom: 0.25rem;
+      }
+
+      .sharing-date-value {
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      /* Calendar */
+      .calendar-container {
+        background: var(--white);
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: var(--shadow);
+      }
+
+      .calendar-header {
+        background: var(--hemo-blue);
+        color: white;
+        padding: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .calendar-nav {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .calendar-nav button {
+        background: none;
+        border: none;
+        color: white;
+        cursor: pointer;
+        font-size: 1.25rem;
+      }
+
+      .calendar-grid {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+      }
+
+      .calendar-weekday {
+        background: var(--hemo-blue-lighter);
+        padding: 0.5rem;
+        text-align: center;
+        font-weight: 600;
+        font-size: 0.875rem;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .calendar-day {
+        min-height: 100px;
+        padding: 0.5rem;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        position: relative;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .calendar-day:hover {
+        background: var(--hemo-blue-lighter);
+      }
+
+      .calendar-day-number {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+
+      .calendar-event {
+        font-size: 0.75rem;
+        padding: 0.125rem 0.25rem;
+        margin-bottom: 0.125rem;
+        border-radius: 3px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .calendar-event.standing-order {
+        background: var(--hemo-blue-lighter);
+        color: var(--hemo-blue);
+      }
+
+      .calendar-event.blood-arrival {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .calendar-event.shipment {
+        background: #dcfce7;
+        color: #166534;
+      }
+      /* Calendar Event Colors by Category */
+      .calendar-event.bulk-event,
+      .calendar-event.fill-event,
+      .calendar-event.wash-rbcs,
+      .calendar-event.coat-rbcs,
+      .calendar-event.setup-event {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+
+      .calendar-event.external-testing,
+      .calendar-event.blood-arrival,
+      .calendar-event.shipment {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .calendar-event.timesheets,
+      .calendar-event.case-study {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      .calendar-event.label-event {
+        background: #f3e8ff;
+        color: #581c87;
+      }
+
+      .calendar-event.conference {
+        background: #e5e7eb;
+        color: #374151;
+      }
+
+      .calendar-event.pto,
+      .calendar-event.holiday {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      /* Contact List in Modal */
+      .contact-list {
+        margin-top: 1rem;
+      }
+
+      .contact-entry {
+        background: var(--light);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 1rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .contact-entry-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+      }
+
+      .contact-remove {
+        background: none;
+        border: none;
+        color: var(--danger);
+        cursor: pointer;
+        font-size: 1.25rem;
+      }
+
+      /* BUP Sections */
+      .bup-section {
+        margin-bottom: 2rem;
+      }
+
+      .bup-header {
+        background: var(--hemo-blue);
+        color: white;
+        padding: 0.75rem 1rem;
+        border-radius: 6px 6px 0 0;
+        font-weight: 600;
+      }
+
+      .bup-content {
+        background: var(--white);
+        border: 1px solid var(--border);
+        border-top: none;
+        padding: 1rem;
+        border-radius: 0 0 6px 6px;
+      }
+
+      /* Loading */
+      .spinner {
+        border: 3px solid var(--border);
+        border-top-color: var(--hemo-blue);
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .loading-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(255, 255, 255, 0.9);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 1rem;
+        z-index: 9999;
+      }
+
+      /* Utilities */
+      .text-center {
+        text-align: center;
+      }
+
+      .text-right {
+        text-align: right;
+      }
+
+      .mb-0 {
+        margin-bottom: 0;
+      }
+
+      .mb-1 {
+        margin-bottom: 0.5rem;
+      }
+
+      .mb-2 {
+        margin-bottom: 1rem;
+      }
+
+      .mb-3 {
+        margin-bottom: 1.5rem;
+      }
+
+      .mt-2 {
+        margin-top: 1rem;
+      }
+
+      .mt-3 {
+        margin-top: 1.5rem;
+      }
+
+      .flex {
+        display: flex;
+      }
+
+      .justify-between {
+        justify-content: space-between;
+      }
+
+      .justify-center {
+        justify-content: center;
+      }
+
+      .align-center {
+        align-items: center;
+      }
+
+      .gap-1 {
+        gap: 0.5rem;
+      }
+
+      .gap-2 {
+        gap: 1rem;
+      }
+
+      /* Responsive */
+      @media (max-width: 768px) {
+        .app-container {
+          flex-direction: column;
+        }
+
+        .sidebar {
+          width: 100%;
+          position: static;
+          height: auto;
+        }
+
+        .header-bar {
+          left: 0;
+          position: static;
+        }
+
+        .main-content {
+          margin-left: 0;
+          margin-top: 0;
+        }
+
+        .content-body {
+          padding: 1rem;
+        }
+
+        .metrics-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .customer-grid,
+        .antibody-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+
+  <body data-theme="light">
+    <div class="app-container">
+      <!-- Sidebar Navigation -->
+      <aside class="sidebar">
+        <div class="sidebar-header">
+          <div class="logo">
+            <div class="logo-icon">Hb</div>
+            <div class="logo-text">
+              <div class="logo-main">Hemo bioscience</div>
+              <div class="logo-sub">Blood Optimization Platform</div>
+            </div>
+          </div>
+        </div>
+
+        <nav class="nav-menu">
+          <div class="nav-section">
+            <div class="nav-section-title">Main</div>
+            <button class="nav-item active" onclick="switchPanel('dashboard', event)">
+              <span class="nav-icon">📊</span>
+              <span>Dashboard</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('calendar', event)">
+              <span class="nav-icon">📅</span>
+              <span>Manufacturing Calendar</span>
+            </button>
+            <button class="nav-item placeholder" onclick="showPlaceholder('Master Schedule')">
+              <span class="nav-icon">📋</span>
+              <span>Master Schedule</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Data Manager</div>
+            <button class="nav-item" onclick="switchPanel('customers', event)">
+              <span class="nav-icon">🏢</span>
+              <span>Customers</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('samples', event)">
+              <span class="nav-icon">🧪</span>
+              <span>Sample Definitions</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('specs', event)">
+              <span class="nav-icon">📝</span>
+              <span>Specifications</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('future-specs', event)">
+              <span class="nav-icon">🔮</span>
+              <span>Future Specifications</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('quantities', event)">
+              <span class="nav-icon">📊</span>
+              <span>Order Quantities</span>
+            </button>
+            <button class="nav-item placeholder" onclick="showPlaceholder('Historical Quantities')">
+              <span class="nav-icon">📉</span>
+              <span>Historical Quantities</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Analysis</div>
+            <button class="nav-item" onclick="switchPanel('calculator', event)">
+              <span class="nav-icon">🧮</span>
+              <span>Blood Calculator</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('bup', event)">
+              <span class="nav-icon">📑</span>
+              <span>BUP Generator</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('sharing', event)">
+              <span class="nav-icon">🔄</span>
+              <span>Sharing Opportunities</span>
+            </button>
+            <button
+              class="nav-item placeholder"
+              onclick="showPlaceholder('Specifications Generator')"
+            >
+              <span class="nav-icon">⚡</span>
+              <span>Specifications Generator</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Inventory</div>
+            <button class="nav-item placeholder" onclick="showPlaceholder('Vendors')">
+              <span class="nav-icon">🚚</span>
+              <span>Vendors</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('units', event)">
+              <span class="nav-icon">🩸</span>
+              <span>Bulk RBCs</span>
+            </button>
+            <button class="nav-item placeholder" onclick="showPlaceholder('Bulk Serums')">
+              <span class="nav-icon">🧫</span>
+              <span>Bulk Serums</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('antibodies', event)">
+              <span class="nav-icon">🧬</span>
+              <span>Antibodies</span>
+            </button>
+            <button class="nav-item placeholder" onclick="showPlaceholder('Other Raw Materials')">
+              <span class="nav-icon">📦</span>
+              <span>Other Raw Materials</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">System</div>
+            <button class="nav-item" onclick="switchPanel('activity', event)">
+              <span class="nav-icon">📜</span>
+              <span>Activity Log</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('settings', event)">
+              <span class="nav-icon">⚙️</span>
+              <span>Settings</span>
+            </button>
+          </div>
+        </nav>
+      </aside>
+
+      <!-- Header Bar -->
+      <header class="header-bar">
+        <div class="header-left">
+          <div class="version-badge">v0.4.3 - Megedition</div>
+          <div class="active-users" id="active-users" style="display: none">
+            <span>👤 Active:</span>
+            <span id="active-user-list">-</span>
+          </div>
+        </div>
+
+        <div class="header-right">
+          <div class="storage-status" id="storage-status">
+            <span class="dot"></span>
+            <span id="storage-text">Not Connected</span>
+          </div>
+
+          <div class="user-info">
+            <div class="user-avatar" id="user-avatar">?</div>
+            <span id="user-name">Not Set</span>
+          </div>
+
+          <button class="theme-toggle" onclick="toggleTheme()">
+            <div class="theme-toggle-slider">
+              <span id="theme-icon">☀️</span>
+            </div>
+          </button>
+        </div>
+      </header>
+
+      <!-- Main Content Area -->
+      <main class="main-content">
+        <!-- Dashboard Panel -->
+        <div id="dashboard-panel" class="panel active">
+          <div class="content-header">
+            <h1 class="content-title">Dashboard</h1>
+            <p class="content-subtitle">Blood optimization overview and quick stats</p>
+          </div>
+
+          <div class="content-body">
+            <div class="metrics-grid">
+              <div class="metric-card">
+                <div class="metric-value" id="total-customers">0</div>
+                <div class="metric-label">Active Customers</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="total-specs">0</div>
+                <div class="metric-label">Total Specifications</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="total-antibodies">0</div>
+                <div class="metric-label">Antibodies Tracked</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="low-stock-count">0</div>
+                <div class="metric-label">Low Stock Alerts</div>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Quick Actions</h3>
+              </div>
+              <div class="btn-group">
+                <button
+                  class="btn btn-primary"
+                  onclick="switchPanel('customers'); openCustomerModal();"
+                >
+                  + Add Customer
+                </button>
+                <button
+                  class="btn btn-primary"
+                  onclick="switchPanel('antibodies'); openAntibodyModal();"
+                >
+                  + Add Antibody
+                </button>
+                <button class="btn btn-outline" onclick="switchPanel('calculator', event)">
+                  Calculate Blood Needs
+                </button>
+                <button class="btn btn-outline" onclick="switchPanel('bup', event)">
+                  Generate BUP
+                </button>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Standing Orders Schedule</h3>
+              </div>
+              <div id="standing-orders-list">
+                <!-- Will be populated -->
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Antibody Alerts</h3>
+              </div>
+              <div id="antibody-alerts">
+                <div class="alert alert-info">No antibody alerts at this time</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Customers Panel -->
+        <div id="customers-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Customer Management</h1>
+            <p class="content-subtitle">Manage customers and their contact information</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Customers</h3>
+                <button class="btn btn-primary btn-sm" onclick="openCustomerModal()">
+                  + Add Customer
+                </button>
+              </div>
+
+              <div class="customer-grid" id="customer-list">
+                <!-- Customers will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sample Definitions Panel -->
+        <div id="samples-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Sample Definitions</h1>
+            <p class="content-subtitle">Manage sample type definitions and properties</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Sample Type Definitions</h3>
+              </div>
+
+              <div class="upload-area" onclick="document.getElementById('sample-csv').click()">
+                <input
+                  type="file"
+                  id="sample-csv"
+                  class="upload-input"
+                  accept=".csv"
+                  onchange="handleSampleCSV(event)"
+                />
+                <div class="upload-icon">📁</div>
+                <div>Click to upload sample_definitions.csv</div>
+                <div style="font-size: 0.875rem; color: var(--gray); margin-top: 0.5rem">
+                  or drag and drop CSV file here
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="sample-table">
+                  <thead>
+                    <tr>
+                      <th>Sample Type ID</th>
+                      <th>Name</th>
+                      <th>Volume (mL)</th>
+                      <th>Hematocrit (%)</th>
+                      <th>Requires RBC</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="6" class="text-center" style="color: var(--gray)">
+                        No sample definitions loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div style="display: flex; justify-content: flex-end; margin-top: 1rem">
+                <button class="btn btn-danger" onclick="deleteAllSamples()">
+                  Delete All Sample Definitions
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Specifications Panel -->
+        <div id="specs-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Historical Specifications</h1>
+            <p class="content-subtitle">Import and manage customer specifications</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Customer Specifications</h3>
+              </div>
+
+              <div class="upload-area" onclick="document.getElementById('spec-csv').click()">
+                <input
+                  type="file"
+                  id="spec-csv"
+                  class="upload-input"
+                  accept=".csv"
+                  onchange="handleSpecCSV(event)"
+                  multiple
+                />
+                <div class="upload-icon">📁</div>
+                <div>Click to upload customer spec CSV files</div>
+                <div style="font-size: 0.875rem; color: var(--gray); margin-top: 0.5rem">
+                  Select multiple files: wslh_specs.csv, sigma_qc_specs.csv, etc.
+                </div>
+              </div>
+
+              <!-- Pagination Controls -->
+              <div style="margin: 1rem 0">
+                <!-- Filter Row -->
+                <div
+                  style="
+                    display: flex;
+                    gap: 1rem;
+                    align-items: center;
+                    margin-bottom: 1rem;
+                    padding: 1rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <input
+                    type="text"
+                    id="spec-search"
+                    class="form-input"
+                    placeholder="Search customer, event..."
+                    style="flex: 1; min-width: 200px"
+                    oninput="filterSpecs()"
+                  />
+
+                  <select
+                    id="spec-filter-year"
+                    class="form-select"
+                    style="width: 120px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Years</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-event"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Events</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-sample-id"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Sample IDs</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-sample-type"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Sample Types</option>
+                  </select>
+
+                  <button class="btn btn-outline btn-sm" onclick="clearSpecFilters()">
+                    Clear Filters
+                  </button>
+                </div>
+
+                <!-- Delete All Row -->
+                <div
+                  style="
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 0.5rem;
+                    padding: 0.5rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <div style="color: var(--gray)">
+                    <span id="spec-selected-count">0 specifications selected</span>
+                  </div>
+                  <button
+                    class="btn btn-danger"
+                    onclick="deleteAllSpecs()"
+                    id="delete-all-specs-btn"
+                  >
+                    Delete All Filtered Specifications
+                  </button>
+                </div>
+
+                <!-- Pagination Row -->
+                <div
+                  style="
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: 0.5rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <select
+                    id="spec-page-size"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="updateSpecPagination()"
+                  >
+                    <option value="25">25 rows</option>
+                    <option value="50">50 rows</option>
+                    <option value="100" selected>100 rows</option>
+                    <option value="all">All rows</option>
+                  </select>
+
+                  <div id="spec-pagination-info" style="color: var(--gray)">
+                    Showing 1-100 of 912 entries
+                  </div>
+
+                  <div id="spec-pagination-controls" style="display: flex; gap: 0.5rem">
+                    <button class="btn btn-outline btn-sm" onclick="specChangePage('prev')">
+                      Previous
+                    </button>
+                    <div
+                      id="spec-page-numbers"
+                      style="display: flex; gap: 0.25rem; align-items: center"
+                    >
+                      <!-- Page numbers will be generated here -->
+                    </div>
+                    <button class="btn btn-outline btn-sm" onclick="specChangePage('next')">
+                      Next
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="spec-table">
+                  <thead>
+                    <tr>
+                      <th>Customer</th>
+                      <th>Event</th>
+                      <th>Year</th>
+                      <th>Sample ID</th>
+                      <th>Sample Type</th>
+                      <th>ABO/Rh</th>
+                      <th>Antibodies</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray)">
+                        No specifications loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Future Specifications Panel -->
+        <div id="future-specs-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Future Specifications</h1>
+            <p class="content-subtitle">Design and optimize specifications for upcoming events</p>
+          </div>
+
+          <div class="content-body">
+            <!-- Create New Future Spec Card -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Create Future Specification</h3>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label class="form-label">Customer <span class="required">*</span></label>
+                  <select
+                    class="form-select"
+                    id="future-spec-customer"
+                    onchange="updateFutureCopyOptions()"
+                  >
+                    <option value="">Select Customer</option>
+                    <option value="WSLH">WSLH</option>
+                    <option value="ISLA">ISLA</option>
+                    <option value="OneWorld">OneWorld</option>
+                    <option value="Aurevia">Aurevia</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Event <span class="required">*</span></label>
+                  <select class="form-select" id="future-spec-event">
+                    <option value="">Select Event</option>
+                    <option value="1st">1st</option>
+                    <option value="2nd">2nd</option>
+                    <option value="3rd">3rd</option>
+                    <option value="4th">4th</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Year <span class="required">*</span></label>
+                  <input
+                    type="number"
+                    class="form-input"
+                    id="future-spec-year"
+                    value="2026"
+                    min="2026"
+                    max="2030"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Copy Structure From</label>
+                  <select class="form-select" id="future-spec-copy-from">
+                    <option value="">Manual Entry</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Forecasted Quantity</label>
+                  <input
+                    type="number"
+                    class="form-input"
+                    id="future-spec-quantity"
+                    placeholder="Auto-calculate from history"
+                  />
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="createFutureSpec()">
+                Create Specification
+              </button>
+            </div>
+
+            <!-- Active Future Specifications -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Future Specifications</h3>
+              </div>
+
+              <div id="future-specs-list">
+                <p class="text-center" style="color: var(--gray)">
+                  No future specifications created yet
+                </p>
+              </div>
+            </div>
+
+            <!-- Optimization Results (hidden initially) -->
+            <div class="card" id="optimization-results" style="display: none">
+              <div class="card-header">
+                <h3 class="card-title">Optimization Results</h3>
+                <button class="btn btn-outline btn-sm" onclick="closeOptimization()">Close</button>
+              </div>
+
+              <div id="optimization-content">
+                <!-- Results will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Blood Calculator Panel -->
+        <div id="calculator-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Blood Calculator</h1>
+            <p class="content-subtitle">Calculate exact pRBC volumes with optimization</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Sample Parameters</h3>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label class="form-label">Customer</label>
+                  <div style="display: flex; gap: 10px; align-items: center">
+                    <select
+                      class="form-select"
+                      id="calc-customer"
+                      onchange="updateYearOptions(); updateEventOptions();"
+                      style="flex: 1"
+                    >
+                      <option value="">Select Customer</option>
+                    </select>
+                    <span>OR</span>
+                    <input
+                      type="text"
+                      class="form-input"
+                      id="calc-customer-manual"
+                      placeholder="Enter customer name manually"
+                      style="flex: 1"
+                      oninput="handleManualCustomerInput()"
+                    />
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Year</label>
+                  <select class="form-select" id="calc-year" onchange="updateEventOptions()">
+                    <option value="">All Years</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Event</label>
+                  <select class="form-select" id="calc-event" onchange="updateSampleOptions()">
+                    <option value="">Select Event</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Sample ID</label>
+                  <select class="form-select" id="calc-sample" onchange="autoFillSampleDetails()">
+                    <option value="">Select Sample</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Quantity</label>
+                  <input
+                    type="number"
+                    class="form-input"
+                    id="calc-quantity"
+                    placeholder="Number of samples"
+                    value="100"
+                  />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Volume (mL)</label>
+                  <input type="number" class="form-input" id="calc-volume" value="2" step="0.1" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Hematocrit (%)</label>
+                  <input type="number" class="form-input" id="calc-hematocrit" value="4" step="1" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Sample Type</label>
+                  <select class="form-select" id="calc-sample-type">
+                    <option value="standard">Standard</option>
+                    <option value="dat_positive">DAT Positive (IgG)</option>
+                    <option value="dat_c3">DAT Positive (C3)</option>
+                    <option value="eluate">Eluate (ELU)</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Blood Type</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="calc-blood-type"
+                    placeholder="e.g., O Pos"
+                  />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Event Expiration Date</label>
+                  <input type="date" class="form-input" id="calc-expiration" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Event Ship Date</label>
+                  <input type="date" class="form-input" id="calc-ship-date" />
+                </div>
+              </div>
+
+              <div class="btn-group">
+                <button class="btn btn-primary" onclick="calculateBloodNeeds()">
+                  Calculate Requirements
+                </button>
+                <button class="btn btn-outline" onclick="showSharingWindow()">
+                  Show Sharing Window
+                </button>
+              </div>
+
+              <div id="calc-results" style="display: none">
+                <div class="calculation-results">
+                  <div class="result-item">
+                    <span class="result-label">Base pRBC Volume:</span>
+                    <span class="result-value" id="base-volume">0p</span>
+                  </div>
+                  <div class="result-item">
+                    <span class="result-label">Retention Volume (5 samples):</span>
+                    <span class="result-value" id="retention-volume">0p</span>
+                  </div>
+                  <div class="result-item">
+                    <span class="result-label">Overage Factor:</span>
+                    <span class="result-value" id="overage-factor">0%</span>
+                  </div>
+                  <div class="result-item">
+                    <span class="result-label">Total pRBC Required:</span>
+                    <span class="result-value" id="total-volume">0p</span>
+                  </div>
+                  <div class="result-item">
+                    <span class="result-label">Units Needed:</span>
+                    <span class="result-value" id="units-needed">0</span>
+                  </div>
+                </div>
+
+                <div id="sharing-window-info" style="display: none"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- BUP Generator Panel -->
+        <div id="bup-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">BUP Generator</h1>
+            <p class="content-subtitle">Create blood utilization plans with optimization</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Select Events for BUP</h3>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Filter and Select Events</label>
+
+                <!-- Filter Controls -->
+                <div
+                  style="
+                    display: grid;
+                    grid-template-columns: 1fr 1fr 1fr;
+                    gap: 1rem;
+                    margin-bottom: 1rem;
+                  "
+                >
+                  <div>
+                    <label class="form-label">Customer</label>
+                    <select
+                      class="form-select"
+                      id="bup-filter-customer"
+                      onchange="updateBUPEventList()"
+                    >
+                      <option value="">All Customers</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="form-label">Year</label>
+                    <select
+                      class="form-select"
+                      id="bup-filter-year"
+                      onchange="updateBUPEventList()"
+                    >
+                      <option value="">All Years</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="form-label">Search</label>
+                    <input
+                      type="text"
+                      class="form-input"
+                      id="bup-filter-search"
+                      placeholder="Search events..."
+                      oninput="updateBUPEventList()"
+                    />
+                  </div>
+                </div>
+
+                <!-- Event Selection List -->
+                <div
+                  style="
+                    border: 1px solid var(--border);
+                    border-radius: 6px;
+                    padding: 1rem;
+                    max-height: 300px;
+                    overflow-y: auto;
+                    background: var(--white);
+                  "
+                >
+                  <div style="margin-bottom: 0.5rem; display: flex; justify-content: space-between">
+                    <label style="font-weight: 600">Available Events</label>
+                    <button class="btn btn-outline btn-sm" onclick="selectAllVisibleEvents()">
+                      Select All Visible
+                    </button>
+                  </div>
+                  <div id="bup-events-list">
+                    <!-- Checkboxes will be populated here -->
+                  </div>
+                </div>
+
+                <div class="form-hint" style="margin-top: 0.5rem">
+                  Selected: <span id="bup-selected-count">0</span> events
+                </div>
+                <!-- Selected Events Pool -->
+                <div id="selected-events-pool" style="margin-top: 1.5rem; display: none">
+                  <h4 style="margin-bottom: 0.5rem">Selected Events Pool</h4>
+                  <div
+                    style="
+                      border: 2px solid var(--hemo-blue);
+                      border-radius: 6px;
+                      padding: 1rem;
+                      background: var(--hemo-blue-lighter);
+                      min-height: 100px;
+                    "
+                  >
+                    <div
+                      id="selected-events-list"
+                      style="display: flex; flex-wrap: wrap; gap: 0.5rem"
+                    >
+                      <!-- Selected event tags will appear here -->
+                    </div>
+                    <div
+                      id="empty-pool-message"
+                      style="color: var(--gray); text-align: center; padding: 2rem"
+                    >
+                      No events selected yet. Use the filters above to find and add events.
+                    </div>
+                  </div>
+                  <button
+                    class="btn btn-danger btn-sm"
+                    style="margin-top: 0.5rem"
+                    onclick="clearSelectedPool()"
+                  >
+                    Clear All Selected
+                  </button>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Include Standing Orders</label>
+                <div style="display: flex; flex-direction: column; gap: 0.5rem">
+                  <label
+                    ><input type="checkbox" id="include-hqc" checked /> HQC (Every 28 days)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-mirrscitech" checked /> Mirrscitech/Korea
+                    (Every 28 days)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-c3" checked /> C3 Control (Every 28 days - O
+                    unit available)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-mqc" checked /> MQC/MQC-CAT (Every 35
+                    days)</label
+                  >
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="generateBUP()">Generate BUP Report</button>
+            </div>
+
+            <div class="card" id="bup-report" style="display: none">
+              <div class="card-header">
+                <h3 class="card-title">Blood Utilization Plan</h3>
+                <div class="btn-group">
+                  <button class="btn btn-outline btn-sm" onclick="toggleBUPView()">
+                    Toggle View
+                  </button>
+                  <button class="btn btn-outline btn-sm" onclick="exportBUP()">
+                    Export Report
+                  </button>
+                </div>
+              </div>
+
+              <div id="bup-summary" class="alert alert-info" style="margin: 1rem">
+                <!-- Summary will appear here -->
+              </div>
+
+              <div id="bup-content">
+                <!-- BUP will be generated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quantities Panel -->
+        <div id="quantities-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Order Quantities</h1>
+            <p class="content-subtitle">Manage confirmed and forecasted quantities</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Import Quantities</h3>
+              </div>
+
+              <div class="upload-area" onclick="document.getElementById('quantities-csv').click()">
+                <input
+                  type="file"
+                  id="quantities-csv"
+                  class="upload-input"
+                  accept=".csv"
+                  onchange="handleQuantitiesCSV(event)"
+                />
+                <div class="upload-icon">📊</div>
+                <div>Click to upload order_quantities_confirmed.csv</div>
+              </div>
+            </div>
+
+            <!-- Filter Quantities Card -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Filter Quantities</h3>
+              </div>
+
+              <div
+                style="
+                  display: grid;
+                  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                  gap: 1rem;
+                  padding: 1rem;
+                "
+              >
+                <div>
+                  <label class="form-label">Customer</label>
+                  <select
+                    class="form-select"
+                    id="qty-filter-customer"
+                    onchange="filterQuantities()"
+                  >
+                    <option value="">All Customers</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Year</label>
+                  <select class="form-select" id="qty-filter-year" onchange="filterQuantities()">
+                    <option value="">All Years</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Event</label>
+                  <select class="form-select" id="qty-filter-event" onchange="filterQuantities()">
+                    <option value="">All Events</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Sample ID</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="qty-filter-sample"
+                    placeholder="Filter by sample ID..."
+                    oninput="filterQuantities()"
+                  />
+                </div>
+
+                <div>
+                  <label class="form-label">PO Number</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="qty-filter-po"
+                    placeholder="Filter by PO..."
+                    oninput="filterQuantities()"
+                  />
+                </div>
+
+                <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+                  <button class="btn btn-outline btn-sm" onclick="clearQuantityFilters()">
+                    Clear Filters
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteFilteredQuantities()">
+                    Delete Filtered
+                  </button>
+                </div>
+              </div>
+
+              <div style="padding: 0 1rem 1rem; color: var(--gray)">
+                <span id="qty-filter-count">Showing all quantities</span>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Confirmed Orders</h3>
+                <div class="btn-group">
+                  <button class="btn btn-primary btn-sm" onclick="openQuantityModal()">
+                    + Add Quantity
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteAllQuantities()">
+                    Delete All Quantities
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="quantities-table">
+                  <thead>
+                    <tr>
+                      <th>Customer</th>
+                      <th>Event</th>
+                      <th>Year</th>
+                      <th>Sample ID</th>
+                      <th>Quantity</th>
+                      <th>PO Number</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray)">
+                        No quantities loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sharing Opportunities Panel -->
+        <div id="sharing-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Sharing Opportunities</h1>
+            <p class="content-subtitle">Analyze blood sharing opportunities between events</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Sharing Analysis</h3>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Analysis Date Range</label>
+                <div class="form-grid">
+                  <input type="date" class="form-input" id="sharing-start-date" />
+                  <input type="date" class="form-input" id="sharing-end-date" />
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="analyzeSharingOpportunities()">
+                Analyze Sharing Opportunities
+              </button>
+
+              <div id="sharing-analysis-results" style="margin-top: 2rem">
+                <!-- Results will appear here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Manufacturing Calendar Panel -->
+        <div id="calendar-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Manufacturing Calendar</h1>
+            <p class="content-subtitle">Track blood arrivals, shipments, and standing orders</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="calendar-container">
+                <div class="calendar-header">
+                  <h3 id="calendar-month-year">January 2025</h3>
+                  <div class="calendar-nav">
+                    <button onclick="previousMonth()">◀</button>
+                    <button onclick="goToToday()">Current Month</button>
+                    <button onclick="nextMonth()">▶</button>
+                  </div>
+                </div>
+                <div class="calendar-grid" id="calendar-grid">
+                  <!-- Calendar will be generated here -->
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- closes .content-body -->
+        </div>
+        <!-- closes #calendar-panel -->
+
+        <!-- Units Panel (Bulk RBCs) -->
+        <div id="units-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Bulk RBC Inventory</h1>
+            <p class="content-subtitle">Track bulk RBC units and partial usage</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Blood Units</h3>
+                <button class="btn btn-primary btn-sm" onclick="openUnitModal()">+ Add Unit</button>
+              </div>
+
+              <div id="units-list">
+                <!-- Units will be displayed here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Antibodies Panel -->
+        <div id="antibodies-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Antibody Management</h1>
+            <p class="content-subtitle">Track inventory, costs, and usage of antibodies</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Antibody Inventory</h3>
+                <button class="btn btn-primary btn-sm" onclick="openAntibodyModal()">
+                  + Add Antibody
+                </button>
+              </div>
+
+              <div class="antibody-grid" id="antibody-list">
+                <!-- Antibodies will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Activity Log Panel -->
+
+        <!-- Activity Log Panel -->
+        <div id="activity-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Activity Log</h1>
+            <p class="content-subtitle">Track all changes and user activity</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header" style="display: flex; gap: 0.5rem; align-items: center">
+                <div class="btn-group">
+                  <button
+                    id="btn-tab-activity"
+                    class="btn btn-primary btn-sm"
+                    onclick="showActivitySection('all')"
+                  >
+                    All Activity
+                  </button>
+                  <button
+                    id="btn-tab-decisions"
+                    class="btn btn-outline btn-sm"
+                    onclick="showActivitySection('decisions')"
+                  >
+                    Decisions
+                  </button>
+                </div>
+                <button
+                  class="btn btn-success btn-sm"
+                  style="margin-left: auto"
+                  onclick="logDecision('Test','Manual test entry', null); showActivitySection('decisions');"
+                >
+                  + Add Test Decision
+                </button>
+              </div>
+
+              <div id="activity-log">
+                <!-- Activity items will be populated here -->
+              </div>
+
+              <div id="decisions-log" style="display: none">
+                <!-- Decision entries will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Settings Panel -->
+        <div id="settings-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Settings</h1>
+            <p class="content-subtitle">Configure platform settings and preferences</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <h3 class="card-title mb-3">File Storage Configuration</h3>
+
+              <div id="storage-setup" style="display: none">
+                <div class="alert alert-warning">
+                  ⚠️ File storage not configured. Click below to select a storage folder.
+                </div>
+                <button class="btn btn-primary" onclick="setupFileAccess()">
+                  Select Storage Folder
+                </button>
+              </div>
+
+              <div id="storage-connected" style="display: none">
+                <div class="alert alert-success">✅ Connected to storage folder</div>
+                <div class="form-group">
+                  <label class="form-label">Current Storage Location</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="storage-path"
+                    readonly
+                    value="[Folder Selected]"
+                  />
+                </div>
+                <button class="btn btn-warning btn-sm" onclick="resetFileAccess()">
+                  Change Storage Location
+                </button>
+              </div>
+            </div>
+
+            <div class="card">
+              <h3 class="card-title mb-3">User Identification</h3>
+              <div class="form-group">
+                <label for="user-name-setting">Your Name</label>
+                <input
+                  type="text"
+                  id="user-name-setting"
+                  class="form-input"
+                  placeholder="Enter your name"
+                />
+                <small>This will be used to track who makes changes</small>
+              </div>
+              <div class="btn-group">
+                <button class="btn btn-primary" onclick="saveUserSettings()">
+                  Save User Settings
+                </button>
+                <button class="btn btn-warning" onclick="resetSetup()">Reset Setup</button>
+              </div>
+              <div class="alert alert-info mt-2" style="display: none" id="reset-setup-info">
+                <strong>Reset Setup:</strong> This will clear your setup status and allow you to
+                re-run the setup wizard. Your data will NOT be deleted. Use this if you're having
+                access issues.
+              </div>
+            </div>
+
+            <div class="card">
+              <h3 class="card-title mb-3">Export/Import</h3>
+              <div class="btn-group">
+                <button class="btn btn-primary" onclick="exportAllData()">Export All Data</button>
+                <button class="btn btn-outline" onclick="importBackup()">Import Backup</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <!-- Setup Wizard Modal -->
+    <div id="setup-wizard-modal" class="modal setup-modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title">Welcome to Blood Optimization Platform</h3>
+        </div>
+        <div class="modal-body">
+          <div class="setup-steps">
+            <div class="setup-step active" id="step-1">
+              <div class="step-number">1</div>
+              <div class="step-label">User Setup</div>
+            </div>
+            <div class="setup-step" id="step-2">
+              <div class="step-number">2</div>
+              <div class="step-label">Storage Setup</div>
+            </div>
+            <div class="setup-step" id="step-3">
+              <div class="step-number">3</div>
+              <div class="step-label">Instructions</div>
+            </div>
+            <div class="setup-step" id="step-4">
+              <div class="step-number">4</div>
+              <div class="step-label">Get Started</div>
+            </div>
+          </div>
+
+          <div class="setup-content" id="setup-content">
+            <!-- Content will be populated by JavaScript -->
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn btn-outline"
+            id="setup-back"
+            onclick="previousSetupStep()"
+            style="display: none"
+          >
+            Back
+          </button>
+          <button class="btn btn-primary" id="setup-next" onclick="nextSetupStep()">Next</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Customer Modal -->
+    <div id="customer-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="customer-modal-title">Add Customer</h3>
+          <button class="close-btn" onclick="closeCustomerModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Customer Name <span class="required">*</span></label>
+              <input
+                type="text"
+                class="form-input"
+                id="customer-name"
+                placeholder="e.g., Wisconsin State Laboratory of Hygiene"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Customer Code <span class="required">*</span></label>
+              <input type="text" class="form-input" id="customer-code" placeholder="e.g., WSLH" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Country/Region <span class="required">*</span></label>
+              <select class="form-select" id="customer-region">
+                <option value="">Select Region</option>
+                <option value="United States">United States</option>
+                <option value="Canada">Canada</option>
+                <option value="Mexico">Mexico</option>
+                <option value="United Kingdom">United Kingdom</option>
+                <option value="Germany">Germany</option>
+                <option value="France">France</option>
+                <option value="Australia">Australia</option>
+                <option value="Japan">Japan</option>
+                <option value="South Korea">South Korea</option>
+                <option value="Other">Other</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Notes</label>
+              <textarea
+                class="form-textarea"
+                id="customer-notes"
+                placeholder="Special requirements, formerly known as, etc."
+              ></textarea>
+            </div>
+          </div>
+
+          <h4 class="mb-2">Contacts</h4>
+          <div class="contact-list" id="contact-list">
+            <!-- Contacts will be added here -->
+          </div>
+          <button class="btn btn-outline btn-sm" onclick="addContactField()">+ Add Contact</button>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeCustomerModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveCustomer()">Save Customer</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Antibody Modal -->
+    <div id="antibody-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="antibody-modal-title">Add Antibody</h3>
+          <button class="close-btn" onclick="closeAntibodyModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <h4 class="mb-2">Basic Information</h4>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Antibody Name <span class="required">*</span></label>
+              <input type="text" class="form-input" id="antibody-name" placeholder="e.g., Anti-K" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Type <span class="required">*</span></label>
+              <select class="form-select" id="antibody-type">
+                <option value="IgG">IgG</option>
+                <option value="IgM">IgM</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Clone</label>
+              <input
+                type="text"
+                class="form-input"
+                id="antibody-clone"
+                placeholder="e.g., K1-2B6"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Manufacturer</label>
+              <input
+                type="text"
+                class="form-input"
+                id="antibody-manufacturer"
+                placeholder="e.g., Immucor"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Availability Status</label>
+              <select class="form-select" id="antibody-status">
+                <option value="Available">Available for Purchase</option>
+                <option value="Limited">Limited Stock Only</option>
+                <option value="Discontinued">Discontinued</option>
+              </select>
+            </div>
+          </div>
+
+          <h4 class="mb-2 mt-3">Purchase Information</h4>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Purchase Quantity (mL)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="antibody-purchase-quantity"
+                placeholder="50"
+                step="0.1"
+              />
+              <div class="form-hint">Original amount purchased</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Purchase Price ($)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="antibody-purchase-price"
+                placeholder="2500"
+                step="0.01"
+              />
+              <div class="form-hint">Total price paid</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Dilution Factor (1:X)</label>
+              <input type="number" class="form-input" id="antibody-dilution" placeholder="100" />
+              <div class="form-hint">Enter 100 for 1:100 dilution</div>
+            </div>
+          </div>
+
+          <h4 class="mb-2 mt-3">Current Inventory</h4>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Current Quantity (mL)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="antibody-current-quantity"
+                placeholder="45"
+                step="0.1"
+              />
+              <div class="form-hint">Amount currently in stock</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Low Stock Alert (mL)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="antibody-low-stock"
+                placeholder="100"
+                value="100"
+                step="1"
+              />
+              <div class="form-hint">Alert when below this amount</div>
+            </div>
+          </div>
+          <h4 class="mb-2 mt-3">Quality Management</h4>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Qualification Date</label>
+              <input type="date" class="form-input" id="antibody-qualification-date" />
+              <div class="form-hint">When antibody was validated for use</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Requalification Due</label>
+              <input type="date" class="form-input" id="antibody-requalification-due" readonly />
+              <div class="form-hint">Auto-calculated (+365 days)</div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeAntibodyModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveAntibody()">Save Antibody</button>
+        </div>
+      </div>
+      <!-- ADD THIS - closes modal-content -->
+    </div>
+    <!-- ADD THIS - closes antibody-modal -->
+
+    <!-- Quantity Edit Modal -->
+    <div id="quantity-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="quantity-modal-title">Edit Quantity</h3>
+          <button class="close-btn" onclick="closeQuantityModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Customer <span class="required">*</span></label>
+              <input type="text" class="form-input" id="qty-modal-customer" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Event <span class="required">*</span></label>
+              <input type="text" class="form-input" id="qty-modal-event" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Year <span class="required">*</span></label>
+              <input type="number" class="form-input" id="qty-modal-year" min="2020" max="2030" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Sample ID</label>
+              <input
+                type="text"
+                class="form-input"
+                id="qty-modal-sample"
+                placeholder="Leave blank for all samples"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Quantity <span class="required">*</span></label>
+              <input type="number" class="form-input" id="qty-modal-quantity" min="1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">PO Number</label>
+              <input type="text" class="form-input" id="qty-modal-po" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Status</label>
+              <select class="form-select" id="qty-modal-status">
+                <option value="Confirmed">Confirmed</option>
+                <option value="Pending">Pending</option>
+                <option value="Forecast">Forecast</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeQuantityModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveQuantity()">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Calendar Add Event Modal -->
+    <div id="calendar-add-event-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="calendar-add-event-modal-title">Add Event</h3>
+          <button class="close-btn" onclick="closeCalendarAddEventModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label required" id="modal-main-date-label">Date</label>
+              <input type="date" class="form-input" id="modal-calendar-date" readonly />
+            </div>
+            <div class="form-group" id="modal-arrival-date-group" style="display: none;">
+              <label class="form-label required">Arrival Date</label>
+              <input type="date" class="form-input" id="modal-arrival-date" />
+            </div>
+            <div class="form-group">
+              <label class="form-label required">Entry Type</label>
+              <select
+                class="form-select"
+                id="modal-calendar-type"
+                onchange="handleTypeChange('modal'); toggleShipmentFields()"
+              >
+                <!-- Will be populated by JavaScript -->
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Notes</label>
+              <textarea
+                class="form-textarea"
+                id="modal-calendar-notes"
+                placeholder="Add optional notes..."
+              ></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn btn-danger"
+            id="modal-delete-event-btn"
+            onclick="deleteCalendarEvent()"
+            style="margin-right: auto; display: none;"
+          >
+            Delete Event
+          </button>
+          <button class="btn btn-outline" onclick="closeCalendarAddEventModal()">Cancel</button>
+          <button class="btn btn-primary" id="calendar-add-event-submit" onclick="addCalendarEvent()">
+            Add Event
+          </button>
+        </div>
+      </div>
+    </div>
+    <script>
+      // ===============================
+      // Application State Management
+      // ===============================
+
+      const APP_STATE = {
+        version: '0.4.3', // Update version
+        customers: [],
+        sampleDefinitions: [],
+        customerSpecs: [],
+        quantities: [],
+        antibodies: [],
+        bloodUnits: [],
+        manufacturingCalendar: [],
+        activityLog: [],
+        decisions: [],
+
+        // ADD THIS NEW STRUCTURE:
+        futureSpecs: {
+          entries: [],
+          versions: {},
+          metadata: {},
+        },
+
+        activeUsers: [],
+        editingCustomerId: null,
+        editingAntibodyId: null,
+        editingQuantityId: null,
+        dirHandle: null,
+        currentUser: null,
+        writeAccess: false,
+        setupComplete: false,
+        instructionsAcknowledged: false,
+        theme: localStorage.getItem('theme') || 'light',
+        currentSetupStep: 1,
+        currentMonth: new Date().getMonth(),
+        currentYear: new Date().getFullYear(),
+        specPagination: {
+          currentPage: 1,
+          pageSize: 100,
+          filteredSpecs: [],
+          searchTerm: '',
+          filterEvent: '',
+          filterYear: '',
+          filterSampleId: '',
+          filterSampleType: '',
+        },
+        quantityFilters: {
+          customer: '',
+          event: '',
+          year: '',
+          sampleId: '',
+          poNumber: '',
+          filteredQuantities: [],
+        },
+        samplePagination: {
+          currentPage: 1,
+          pageSize: 25,
+          filteredSamples: [],
+          searchTerm: '',
+        },
+        bupAnalysis: {
+          selectedEvents: [],
+          calculations: [],
+          sharingOpportunities: [],
+          optimizedPlan: null,
+        },
+        bupSelectedPool: new Set(), // Stores selected event keys
+      };
+
+      let editingCalendarEntryId = null;
+
+      // Constants
+      const RBC_UNIT_ML = 180.0;
+      const RETENTION_SAMPLES = 5;
+      const MAX_BLOOD_AGE = 77; // days
+      const STANDARD_BUFFER = 10; // days
+      const EXTERNAL_TESTING_BUFFER = 17; // days (future feature)
+
+      // Calendar Configuration
+      const CALENDAR_CATEGORIES = {
+        Manufacturing: [
+          { value: 'bulk-event', label: 'Bulk Event' },
+          { value: 'fill-event', label: 'Fill Event' },
+          { value: 'wash-rbcs', label: 'Wash RBCs' },
+          { value: 'coat-rbcs', label: 'Coat RBCs' },
+          { value: 'setup-event', label: 'Set Up for Event' },
+        ],
+        Shipping: [
+          { value: 'external-testing', label: 'External Testing Ship' },
+          { value: 'blood-shipment', label: 'Blood Shipment (Ship/Arrival)' },
+          { value: 'blood-arrival', label: 'Blood Arrival' },
+          { value: 'shipment', label: 'Shipment' },
+        ],
+        Administrative: [
+          { value: 'timesheets', label: 'Timesheets Due' },
+          { value: 'case-study', label: 'Case Study Due' },
+        ],
+        Quality: [{ value: 'label-event', label: 'Label Event' }],
+        Professional: [{ value: 'conference', label: 'Conference' }],
+        'Time Off': [
+          { value: 'pto', label: 'Employee PTO' },
+          { value: 'holiday', label: 'Holiday/Hb Closed' },
+        ],
+        Recurring: [{ value: 'standing-order', label: 'Standing Order' }],
+      };
+
+      const RECURRENCE_ENABLED_CATEGORY = 'Recurring';
+
+      // Overage Tiers
+      const OVERAGE_TIERS = [
+        { maxQuantity: 200, overage: 1.15 },
+        { maxQuantity: 1000, overage: 1.1 },
+        { maxQuantity: 2000, overage: 1.08 },
+        { maxQuantity: Infinity, overage: 1.06 },
+      ];
+
+      const DAT_OVERAGE_MIN = 1.25;
+      const DAT_OVERAGE_MAX = 1.3;
+      const ELU_OVERAGE_MIN = 1.25;
+      const ELU_OVERAGE_MAX = 1.3;
+
+      // Standing Orders Configuration
+      const STANDING_ORDERS = [
+        {
+          product: 'C3 Control Cells',
+          units: [
+            { type: 'O', count: 2, vendor: 'Tennessee' },
+            { type: 'FFS', count: 4, vendor: 'Tennessee' },
+          ],
+          frequency: 28,
+          bonus: { type: 'O', volume: 180 },
+        },
+        {
+          product: 'Hemo-QC',
+          units: [
+            { type: 'AsubB Pos', count: 3, vendor: 'Memorial' },
+            { type: 'O Pos R1r Fya Neg', count: 3, vendor: 'Memorial' },
+            { type: 'A₁ Neg rr', count: 3, vendor: 'Memorial' },
+          ],
+          frequency: 28,
+        },
+        {
+          product: 'MQC/MQC-CAT',
+          units: [
+            { type: 'A₁B Pos', count: 1, vendor: 'Kansas City' },
+            { type: 'O Neg rr K Pos', count: 1, vendor: 'Kansas City' },
+          ],
+          frequency: 35,
+        },
+        {
+          product: 'Korea FFMU/Mirrscitech',
+          units: [
+            { type: 'A₁ Pos R1R1', count: 1, vendor: 'Memorial' },
+            { type: 'B Pos R2R2', count: 1, vendor: 'Memorial' },
+            { type: 'O Neg rr', count: 1, vendor: 'Tennessee' },
+          ],
+          frequency: 28,
+        },
+      ];
+
+      // Antigen Cost Configuration
+      const ANTIGEN_COSTS = {
+        standard: 35, // Common antigens (Fya, Fyb, K, etc.)
+        rare: 75, // Rare antigens
+        panel: 150, // Full phenotyping panels
+      };
+
+      const BLOOD_UNIT_COSTS = {
+        standard: 450, // Regular ABO/Rh matched
+        antigenMatched: 525, // With specific antigens
+        rare: 650, // Rare blood types
+        emergency: 850, // Rush orders
+      };
+
+      // Common antigens tracked for optimization
+      const TRACKED_ANTIGENS = [
+        'C',
+        'c',
+        'E',
+        'e',
+        'K',
+        'Fya',
+        'Fyb',
+        'Jka',
+        'Jkb',
+        'S',
+        's',
+        'M',
+        'N',
+      ];
+
+      // Helper function to migrate old antigen/antibody format to new format
+      function migrateFutureSpecsFormat() {
+        if (!APP_STATE.futureSpecs || !APP_STATE.futureSpecs.entries) return;
+
+        APP_STATE.futureSpecs.entries.forEach((spec) => {
+          // Migrate antigens from string to array format
+          if (typeof spec.antigens === 'string') {
+            const oldAntigens = spec.antigens;
+            spec.antigens = [];
+            if (oldAntigens && oldAntigens.trim()) {
+              const parts = oldAntigens.split(',').map((s) => s.trim());
+              parts.forEach((part) => {
+                const match = part.match(/^([A-Za-z]+)([\+\-])$/);
+                if (match) {
+                  spec.antigens.push({
+                    antigen: match[1],
+                    status: match[2] === '+' ? 'Positive' : 'Negative',
+                  });
+                }
+              });
+            }
+          }
+
+          // Migrate antibodies to array format
+          if (!Array.isArray(spec.antibodies)) {
+            spec.antibodies = [];
+            if (spec.antibody_1) spec.antibodies.push(spec.antibody_1);
+            if (spec.antibody_2) spec.antibodies.push(spec.antibody_2);
+            delete spec.antibody_1;
+            delete spec.antibody_2;
+          }
+
+          // Migrate DAT format
+          if (spec.is_dat_positive === 'TRUE') {
+            spec.dat_status = 'Positive';
+          } else {
+            spec.dat_status = 'Negative';
+          }
+          delete spec.is_dat_positive;
+        });
+      }
+
+      // Define proper antigen order for immunohematology
+      const ANTIGEN_ORDER = ['C', 'E', 'c', 'e', 'K', 'k', 'Fya', 'Fyb', 'Jka', 'Jkb', 'S', 's'];
+
+      // Available antibodies list
+      const AVAILABLE_ANTIBODIES = [
+        'Anti-D',
+        'Anti-C',
+        'Anti-E',
+        'Anti-c',
+        'Anti-e',
+        'Anti-K',
+        'Anti-k',
+        'Anti-Fya',
+        'Anti-Fyb',
+        'Anti-Jka',
+        'Anti-Jkb',
+        'Anti-S',
+        'Anti-s',
+        'WAA',
+        'Daratumumab',
+      ];
+
+      // Helper functions
+      function formatAntigensDisplay(antigens) {
+        if (!antigens || !Array.isArray(antigens)) return '';
+        const sorted = antigens.sort((a, b) => {
+          const indexA = ANTIGEN_ORDER.indexOf(a.antigen);
+          const indexB = ANTIGEN_ORDER.indexOf(b.antigen);
+          return indexA - indexB;
+        });
+        return sorted.map((a) => `${a.antigen}${a.status === 'Positive' ? '+' : '-'}`).join(', ');
+      }
+
+      function generateElementId() {
+        return 'elem_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+      }
+
+      // ===============================
+
+      // ===============================
+      // Initialization
+      // ===============================
+
+      document.addEventListener('DOMContentLoaded', async function () {
+        // Apply saved theme
+        document.body.setAttribute('data-theme', APP_STATE.theme);
+        updateThemeIcon();
+
+        // Check if setup is needed
+        const setupComplete = localStorage.getItem('setup_complete') === 'true';
+        const currentUser = localStorage.getItem('current_user');
+
+        // Try to auto-connect to previous storage
+        if (currentUser && !setupComplete) {
+          // User exists but setup not marked complete - check for existing data
+          APP_STATE.currentUser = currentUser;
+          await attemptAutoConnect();
+        }
+
+        if (!setupComplete || !currentUser) {
+          // Create automatic backup if data exists
+          await createAutomaticBackup('new_user_detected');
+          showSetupWizard();
+        } else {
+          APP_STATE.setupComplete = true;
+          APP_STATE.currentUser = currentUser;
+          APP_STATE.instructionsAcknowledged =
+            localStorage.getItem('instructions_acknowledged') === 'true';
+          APP_STATE.writeAccess = APP_STATE.instructionsAcknowledged;
+
+          updateUserDisplay();
+          await checkFileAccess();
+          await loadData();
+
+          updateDashboard();
+          updateCustomerList();
+          updateAntibodyList();
+          updateActivityLog();
+          displayStandingOrders();
+          initializeCalendar();
+          // Initialize calendar with current month/year
+          APP_STATE.currentMonth = new Date().getMonth();
+          APP_STATE.currentYear = new Date().getFullYear();
+          renderCalendar();
+        }
+
+        // Auto-calculate requalification date
+        const qualDateInput = document.getElementById('antibody-qualification-date');
+        if (qualDateInput) {
+          qualDateInput.addEventListener('change', function (e) {
+            if (e.target.value) {
+              const qualDate = new Date(e.target.value);
+              const requalDate = new Date(qualDate);
+              requalDate.setDate(requalDate.getDate() + 365);
+              document.getElementById('antibody-requalification-due').value = requalDate
+                .toISOString()
+                .split('T')[0];
+            }
+          });
+        }
+
+        // Initialize drag and drop
+        initializeDragAndDrop();
+
+        // Auto-save every 30 seconds
+        setInterval(autoSave, 30000);
+      });
+
+      // ===============================
+      // Setup Wizard
+      // ===============================
+
+      function showSetupWizard() {
+        const modal = document.getElementById('setup-wizard-modal');
+        modal.classList.add('active');
+        showSetupStep(1);
+      }
+
+      function showSetupStep(step) {
+        console.log('showSetupStep called with step:', step);
+        APP_STATE.currentSetupStep = step;
+        console.log('currentSetupStep set to:', APP_STATE.currentSetupStep);
+
+        // Rest of the function...
+
+        // Update step indicators
+        for (let i = 1; i <= 4; i++) {
+          const stepEl = document.getElementById(`step-${i}`);
+          stepEl.classList.remove('active', 'completed');
+          if (i < step) stepEl.classList.add('completed');
+          if (i === step) stepEl.classList.add('active');
+        }
+
+        // Update content
+        const content = document.getElementById('setup-content');
+        const backBtn = document.getElementById('setup-back');
+        const nextBtn = document.getElementById('setup-next');
+
+        switch (step) {
+          case 1:
+            content.innerHTML = `
+                                                            <h3>Welcome! Let's set up your profile</h3>
+                                                            <p>This platform requires initial configuration to function properly.</p>
+                                                            <div class="form-group">
+                                                                <label class="form-label">Your Name</label>
+                                                                <input type="text" class="form-input" id="setup-user-name"
+                                                                       placeholder="Enter your full name"
+                                                                       value="${
+                                                                         APP_STATE.currentUser || ''
+                                                                       }">
+                                                                <small>This will be used to track changes and activity</small>
+                                                            </div>
+                                                            <div class="alert alert-warning">
+                                                                ⚠️ This platform will have read-only access until setup is complete
+                                                            </div>
+                                                        `;
+            backBtn.style.display = 'none';
+            nextBtn.textContent = 'Next';
+            nextBtn.disabled = false;
+            break;
+
+          case 2:
+            content.innerHTML = `
+                                                            <h3>Storage Setup</h3>
+                                                            <p>Select a folder where data will be stored and auto-saved.</p>
+                                                            <div id="wizard-storage-status"></div>
+                                                            <button class="btn btn-primary" onclick="setupFileAccessFromWizard()">
+                                                                Select Storage Folder
+                                                            </button>
+                                                            <div class="alert alert-info mt-2">
+                                                                📁 A folder structure will be created automatically<br>
+                                                                💾 Data will auto-save every 30 seconds<br>
+                                                                🔒 Your browser will remember this location
+                                                            </div>
+                                                        `;
+            backBtn.style.display = 'inline-flex';
+            nextBtn.textContent = 'Next';
+            nextBtn.disabled = !APP_STATE.dirHandle;
+            break;
+
+          case 3:
+            content.innerHTML = `
+                                                            <h3>Platform Instructions</h3>
+                                                            <div class="instructions-panel">
+                                                                <h4>Important Guidelines:</h4>
+                                                                <ul>
+                                                                    <li>All changes are tracked with your user name</li>
+                                                                    <li>Data auto-saves every 30 seconds</li>
+                                                                    <li>Use Chrome or Edge browser for best compatibility</li>
+                                                                    <li>Regular backups are created automatically</li>
+                                                                </ul>
+
+                                                                <h4>Blood Unit Management:</h4>
+                                                                <ul>
+                                                                    <li>Standard unit size: 180 mL per pRBC unit</li>
+                                                                    <li>Maximum blood age: 77 days from event expiration</li>
+                                                                    <li>Standard manufacturing buffer: 10 days</li>
+                                                                    <li>Extended buffer for external testing: 17 days</li>
+                                                                </ul>
+
+                                                                <h4>Blood Calculation Methodology:</h4>
+                                                                <p><strong>Base Formula:</strong><br>
+                                                                pRBC needed = (Quantity + 5 retention) × Volume × Overage × (Hematocrit% / 100)</p>
+
+                                                                <h4>Standard Overage (by quantity):</h4>
+                                                                <ul>
+                                                                    <li>&lt;200 samples: 15% overage (multiply by 1.15)</li>
+                                                                    <li>200-1000 samples: 10% overage (multiply by 1.10)</li>
+                                                                    <li>1001-2000 samples: 8% overage (multiply by 1.08)</li>
+                                                                    <li>&gt;2000 samples: 6% overage (multiply by 1.06)</li>
+                                                                </ul>
+
+                                                                <h4>Special Overage (overrides standard):</h4>
+                                                                <ul>
+                                                                    <li>DAT Positive (IgG or C3): 25-30% overage (multiply by 1.25-1.30)</li>
+                                                                    <li>Eluate (ELU) samples: 25-30% overage (multiply by 1.25-1.30)</li>
+                                                                </ul>
+
+                                                                <p><em>Note: System calculates multiple scenarios to identify optimization opportunities</em></p>
+                                                            </div>
+                                                            <div class="form-group">
+                                                                <label class="checkbox-label">
+                                                                    <input type="checkbox" id="acknowledge-instructions">
+                                                                    I have read and understand these instructions
+                                                                </label>
+                                                            </div>
+                                                        `;
+            backBtn.style.display = 'inline-flex';
+            nextBtn.textContent = 'Next';
+            nextBtn.disabled = false;
+            break;
+
+          case 4:
+            content.innerHTML = `
+                                                            <h3>Setup Complete!</h3>
+                                                            <p>You're ready to start using the Blood Optimization Platform.</p>
+                                                            <div class="alert alert-success">
+                                                                ✅ User profile configured<br>
+                                                                ✅ Storage folder connected<br>
+                                                                ✅ Instructions acknowledged<br>
+                                                                ✅ Write access enabled
+                                                            </div>
+                                                            <p>You can now:</p>
+                                                            <ul>
+                                                                <li>Import your CSV data files</li>
+                                                                <li>Add customers and antibodies</li>
+                                                                <li>Calculate blood requirements</li>
+                                                                <li>Track inventory and generate reports</li>
+                                                            </ul>
+                                                        `;
+            backBtn.style.display = 'inline-flex';
+            nextBtn.textContent = 'Get Started';
+            nextBtn.disabled = false;
+            break;
+        }
+      }
+
+      function nextSetupStep() {
+        console.log('nextSetupStep called, current step:', APP_STATE.currentSetupStep);
+
+        if (APP_STATE.currentSetupStep === 1) {
+          const name = document.getElementById('setup-user-name').value.trim();
+          if (!name) {
+            showAlert('error', 'Please enter your name');
+            return;
+          }
+          APP_STATE.currentUser = name;
+          localStorage.setItem('current_user', name);
+          updateUserDisplay();
+          console.log('Step 1 validated, name set to:', name);
+        } else if (APP_STATE.currentSetupStep === 2) {
+          if (!APP_STATE.dirHandle) {
+            showAlert('error', 'Please select a storage folder');
+            return;
+          }
+          console.log('Step 2 validated');
+        } else if (APP_STATE.currentSetupStep === 3) {
+          const acknowledged = document.getElementById('acknowledge-instructions').checked;
+          if (!acknowledged) {
+            showAlert('error', 'Please acknowledge the instructions');
+            return;
+          }
+          APP_STATE.instructionsAcknowledged = true;
+          APP_STATE.writeAccess = true;
+          localStorage.setItem('instructions_acknowledged', 'true');
+          console.log('Step 3 validated');
+        } else if (APP_STATE.currentSetupStep === 4) {
+          // Complete setup
+          APP_STATE.setupComplete = true;
+          localStorage.setItem('setup_complete', 'true');
+          document.getElementById('setup-wizard-modal').classList.remove('active');
+
+          // Initialize app
+          loadData();
+          updateDashboard();
+          updateCustomerList();
+          updateAntibodyList();
+          updateActivityLog();
+          displayStandingOrders();
+          initializeCalendar();
+
+          logActivity('Platform setup completed');
+          showAlert('success', 'Setup complete! Welcome to Blood Optimization Platform.');
+          console.log('Step 4 - setup complete');
+          return;
+        }
+
+        console.log('About to call showSetupStep with step:', APP_STATE.currentSetupStep + 1);
+        showSetupStep(APP_STATE.currentSetupStep + 1);
+      }
+
+      function previousSetupStep() {
+        if (APP_STATE.currentSetupStep > 1) {
+          showSetupStep(APP_STATE.currentSetupStep - 1);
+        }
+      }
+
+      async function setupFileAccessFromWizard() {
+        try {
+          APP_STATE.dirHandle = await window.showDirectoryPicker({
+            mode: 'readwrite',
+          });
+
+          // Create folder structure
+          await createFolderStructure();
+
+          const statusDiv = document.getElementById('wizard-storage-status');
+          statusDiv.innerHTML =
+            '<div class="alert alert-success">✅ Storage folder connected successfully!</div>';
+
+          // Enable next button
+          document.getElementById('setup-next').disabled = false;
+
+          // Update main storage status
+          document.getElementById('storage-status').classList.add('connected');
+          document.getElementById('storage-text').textContent = 'Connected';
+        } catch (err) {
+          if (err.name !== 'AbortError') {
+            showAlert('error', 'Failed to access folder. Please try again.');
+          }
+        }
+      }
+
+      async function attemptAutoConnect() {
+        // This function tries to reconnect to previous storage without user interaction
+        // It's called when a user is recognized but setup isn't marked complete
+
+        try {
+          // For security reasons, we can't auto-connect without user permission
+          // But we can check localStorage for indicators
+          const storageGranted = localStorage.getItem('storage_granted');
+
+          if (storageGranted === 'true') {
+            // User previously granted storage access
+            // Mark setup as complete for known users with previous access
+            localStorage.setItem('setup_complete', 'true');
+            localStorage.setItem('instructions_acknowledged', 'true');
+            APP_STATE.writeAccess = true;
+          }
+        } catch (err) {
+          console.log('Auto-connect check failed:', err);
+        }
+      }
+
+      // ===============================
+      // File System Access API
+      // ===============================
+
+      async function setupFileAccess() {
+        try {
+          APP_STATE.dirHandle = await window.showDirectoryPicker({
+            mode: 'readwrite',
+          });
+
+          // Create folder structure
+          await createFolderStructure();
+
+          // Check if data file exists
+          try {
+            const dataDir = await APP_STATE.dirHandle.getDirectoryHandle('data');
+            const fileHandle = await dataDir.getFileHandle('blood_platform_data.json');
+            const file = await fileHandle.getFile();
+            const text = await file.text();
+            const data = JSON.parse(text);
+
+            // Data exists! Mark setup as complete
+            if (data && data.customers) {
+              localStorage.setItem('setup_complete', 'true');
+              localStorage.setItem('instructions_acknowledged', 'true');
+              APP_STATE.writeAccess = true;
+
+              // Create automatic backup
+              await createAutomaticBackup('existing_data_reconnection');
+
+              showAlert('success', 'Connected to existing data. Setup complete!');
+            }
+          } catch (err) {
+            // No existing data, this is a new setup
+            console.log('No existing data found, proceeding with new setup');
+          }
+
+          // Update UI
+          document.getElementById('storage-setup').style.display = 'none';
+          document.getElementById('storage-connected').style.display = 'block';
+          document.getElementById('storage-status').classList.add('connected');
+          document.getElementById('storage-text').textContent = 'Connected';
+
+          logActivity('Connected to storage folder');
+
+          // Load existing data
+          await loadData();
+        } catch (err) {
+          if (err.name !== 'AbortError') {
+            showAlert('error', 'Failed to access folder. Please try again.');
+          }
+        }
+      }
+
+      async function createFolderStructure() {
+        if (!APP_STATE.dirHandle) return;
+
+        try {
+          // Create subfolders
+          await APP_STATE.dirHandle.getDirectoryHandle('data', { create: true });
+          await APP_STATE.dirHandle.getDirectoryHandle('backups', { create: true });
+          await APP_STATE.dirHandle.getDirectoryHandle('exports', { create: true });
+          await APP_STATE.dirHandle.getDirectoryHandle('logs', { create: true });
+        } catch (err) {
+          console.error('Failed to create folder structure:', err);
+        }
+      }
+
+      async function checkFileAccess() {
+        if (APP_STATE.dirHandle) {
+          document.getElementById('storage-setup').style.display = 'none';
+          document.getElementById('storage-connected').style.display = 'block';
+          document.getElementById('storage-status').classList.add('connected');
+          document.getElementById('storage-text').textContent = 'Connected';
+        } else {
+          document.getElementById('storage-setup').style.display = 'block';
+          document.getElementById('storage-connected').style.display = 'none';
+
+          // If user was previously set up, show reconnect prompt
+          if (APP_STATE.setupComplete) {
+            const setupDiv = document.getElementById('storage-setup');
+            if (setupDiv) {
+              setupDiv.innerHTML = `
+                                                        <div class="alert alert-warning">
+                                                            ⚠️ Storage disconnected after refresh. Please reconnect to your storage folder.
+                                                        </div>
+                                                        <button class="btn btn-primary" onclick="setupFileAccess()">
+                                                            Reconnect Storage Folder
+                                                        </button>
+                                                        <div class="alert alert-info mt-2">
+                                                            This is normal browser security behavior. Your data is safe.
+                                                        </div>
+                                                    `;
+            }
+          }
+        }
+      }
+
+      async function resetFileAccess() {
+        APP_STATE.dirHandle = null;
+        document.getElementById('storage-setup').style.display = 'block';
+        document.getElementById('storage-connected').style.display = 'none';
+        document.getElementById('storage-status').classList.remove('connected');
+        document.getElementById('storage-text').textContent = 'Not Connected';
+      }
+
+      async function createAutomaticBackup(reason) {
+        if (!APP_STATE.dirHandle) return;
+
+        try {
+          const backupsDir = await APP_STATE.dirHandle.getDirectoryHandle('backups');
+
+          // Create timestamp
+          const now = new Date();
+          const timestamp = now
+            .toISOString()
+            .replace(/[:.]/g, '')
+            .replace('T', '_')
+            .substring(0, 15);
+          const filename = `blood_platform_backup_${timestamp}.json`;
+
+          // Create backup data
+          const backupData = {
+            version: APP_STATE.version,
+            backupDate: now.toISOString(),
+            backupReason: reason,
+            customers: APP_STATE.customers,
+            sampleDefinitions: APP_STATE.sampleDefinitions,
+            customerSpecs: APP_STATE.customerSpecs,
+            quantities: APP_STATE.quantities,
+            antibodies: APP_STATE.antibodies,
+            bloodUnits: APP_STATE.bloodUnits,
+            manufacturingCalendar: APP_STATE.manufacturingCalendar,
+            activityLog: APP_STATE.activityLog,
+            decisions: APP_STATE.decisions,
+            futureSpecs: APP_STATE.futureSpecs, // ADD THIS LINE
+          };
+
+          const fileHandle = await backupsDir.getFileHandle(filename, { create: true });
+          const writable = await fileHandle.createWritable();
+          await writable.write(JSON.stringify(backupData, null, 2));
+          await writable.close();
+
+          console.log(`Backup created: ${filename}`);
+        } catch (err) {
+          console.error('Failed to create backup:', err);
+        }
+      }
+
+      async function autoSave() {
+        if (!APP_STATE.dirHandle || !APP_STATE.writeAccess) return;
+
+        try {
+          await saveToFile();
+          console.log('Auto-saved at', new Date().toLocaleTimeString());
+        } catch (err) {
+          console.error('Auto-save failed:', err);
+        }
+      }
+
+      async function saveToFile() {
+        if (!APP_STATE.dirHandle || !APP_STATE.writeAccess) return;
+
+        try {
+          const dataDir = await APP_STATE.dirHandle.getDirectoryHandle('data');
+          const fileHandle = await dataDir.getFileHandle('blood_platform_data.json', {
+            create: true,
+          });
+          const writable = await fileHandle.createWritable();
+
+          const data = {
+            version: APP_STATE.version,
+            lastModified: new Date().toISOString(),
+            lastModifiedBy: APP_STATE.currentUser,
+            activeUsers: APP_STATE.activeUsers,
+            customers: APP_STATE.customers,
+            sampleDefinitions: APP_STATE.sampleDefinitions,
+            customerSpecs: APP_STATE.customerSpecs,
+            quantities: APP_STATE.quantities,
+            antibodies: APP_STATE.antibodies,
+            bloodUnits: APP_STATE.bloodUnits,
+            manufacturingCalendar: APP_STATE.manufacturingCalendar,
+            activityLog: APP_STATE.activityLog,
+            decisions: APP_STATE.decisions,
+            futureSpecs: APP_STATE.futureSpecs, // ADD THIS LINE
+          };
+
+          await writable.write(JSON.stringify(data, null, 2));
+          await writable.close();
+
+          // Update status
+          const now = new Date().toLocaleTimeString();
+          document.getElementById('storage-text').textContent = `Saved at ${now}`;
+        } catch (err) {
+          console.error('Failed to save:', err);
+        }
+      }
+
+      // ===============================
+      // Data Migration Utilities
+      // ===============================
+
+      function migrateDataFormats(data) {
+        console.log('Starting data format migration...');
+
+        // Helper function to convert antigen string to new format
+        const convertAntigens = (antigenString) => {
+          if (typeof antigenString !== 'string' || !antigenString.trim()) {
+            return []; // Return empty array if not a string or is empty
+          }
+
+          const result = [];
+          // Handle formats like "A1-pos K-neg", "K-neg Jka-pos", etc.
+          const antigenPairs = antigenString.split(/\s+/);
+
+          for (const pair of antigenPairs) {
+            if (pair.includes('-')) {
+              const [antigen, status] = pair.split('-');
+              if (antigen && status) {
+                const formattedStatus = status.toLowerCase() === 'pos' ? 'Positive' : 'Negative';
+                result.push({ antigen: antigen.trim(), status: formattedStatus });
+              }
+            }
+          }
+
+          return result;
+        };
+
+        // Helper function to convert legacy antibody fields to new format
+        const convertAntibodies = (antibody1, antibody2) => {
+          const result = [];
+          if (typeof antibody1 === 'string' && antibody1.trim()) {
+            result.push(antibody1.trim());
+          }
+          if (typeof antibody2 === 'string' && antibody2.trim()) {
+            result.push(antibody2.trim());
+          }
+          return result;
+        };
+
+        // Helper function to convert DAT status
+        const convertDatStatus = (isDatPositive) => {
+          if (typeof isDatPositive === 'string') {
+            return isDatPositive.toUpperCase() === 'TRUE' ? 'Positive' : 'Negative';
+          }
+          return 'Negative'; // Default
+        };
+
+        // Process customerSpecs
+        if (data.customerSpecs && Array.isArray(data.customerSpecs)) {
+          for (const spec of data.customerSpecs) {
+            // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+            if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+              spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+              delete spec.antibody_1;
+              delete spec.antibody_2;
+            }
+
+            // Migrate antigens from string to array format
+            if (typeof spec.antigens === 'string') {
+              spec.antigens = convertAntigens(spec.antigens);
+            }
+
+            // Migrate DAT status
+            if (spec.is_dat_positive !== undefined) {
+              spec.dat_status = convertDatStatus(spec.is_dat_positive);
+              delete spec.is_dat_positive;
+            }
+          }
+          console.log(`Migrated ${data.customerSpecs.length} customer specifications`);
+        }
+
+        // Process futureSpecs.entries
+        if (
+          data.futureSpecs &&
+          data.futureSpecs.entries &&
+          Array.isArray(data.futureSpecs.entries)
+        ) {
+          for (const spec of data.futureSpecs.entries) {
+            // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+            if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+              spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+              delete spec.antibody_1;
+              delete spec.antibody_2;
+            }
+
+            // Migrate antigens from string to array format
+            if (typeof spec.antigens === 'string') {
+              spec.antigens = convertAntigens(spec.antigens);
+            }
+
+            // Migrate DAT status
+            if (spec.is_dat_positive !== undefined) {
+              spec.dat_status = convertDatStatus(spec.is_dat_positive);
+              delete spec.is_dat_positive;
+            }
+          }
+          console.log(`Migrated ${data.futureSpecs.entries.length} future specifications`);
+        }
+
+        // Process futureSpecs.versions (historical data)
+        if (data.futureSpecs && data.futureSpecs.versions) {
+          Object.keys(data.futureSpecs.versions).forEach((versionKey) => {
+            const versionData = data.futureSpecs.versions[versionKey];
+            if (versionData.samples && Array.isArray(versionData.samples)) {
+              for (const spec of versionData.samples) {
+                // Apply same migrations to historical versions
+                if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+                  spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+                  delete spec.antibody_1;
+                  delete spec.antibody_2;
+                }
+
+                if (typeof spec.antigens === 'string') {
+                  spec.antigens = convertAntigens(spec.antigens);
+                }
+
+                if (spec.is_dat_positive !== undefined) {
+                  spec.dat_status = convertDatStatus(spec.is_dat_positive);
+                  delete spec.is_dat_positive;
+                }
+              }
+            }
+          });
+          console.log(
+            `Migrated ${Object.keys(data.futureSpecs.versions).length} future spec versions`
+          );
+        }
+
+        console.log('Data format migration completed');
+        return data;
+      }
+
+      // ===============================
+      // Data Migration Utilities
+      // ===============================
+
+      function migrateDataFormats(data) {
+        console.log('Starting data format migration...');
+
+        // Helper function to convert antigen string to new format
+        const convertAntigens = (antigenString) => {
+          if (typeof antigenString !== 'string' || !antigenString.trim()) {
+            return []; // Return empty array if not a string or is empty
+          }
+
+          const result = [];
+          // Handle formats like "A1-pos K-neg", "K-neg Jka-pos", etc.
+          const antigenPairs = antigenString.split(/\s+/);
+
+          for (const pair of antigenPairs) {
+            if (pair.includes('-')) {
+              const [antigen, status] = pair.split('-');
+              if (antigen && status) {
+                const formattedStatus = status.toLowerCase() === 'pos' ? 'Positive' : 'Negative';
+                result.push({ antigen: antigen.trim(), status: formattedStatus });
+              }
+            }
+          }
+
+          return result;
+        };
+
+        // Helper function to convert legacy antibody fields to new format
+        const convertAntibodies = (antibody1, antibody2) => {
+          const result = [];
+          if (typeof antibody1 === 'string' && antibody1.trim()) {
+            result.push(antibody1.trim());
+          }
+          if (typeof antibody2 === 'string' && antibody2.trim()) {
+            result.push(antibody2.trim());
+          }
+          return result;
+        };
+
+        // Helper function to convert DAT status
+        const convertDatStatus = (isDatPositive) => {
+          if (typeof isDatPositive === 'string') {
+            return isDatPositive.toUpperCase() === 'TRUE' ? 'Positive' : 'Negative';
+          }
+          return 'Negative'; // Default
+        };
+
+        // Process customerSpecs
+        if (data.customerSpecs && Array.isArray(data.customerSpecs)) {
+          for (const spec of data.customerSpecs) {
+            // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+            if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+              spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+              delete spec.antibody_1;
+              delete spec.antibody_2;
+            }
+
+            // Migrate antigens from string to array format
+            if (typeof spec.antigens === 'string') {
+              spec.antigens = convertAntigens(spec.antigens);
+            }
+
+            // Migrate DAT status
+            if (spec.is_dat_positive !== undefined) {
+              spec.dat_status = convertDatStatus(spec.is_dat_positive);
+              delete spec.is_dat_positive;
+            }
+          }
+          console.log(`Migrated ${data.customerSpecs.length} customer specifications`);
+        }
+
+        // Process futureSpecs.entries
+        if (
+          data.futureSpecs &&
+          data.futureSpecs.entries &&
+          Array.isArray(data.futureSpecs.entries)
+        ) {
+          for (const spec of data.futureSpecs.entries) {
+            // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+            if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+              spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+              delete spec.antibody_1;
+              delete spec.antibody_2;
+            }
+
+            // Migrate antigens from string to array format
+            if (typeof spec.antigens === 'string') {
+              spec.antigens = convertAntigens(spec.antigens);
+            }
+
+            // Migrate DAT status
+            if (spec.is_dat_positive !== undefined) {
+              spec.dat_status = convertDatStatus(spec.is_dat_positive);
+              delete spec.is_dat_positive;
+            }
+          }
+          console.log(`Migrated ${data.futureSpecs.entries.length} future specifications`);
+        }
+
+        // Process futureSpecs.versions (historical data)
+        if (data.futureSpecs && data.futureSpecs.versions) {
+          Object.keys(data.futureSpecs.versions).forEach((versionKey) => {
+            const versionData = data.futureSpecs.versions[versionKey];
+            if (versionData.samples && Array.isArray(versionData.samples)) {
+              for (const spec of versionData.samples) {
+                // Apply same migrations to historical versions
+                if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+                  spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+                  delete spec.antibody_1;
+                  delete spec.antibody_2;
+                }
+
+                if (typeof spec.antigens === 'string') {
+                  spec.antigens = convertAntigens(spec.antigens);
+                }
+
+                if (spec.is_dat_positive !== undefined) {
+                  spec.dat_status = convertDatStatus(spec.is_dat_positive);
+                  delete spec.is_dat_positive;
+                }
+              }
+            }
+          });
+          console.log(
+            `Migrated ${Object.keys(data.futureSpecs.versions).length} future spec versions`
+          );
+        }
+
+        console.log('Data format migration completed');
+        return data;
+      }
+
+      async function loadData() {
+        if (!APP_STATE.dirHandle) return;
+
+        try {
+          const dataDir = await APP_STATE.dirHandle.getDirectoryHandle('data');
+          const fileHandle = await dataDir.getFileHandle('blood_platform_data.json');
+          const file = await fileHandle.getFile();
+          const text = await file.text();
+          const data = JSON.parse(text);
+
+          // *** MIGRATE DATA FORMATS ***
+          const migratedData = migrateDataFormats(data);
+
+          // Check for different user
+          if (
+            migratedData.lastModifiedBy &&
+            migratedData.lastModifiedBy !== APP_STATE.currentUser
+          ) {
+            // Create backup before loading
+            await createAutomaticBackup('different_user_detected');
+          }
+
+          // Load data into state
+          APP_STATE.customers = migratedData.customers || [];
+          APP_STATE.sampleDefinitions = migratedData.sampleDefinitions || [];
+          APP_STATE.customerSpecs = migratedData.customerSpecs || [];
+          APP_STATE.quantities = migratedData.quantities || [];
+          APP_STATE.antibodies = migratedData.antibodies || [];
+          APP_STATE.bloodUnits = migratedData.bloodUnits || [];
+          APP_STATE.manufacturingCalendar = migratedData.manufacturingCalendar || [];
+          // Generate standing orders for current month after data load
+          APP_STATE.activityLog = migratedData.activityLog || [];
+          APP_STATE.decisions = migratedData.decisions || [];
+          APP_STATE.activeUsers = migratedData.activeUsers || [];
+          APP_STATE.futureSpecs = migratedData.futureSpecs || {
+            entries: [],
+            versions: {},
+            metadata: {},
+          };
+          // Ensure future specs display updates after data load
+          setTimeout(() => {
+            if (document.getElementById('future-specs-list')) {
+              updateFutureSpecsList();
+            }
+          }, 100);
+          if (APP_STATE.futureSpecs.entries && APP_STATE.futureSpecs.entries.length > 0) {
+            setTimeout(() => {
+              if (document.getElementById('future-specs-list')) {
+                updateFutureSpecsList();
+              }
+            }, 100);
+          }
+
+          // Update active users list
+          updateActiveUsers(migratedData.lastModifiedBy);
+
+          // Update all displays
+          updateDashboard();
+          updateCustomerList();
+          updateAntibodyList();
+          updateActivityLog();
+          updateAllTables();
+          populateSpecFilters();
+
+          // Populate calculator dropdowns after all data is loaded
+          populateCalculatorDropdowns();
+        } catch (err) {
+          if (err.name !== 'NotFoundError') {
+            console.error('Failed to load data:', err);
+          }
+        }
+      }
+
+      function updateActiveUsers(lastUser) {
+        if (!lastUser) return;
+
+        // Add current user if not in list
+        if (APP_STATE.currentUser && !APP_STATE.activeUsers.includes(APP_STATE.currentUser)) {
+          APP_STATE.activeUsers.push(APP_STATE.currentUser);
+        }
+
+        // Update display
+        if (APP_STATE.activeUsers.length > 0) {
+          document.getElementById('active-users').style.display = 'flex';
+          document.getElementById('active-user-list').textContent =
+            APP_STATE.activeUsers.join(', ');
+        }
+      }
+
+      // ===============================
+      // Theme Management
+      // ===============================
+
+      function toggleTheme() {
+        const currentTheme = document.body.getAttribute('data-theme');
+        const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+        document.body.setAttribute('data-theme', newTheme);
+        APP_STATE.theme = newTheme;
+        localStorage.setItem('theme', newTheme);
+        updateThemeIcon();
+      }
+
+      function updateThemeIcon() {
+        const icon = document.getElementById('theme-icon');
+        icon.textContent = APP_STATE.theme === 'light' ? '☀️' : '🌙';
+      }
+
+      // ===============================
+      // User Management
+      // ===============================
+
+      function saveUserSettings() {
+        const userName = document.getElementById('user-name-setting').value.trim();
+        if (!userName) {
+          showAlert('error', 'Please enter your name');
+          return;
+        }
+
+        APP_STATE.currentUser = userName;
+        localStorage.setItem('current_user', userName);
+        updateUserDisplay();
+        logActivity('Updated user settings');
+        showAlert('success', 'User settings saved');
+      }
+
+      function updateUserDisplay() {
+        if (APP_STATE.currentUser) {
+          const initials = APP_STATE.currentUser
+            .split(' ')
+            .map((n) => n[0])
+            .join('')
+            .toUpperCase();
+          document.getElementById('user-avatar').textContent = initials;
+          document.getElementById('user-name').textContent = APP_STATE.currentUser;
+
+          // Check if settings element exists before updating (it won't during setup wizard)
+          const settingsNameInput = document.getElementById('user-name-setting');
+          if (settingsNameInput) {
+            settingsNameInput.value = APP_STATE.currentUser;
+          }
+        }
+      }
+
+      function resetSetup() {
+        const info = document.getElementById('reset-setup-info');
+
+        if (info && info.style.display === 'none') {
+          // First click - show info
+          info.style.display = 'block';
+          return;
+        }
+
+        // Second click - confirm and reset
+        if (
+          confirm(
+            'Are you sure you want to reset the setup? This will:\n\n• Clear your setup completion status\n• Require you to re-acknowledge instructions\n• NOT delete any of your data\n\nProceed?'
+          )
+        ) {
+          localStorage.removeItem('setup_complete');
+          localStorage.removeItem('instructions_acknowledged');
+          localStorage.removeItem('storage_granted');
+          APP_STATE.writeAccess = false;
+
+          showAlert('info', 'Setup has been reset. Please refresh the page to run setup again.');
+
+          setTimeout(() => {
+            location.reload();
+          }, 2000);
+        }
+      }
+
+      // ===============================
+      // Activity Logging
+      // ===============================
+
+      function logActivity(action, details = null) {
+        if (!APP_STATE.writeAccess) return;
+
+        const activity = {
+          timestamp: new Date().toISOString(),
+          user: APP_STATE.currentUser || 'Unknown',
+          action: action,
+          details: details,
+        };
+
+        APP_STATE.activityLog.unshift(activity);
+
+        // Keep only last 100 activities
+        if (APP_STATE.activityLog.length > 100) {
+          APP_STATE.activityLog = APP_STATE.activityLog.slice(0, 100);
+        }
+
+        updateActivityLog();
+        autoSave();
+      }
+
+      function updateActivityLog() {
+        const logDiv = document.getElementById('activity-log');
+
+        if (APP_STATE.activityLog.length === 0) {
+          logDiv.innerHTML =
+            '<p class="text-center" style="color: var(--gray);">No activity recorded</p>';
+          return;
+        }
+
+        logDiv.innerHTML = APP_STATE.activityLog
+          .slice(0, 20)
+          .map(
+            (activity) => `
+              <div class="activity-item">
+                <div class="activity-time">${new Date(
+                  activity.timestamp
+                ).toLocaleTimeString()}</div>
+                <div class="activity-user">${activity.user}</div>
+                <div class="activity-action">${activity.action}${
+              activity.details ? ` - ${activity.details}` : ''
+            }</div>
+              </div>
+            `
+          )
+          .join('');
+      }
+
+      /* ===============================
+      Decision Logging (new)  
+      =============================== */
+      function logDecision(type, summary, context = null) {
+        const entry = {
+          timestamp: new Date().toISOString(),
+          user: APP_STATE.currentUser || 'Unknown',
+          type,
+          summary,
+          context,
+        };
+
+        APP_STATE.decisions = APP_STATE.decisions || [];
+        APP_STATE.decisions.unshift(entry);
+
+        if (APP_STATE.decisions.length > 200) {
+          APP_STATE.decisions.length = 200;
+        }
+
+        updateDecisionsLog();
+        autoSave();
+      }
+
+      function updateDecisionsLog() {
+        const div = document.getElementById('decisions-log');
+        if (!div) return;
+
+        if (!APP_STATE.decisions || APP_STATE.decisions.length === 0) {
+          div.innerHTML =
+            '<p class="text-center" style="color: var(--gray);">No decisions recorded</p>';
+          return;
+        }
+
+        div.innerHTML = APP_STATE.decisions
+          .slice(0, 50)
+          .map((d) => {
+            const t = new Date(d.timestamp).toLocaleString();
+            const ctx = d.context
+              ? '<div class="activity-action" style="color:var(--gray);">' +
+                escapeHtml(JSON.stringify(d.context)) +
+                '</div>'
+              : '';
+            return (
+              '<div class="activity-item">' +
+              '<div class="activity-time">' +
+              t +
+              '</div>' +
+              '<div class="activity-user">' +
+              d.user +
+              '</div>' +
+              '<div class="activity-action"><strong>' +
+              escapeHtml(d.type) +
+              '</strong> — ' +
+              escapeHtml(d.summary) +
+              '</div>' +
+              ctx +
+              '</div>'
+            );
+          })
+          .join('');
+      }
+
+      function showActivitySection(section) {
+        const btnAll = document.getElementById('btn-tab-activity');
+        const btnDec = document.getElementById('btn-tab-decisions');
+        const allDiv = document.getElementById('activity-log');
+        const decDiv = document.getElementById('decisions-log');
+
+        const showDecisions = section === 'decisions';
+
+        if (btnAll && btnDec) {
+          btnAll.classList.toggle('btn-primary', !showDecisions);
+          btnAll.classList.toggle('btn-outline', showDecisions);
+          btnDec.classList.toggle('btn-primary', showDecisions);
+          btnDec.classList.toggle('btn-outline', !showDecisions);
+        }
+
+        if (allDiv) allDiv.style.display = showDecisions ? 'none' : '';
+        if (decDiv) decDiv.style.display = showDecisions ? '' : 'none';
+
+        if (showDecisions) {
+          updateDecisionsLog();
+        } else {
+          updateActivityLog();
+        }
+      }
+
+      function escapeHtml(s) {
+        if (typeof s !== 'string') return s;
+        return s
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#039;');
+      }
+
+      // ===============================
+      // Navigation
+      // ===============================
+
+      function switchPanel(panelName, evt) {
+        if (!APP_STATE.writeAccess && ['customers', 'calculator', 'bup'].includes(panelName)) {
+          showAlert('warning', 'Please complete setup to access this feature');
+          return;
+        }
+
+        // clear active state
+        document.querySelectorAll('.nav-item').forEach((i) => i.classList.remove('active'));
+
+        // correct target + fixed selector quote
+        const clicked =
+          evt?.currentTarget ||
+          evt?.target?.closest('.nav-item') ||
+          document.querySelector(`.nav-item[onclick*="switchPanel('${panelName}')"]`);
+
+        clicked?.classList.add('active');
+
+        // switch panels
+        document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
+        const panelElement = document.getElementById(`${panelName}-panel`);
+        if (panelElement) {
+          panelElement.classList.add('active');
+        }
+        if (panelName === 'calendar') {
+          renderCalendar();
+        }
+        if (panelName === 'activity') {
+          // default to All Activity on open; refresh Decisions as well
+          showActivitySection('all');
+          updateDecisionsLog();
+        }
+
+        if (panelName === 'bup') {
+          populateBUPEvents();
+        } else if (panelName === 'future-specs') {
+          runFutureSpecOptimization();
+          updateFutureSpecsList();
+        } else if (panelName === 'activity') {
+          // default to All Activity on open; refresh Decisions as well
+          showActivitySection('all');
+          updateDecisionsLog();
+        }
+      }
+
+      function showPlaceholder(feature) {
+        showAlert('info', `${feature} - Coming in future version`);
+      }
+
+      // ===============================
+      // Customer Management
+      // ===============================
+
+      let contactCounter = 0;
+
+      function updateCustomerList() {
+        const listDiv = document.getElementById('customer-list');
+
+        if (APP_STATE.customers.length === 0) {
+          listDiv.innerHTML = `
+                                                        <div class="text-center" style="grid-column: 1/-1; color: var(--gray);">
+                                                            No customers yet. Click "Add Customer" to get started.
+                                                        </div>
+                                                    `;
+          return;
+        }
+
+        listDiv.innerHTML = APP_STATE.customers
+          .map(
+            (customer) => `
+                                                    <div class="customer-card">
+                                                        <div class="customer-actions">
+                                                            <button onclick="editCustomer('${
+                                                              customer.id
+                                                            }')" ${
+              !APP_STATE.writeAccess ? 'disabled' : ''
+            }>✏️</button>
+                                                            <button onclick="deleteCustomer('${
+                                                              customer.id
+                                                            }')" ${
+              !APP_STATE.writeAccess ? 'disabled' : ''
+            }>🗑️</button>
+                                                        </div>
+                                                        <div class="customer-header">
+                                                            <div>
+                                                                <div class="customer-name">${
+                                                                  customer.name
+                                                                }</div>
+                                                                <div class="customer-code">Code: ${
+                                                                  customer.code
+                                                                }</div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="customer-info">📍 ${
+                                                          customer.region
+                                                        }</div>
+                                                        ${
+                                                          customer.notes
+                                                            ? `<div class="customer-info" style="font-style: italic;">📝 ${customer.notes}</div>`
+                                                            : ''
+                                                        }
+                                                        ${
+                                                          customer.contacts &&
+                                                          customer.contacts.length > 0
+                                                            ? `
+                                                            <div class="customer-contacts">
+                                                                ${customer.contacts
+                                                                  .slice(0, 2)
+                                                                  .map(
+                                                                    (contact) => `
+                                                                    <div class="contact-item">
+                                                                        <span>👤 ${contact.name} (${contact.role})</span>
+                                                                    </div>
+                                                                `
+                                                                  )
+                                                                  .join('')}
+                                                                ${
+                                                                  customer.contacts.length > 2
+                                                                    ? `<div class="contact-item" style="color: var(--gray);">+${
+                                                                        customer.contacts.length - 2
+                                                                      } more contacts</div>`
+                                                                    : ''
+                                                                }
+                                                            </div>
+                                                        `
+                                                            : ''
+                                                        }
+                                                    </div>
+                                                `
+          )
+          .join('');
+      }
+
+      function openCustomerModal(customerId = null) {
+        if (!APP_STATE.writeAccess) {
+          showAlert('warning', 'Please complete setup to add customers');
+          return;
+        }
+
+        const modal = document.getElementById('customer-modal');
+        const title = document.getElementById('customer-modal-title');
+
+        // Reset contact list
+        document.getElementById('contact-list').innerHTML = '';
+        contactCounter = 0;
+
+        if (customerId) {
+          const customer = APP_STATE.customers.find((c) => c.id === customerId);
+          title.textContent = 'Edit Customer';
+          document.getElementById('customer-name').value = customer.name;
+          document.getElementById('customer-code').value = customer.code;
+          document.getElementById('customer-region').value = customer.region;
+          document.getElementById('customer-notes').value = customer.notes || '';
+
+          // Load contacts
+          if (customer.contacts) {
+            customer.contacts.forEach((contact) => {
+              addContactField(contact);
+            });
+          }
+
+          APP_STATE.editingCustomerId = customerId;
+        } else {
+          title.textContent = 'Add Customer';
+          document.getElementById('customer-name').value = '';
+          document.getElementById('customer-code').value = '';
+          document.getElementById('customer-region').value = '';
+          document.getElementById('customer-notes').value = '';
+          APP_STATE.editingCustomerId = null;
+
+          // Add one empty contact field
+          addContactField();
+        }
+
+        modal.classList.add('active');
+      }
+
+      function addContactField(contact = null) {
+        const contactList = document.getElementById('contact-list');
+        const contactId = `contact_${contactCounter++}`;
+
+        const contactDiv = document.createElement('div');
+        contactDiv.className = 'contact-entry';
+        contactDiv.id = contactId;
+        contactDiv.innerHTML = `
+                                                    <div class="contact-entry-header">
+                                                        <h5>Contact ${contactCounter}</h5>
+                                                        <button class="contact-remove" onclick="removeContact('${contactId}')">×</button>
+                                                    </div>
+                                                    <div class="form-grid">
+                                                        <div class="form-group">
+                                                            <label class="form-label">Name</label>
+                                                            <input type="text" class="form-input contact-name" placeholder="Jane Smith" value="${
+                                                              contact ? contact.name : ''
+                                                            }">
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Role</label>
+                                                            <select class="form-select contact-role">
+                                                                <option value="Primary" ${
+                                                                  contact &&
+                                                                  contact.role === 'Primary'
+                                                                    ? 'selected'
+                                                                    : ''
+                                                                }>Primary Contact</option>
+                                                                <option value="Secondary" ${
+                                                                  contact &&
+                                                                  contact.role === 'Secondary'
+                                                                    ? 'selected'
+                                                                    : ''
+                                                                }>Secondary Contact</option>
+                                                                <option value="Technical" ${
+                                                                  contact &&
+                                                                  contact.role === 'Technical'
+                                                                    ? 'selected'
+                                                                    : ''
+                                                                }>Technical Contact</option>
+                                                                <option value="Billing" ${
+                                                                  contact &&
+                                                                  contact.role === 'Billing'
+                                                                    ? 'selected'
+                                                                    : ''
+                                                                }>Billing Contact</option>
+                                                            </select>
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Email</label>
+                                                            <input type="email" class="form-input contact-email" placeholder="jane@example.com" value="${
+                                                              contact ? contact.email : ''
+                                                            }">
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Phone</label>
+                                                            <input type="tel" class="form-input contact-phone" placeholder="+1 (555) 123-4567" value="${
+                                                              contact ? contact.phone : ''
+                                                            }">
+                                                        </div>
+                                                    </div>
+                                                `;
+
+        contactList.appendChild(contactDiv);
+      }
+
+      function removeContact(contactId) {
+        document.getElementById(contactId).remove();
+      }
+
+      function closeCustomerModal() {
+        document.getElementById('customer-modal').classList.remove('active');
+        APP_STATE.editingCustomerId = null;
+      }
+
+      function saveCustomer() {
+        const name = document.getElementById('customer-name').value.trim();
+        const code = document.getElementById('customer-code').value.trim();
+        const region = document.getElementById('customer-region').value;
+        const notes = document.getElementById('customer-notes').value.trim();
+
+        if (!name || !code || !region) {
+          showAlert('error', 'Name, code, and region are required');
+          return;
+        }
+
+        // Collect contacts
+        const contacts = [];
+        document.querySelectorAll('.contact-entry').forEach((entry) => {
+          const contact = {
+            name: entry.querySelector('.contact-name').value.trim(),
+            role: entry.querySelector('.contact-role').value,
+            email: entry.querySelector('.contact-email').value.trim(),
+            phone: entry.querySelector('.contact-phone').value.trim(),
+          };
+
+          if (contact.name || contact.email) {
+            contacts.push(contact);
+          }
+        });
+
+        if (APP_STATE.editingCustomerId) {
+          // Edit existing
+          const customer = APP_STATE.customers.find((c) => c.id === APP_STATE.editingCustomerId);
+          customer.name = name;
+          customer.code = code;
+          customer.region = region;
+          customer.notes = notes;
+          customer.contacts = contacts;
+          logActivity('Updated customer', name);
+          showAlert('success', 'Customer updated successfully');
+        } else {
+          // Add new
+          const newCustomer = {
+            id: 'cust_' + Date.now(),
+            name,
+            code,
+            region,
+            notes,
+            contacts,
+            createdAt: new Date().toISOString(),
+            createdBy: APP_STATE.currentUser,
+          };
+          APP_STATE.customers.push(newCustomer);
+          logActivity('Added customer', name);
+          showAlert('success', 'Customer added successfully');
+        }
+
+        updateCustomerList();
+        updateDashboard();
+        autoSave();
+        closeCustomerModal();
+      }
+
+      function editCustomer(customerId) {
+        openCustomerModal(customerId);
+      }
+
+      function deleteCustomer(customerId) {
+        if (!APP_STATE.writeAccess) return;
+
+        const customer = APP_STATE.customers.find((c) => c.id === customerId);
+        if (confirm(`Are you sure you want to delete ${customer.name}? This cannot be undone.`)) {
+          APP_STATE.customers = APP_STATE.customers.filter((c) => c.id !== customerId);
+          updateCustomerList();
+          updateDashboard();
+          logActivity('Deleted customer', customer.name);
+          autoSave();
+          showAlert('success', 'Customer deleted');
+        }
+      }
+
+      // ===============================
+      // Antibody Management
+      // ===============================
+
+      function updateAntibodyList() {
+        const listDiv = document.getElementById('antibody-list');
+
+        if (APP_STATE.antibodies.length === 0) {
+          listDiv.innerHTML = `
+                                                <div class="text-center" style="color: var(--gray);">
+                                                    No antibodies tracked yet. Click "Add Antibody" to get started.
+                                                </div>
+                                            `;
+          return;
+        }
+
+        listDiv.innerHTML = APP_STATE.antibodies
+          .map((antibody) => {
+            const workingVolume = antibody.purchaseQuantity * antibody.dilution;
+            const rawCostPerMl = antibody.purchasePrice / antibody.purchaseQuantity;
+            const workingCostPerMl = antibody.purchasePrice / workingVolume;
+            const percentRemaining = (antibody.currentQuantity / antibody.purchaseQuantity) * 100;
+            const fillClass =
+              antibody.currentQuantity <= antibody.lowStockThreshold
+                ? antibody.currentQuantity <= 50
+                  ? 'critical'
+                  : 'low'
+                : '';
+
+            return `
+                                            <div class="antibody-card">
+                                                <div class="antibody-header">
+                                                    <div>
+                                                        <span class="antibody-name">${
+                                                          antibody.name
+                                                        }</span>
+                                                        <span class="antibody-type">${
+                                                          antibody.type
+                                                        }</span>
+                                                    </div>
+                                                    <span class="status-tag ${antibody.status.toLowerCase()}">${
+              antibody.status
+            }</span>
+                                                </div>
+
+                                                <div class="antibody-details">
+                                                    <div class="antibody-detail">
+                                                        <span class="antibody-detail-label">Clone</span>
+                                                        <span class="antibody-detail-value">${
+                                                          antibody.clone || 'N/A'
+                                                        }</span>
+                                                    </div>
+                                                    <div class="antibody-detail">
+                                                        <span class="antibody-detail-label">Manufacturer</span>
+                                                        <span class="antibody-detail-value">${
+                                                          antibody.manufacturer || 'N/A'
+                                                        }</span>
+                                                    </div>
+                                                    <div class="antibody-detail">
+                                                        <span class="antibody-detail-label">Dilution</span>
+                                                        <span class="antibody-detail-value">1:${
+                                                          antibody.dilution
+                                                        }</span>
+                                                    </div>
+                                                    <div class="antibody-detail">
+                                                        <span class="antibody-detail-label">Purchase Qty</span>
+                                                        <span class="antibody-detail-value">${
+                                                          antibody.purchaseQuantity
+                                                        } mL</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="antibody-inventory">
+                                                    <div class="inventory-status">
+                                                        <div>
+                                                            <div class="antibody-detail-label">Current Stock</div>
+                                                            <div style="font-weight: 600;">${
+                                                              antibody.currentQuantity
+                                                            } mL</div>
+                                                        </div>
+                                                        <div class="inventory-bar">
+                                                            <div class="inventory-fill ${fillClass}" style="width: ${percentRemaining}%"></div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                <div class="antibody-cost">
+                                                    <div class="cost-grid">
+                                                        <div class="cost-item">
+                                                            <div class="cost-label">Raw Cost/mL</div>
+                                                            <div class="cost-value">$${rawCostPerMl.toFixed(
+                                                              2
+                                                            )}</div>
+                                                        </div>
+                                                        <div class="cost-item">
+                                                            <div class="cost-label">Working Cost/mL</div>
+                                                            <div class="cost-value">$${workingCostPerMl.toFixed(
+                                                              2
+                                                            )}</div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="btn-group">
+                                                        <button class="btn btn-outline btn-sm" onclick="editAntibody('${
+                                                          antibody.id
+                                                        }')" ${
+              !APP_STATE.writeAccess ? 'disabled' : ''
+            }>Edit</button>
+                                                        <button class="btn btn-danger btn-sm" onclick="deleteAntibody('${
+                                                          antibody.id
+                                                        }')" ${
+              !APP_STATE.writeAccess ? 'disabled' : ''
+            }>Delete</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            `;
+          })
+          .join('');
+
+        // Update alerts
+        updateAntibodyAlerts();
+      }
+
+      function updateAntibodyAlerts() {
+        const alertsDiv = document.getElementById('antibody-alerts');
+        const alerts = [];
+        const today = new Date();
+        const thirtyDaysFromNow = new Date();
+        thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
+
+        APP_STATE.antibodies.forEach((antibody) => {
+          // Check for low stock
+          if (antibody.currentQuantity <= antibody.lowStockThreshold) {
+            const alertType = antibody.currentQuantity <= 50 ? 'error' : 'warning';
+            alerts.push({
+              type: alertType,
+              message: `${antibody.name}: ${antibody.currentQuantity} mL remaining (low stock)`,
+            });
+          }
+
+          // Check for requalification due
+          if (antibody.requalificationDue) {
+            const requalDate = new Date(antibody.requalificationDue);
+            if (requalDate < today) {
+              alerts.push({
+                type: 'error',
+                message: `${
+                  antibody.name
+                }: Requalification PAST DUE (was due ${requalDate.toLocaleDateString()})`,
+              });
+            } else if (requalDate <= thirtyDaysFromNow) {
+              const daysUntilDue = Math.ceil((requalDate - today) / (1000 * 60 * 60 * 24));
+              alerts.push({
+                type: 'warning',
+                message: `${
+                  antibody.name
+                }: Requalification due in ${daysUntilDue} days (${requalDate.toLocaleDateString()})`,
+              });
+            }
+          }
+        });
+
+        if (alerts.length === 0) {
+          alertsDiv.innerHTML =
+            '<div class="alert alert-info">No antibody alerts at this time</div>';
+        } else {
+          alertsDiv.innerHTML = alerts
+            .map(
+              (alert) => `
+                                                        <div class="alert alert-${alert.type}">${alert.message}</div>
+                                                    `
+            )
+            .join('');
+        }
+
+        // Update dashboard low stock count
+        const lowStockCount = APP_STATE.antibodies.filter(
+          (a) => a.currentQuantity <= a.lowStockThreshold
+        ).length;
+        document.getElementById('low-stock-count').textContent = lowStockCount;
+      }
+
+      function openAntibodyModal(antibodyId = null) {
+        if (!APP_STATE.writeAccess) {
+          showAlert('warning', 'Please complete setup to add antibodies');
+          return;
+        }
+
+        const modal = document.getElementById('antibody-modal');
+        const title = document.getElementById('antibody-modal-title');
+
+        if (antibodyId) {
+          const antibody = APP_STATE.antibodies.find((a) => a.id === antibodyId);
+          title.textContent = 'Edit Antibody';
+          document.getElementById('antibody-name').value = antibody.name;
+          document.getElementById('antibody-type').value = antibody.type;
+          document.getElementById('antibody-clone').value = antibody.clone || '';
+          document.getElementById('antibody-manufacturer').value = antibody.manufacturer || '';
+          document.getElementById('antibody-status').value = antibody.status;
+          document.getElementById('antibody-purchase-quantity').value = antibody.purchaseQuantity;
+          document.getElementById('antibody-purchase-price').value = antibody.purchasePrice;
+          document.getElementById('antibody-dilution').value = antibody.dilution;
+          document.getElementById('antibody-current-quantity').value = antibody.currentQuantity;
+          document.getElementById('antibody-low-stock').value = antibody.lowStockThreshold || 100;
+          document.getElementById('antibody-qualification-date').value =
+            antibody.qualificationDate || '';
+          document.getElementById('antibody-requalification-due').value =
+            antibody.requalificationDue || '';
+          APP_STATE.editingAntibodyId = antibodyId;
+        } else {
+          title.textContent = 'Add Antibody';
+          document.getElementById('antibody-name').value = '';
+          document.getElementById('antibody-type').value = 'IgG';
+          document.getElementById('antibody-clone').value = '';
+          document.getElementById('antibody-manufacturer').value = '';
+          document.getElementById('antibody-status').value = 'Available';
+          document.getElementById('antibody-purchase-quantity').value = '';
+          document.getElementById('antibody-purchase-price').value = '';
+          document.getElementById('antibody-dilution').value = '';
+          document.getElementById('antibody-current-quantity').value = '';
+          document.getElementById('antibody-low-stock').value = '100';
+          document.getElementById('antibody-qualification-date').value = '';
+          document.getElementById('antibody-requalification-due').value = '';
+          APP_STATE.editingAntibodyId = null;
+        }
+
+        modal.classList.add('active');
+      }
+
+      function closeAntibodyModal() {
+        document.getElementById('antibody-modal').classList.remove('active');
+        APP_STATE.editingAntibodyId = null;
+      }
+
+      function saveAntibody() {
+        const name = document.getElementById('antibody-name').value.trim();
+        const type = document.getElementById('antibody-type').value;
+        const clone = document.getElementById('antibody-clone').value.trim();
+        const manufacturer = document.getElementById('antibody-manufacturer').value.trim();
+        const status = document.getElementById('antibody-status').value;
+        const purchaseQuantity =
+          parseFloat(document.getElementById('antibody-purchase-quantity').value) || 0;
+        const purchasePrice =
+          parseFloat(document.getElementById('antibody-purchase-price').value) || 0;
+        const dilution = parseFloat(document.getElementById('antibody-dilution').value) || 1;
+        const currentQuantity =
+          parseFloat(document.getElementById('antibody-current-quantity').value) ||
+          purchaseQuantity;
+        const lowStockThreshold =
+          parseFloat(document.getElementById('antibody-low-stock').value) || 100;
+        const qualificationDate = document.getElementById('antibody-qualification-date').value;
+        const requalificationDue = document.getElementById('antibody-requalification-due').value;
+
+        if (!name) {
+          showAlert('error', 'Antibody name is required');
+          return;
+        }
+
+        if (APP_STATE.editingAntibodyId) {
+          // Edit existing
+          const antibody = APP_STATE.antibodies.find((a) => a.id === APP_STATE.editingAntibodyId);
+          Object.assign(antibody, {
+            name,
+            type,
+            clone,
+            manufacturer,
+            status,
+            purchaseQuantity,
+            purchasePrice,
+            dilution,
+            currentQuantity,
+            lowStockThreshold,
+            qualificationDate,
+            requalificationDue,
+          });
+          logActivity('Updated antibody', name);
+          showAlert('success', 'Antibody updated successfully');
+        } else {
+          // Add new
+          const newAntibody = {
+            id: 'ant_' + Date.now(),
+            name,
+            type,
+            clone,
+            manufacturer,
+            status,
+            purchaseQuantity,
+            purchasePrice,
+            dilution,
+            currentQuantity,
+            lowStockThreshold,
+            qualificationDate,
+            requalificationDue,
+            usageHistory: [],
+            createdAt: new Date().toISOString(),
+            createdBy: APP_STATE.currentUser,
+          };
+          APP_STATE.antibodies.push(newAntibody);
+          logActivity('Added antibody', name);
+          showAlert('success', 'Antibody added successfully');
+        }
+
+        updateAntibodyList();
+        updateDashboard();
+        autoSave();
+        closeAntibodyModal();
+      }
+
+      function editAntibody(antibodyId) {
+        openAntibodyModal(antibodyId);
+      }
+
+      function deleteAntibody(antibodyId) {
+        if (!APP_STATE.writeAccess) return;
+
+        const antibody = APP_STATE.antibodies.find((a) => a.id === antibodyId);
+        if (confirm(`Are you sure you want to delete ${antibody.name}? This cannot be undone.`)) {
+          APP_STATE.antibodies = APP_STATE.antibodies.filter((a) => a.id !== antibodyId);
+          updateAntibodyList();
+          updateDashboard();
+          logActivity('Deleted antibody', antibody.name);
+          autoSave();
+          showAlert('success', 'Antibody deleted');
+        }
+      }
+
+      // ===============================
+      // Dashboard Functions
+      // ===============================
+
+      function updateDashboard() {
+        document.getElementById('total-customers').textContent = APP_STATE.customers.length;
+        document.getElementById('total-specs').textContent = APP_STATE.customerSpecs.length;
+        document.getElementById('total-antibodies').textContent = APP_STATE.antibodies.length;
+
+        const lowStockCount = APP_STATE.antibodies.filter(
+          (a) => a.currentQuantity <= a.lowStockThreshold
+        ).length;
+        document.getElementById('low-stock-count').textContent = lowStockCount;
+      }
+
+      function displayStandingOrders() {
+        const container = document.getElementById('standing-orders-list');
+        let html =
+          '<div class="table-container"><table><thead><tr>' +
+          '<th>Product</th><th>Frequency</th><th>Blood Types</th><th>Vendor</th>' +
+          '</tr></thead><tbody>';
+
+        STANDING_ORDERS.forEach((order) => {
+          const types = order.units
+            .map((u) => (u.type === 'FFS' ? `${u.count}x FFS` : `${u.count}x ${u.type}`))
+            .join(', ');
+          const vendors = [...new Set(order.units.map((u) => u.vendor).filter((v) => v))].join(
+            ', '
+          );
+
+          html += `
+                                                        <tr>
+                                                            <td>${order.product}</td>
+                                                            <td>Every ${order.frequency} days</td>
+                                                            <td>${types}</td>
+                                                            <td>${vendors}</td>
+                                                        </tr>
+                                                    `;
+
+          if (order.bonus) {
+            html += `
+                                                            <tr style="background: var(--hemo-blue-lighter);">
+                                                                <td>${order.product} Bonus</td>
+                                                                <td>-</td>
+                                                                <td>${order.bonus.type} (${order.bonus.volume}p)</td>
+                                                                <td>Available for sharing</td>
+                                                            </tr>
+                                                        `;
+          }
+        });
+
+        html += '</tbody></table></div>';
+        container.innerHTML = html;
+      }
+
+      // ===============================
+      // Blood Calculator Functions
+      // ===============================
+      // Populate calculator dropdowns after data loads
+      function populateCalculatorDropdowns() {
+        const customerSelect = document.getElementById('calc-customer');
+
+        if (customerSelect && APP_STATE.customerSpecs.length > 0) {
+          // Clear existing options except the first one
+          customerSelect.innerHTML = '<option value="">Select Customer</option>';
+
+          // Get unique customers from specs
+          const uniqueCustomers = [
+            ...new Set(APP_STATE.customerSpecs.map((spec) => spec.customer)),
+          ];
+          uniqueCustomers.sort().forEach((customer) => {
+            customerSelect.innerHTML += `<option value="${customer}">${customer}</option>`;
+          });
+        }
+      }
+      function handleManualCustomerInput() {
+        // Clear the dropdown when manual input is used
+        document.getElementById('calc-customer').value = '';
+        // Update year options for the manual customer
+        updateYearOptions();
+        // Clear and update events
+        updateEventOptions();
+      }
+      function updateYearOptions() {
+        const customer = document.getElementById('calc-customer').value;
+        const customerManual = document.getElementById('calc-customer-manual')?.value?.trim() || '';
+        const selectedCustomer = customer || customerManual;
+        const yearSelect = document.getElementById('calc-year');
+
+        yearSelect.innerHTML = '<option value="">All Years</option>';
+
+        if (selectedCustomer) {
+          // Get unique years for this customer
+          const years = [
+            ...new Set(
+              APP_STATE.customerSpecs
+                .filter((spec) => spec.customer === selectedCustomer)
+                .map((spec) => spec.year)
+                .filter((year) => year)
+            ),
+          ] // Remove any undefined/null years
+            .sort((a, b) => b - a); // Sort descending (newest first)
+
+          years.forEach((year) => {
+            yearSelect.innerHTML += `<option value="${year}">${year}</option>`;
+          });
+        }
+      }
+
+      function updateEventOptions() {
+        // Clear manual input ONLY if dropdown was used
+        const dropdown = document.getElementById('calc-customer');
+        const manual = document.getElementById('calc-customer-manual');
+
+        // If this was triggered by dropdown selection (not manual input)
+        if (dropdown.value && manual) {
+          manual.value = '';
+        }
+
+        const customer = dropdown.value;
+        const customerManual = manual?.value?.trim() || '';
+        const selectedCustomer = customer || customerManual;
+        const selectedYear = document.getElementById('calc-year')?.value;
+        const eventSelect = document.getElementById('calc-event');
+
+        eventSelect.innerHTML = '<option value="">Select Event</option>';
+
+        if (selectedCustomer) {
+          // Filter events for this customer and year
+          let specs = APP_STATE.customerSpecs.filter((spec) => spec.customer === selectedCustomer);
+
+          // Apply year filter if selected
+          if (selectedYear) {
+            specs = specs.filter((spec) => spec.year == selectedYear);
+          }
+
+          const events = [...new Set(specs.map((spec) => spec.event))];
+
+          events.forEach((event) => {
+            eventSelect.innerHTML += `<option value="${event}">${event}</option>`;
+          });
+        }
+
+        // Clear the sample dropdown since event changed
+        updateSampleOptions();
+      }
+
+      function updateSampleOptions() {
+        const customer = document.getElementById('calc-customer').value;
+        const customerManual = document.getElementById('calc-customer-manual')?.value?.trim() || '';
+        const selectedCustomer = customer || customerManual;
+        const selectedYear = document.getElementById('calc-year')?.value;
+        const event = document.getElementById('calc-event').value;
+        const sampleSelect = document.getElementById('calc-sample');
+
+        sampleSelect.innerHTML = '<option value="">Select Sample</option>';
+
+        if (selectedCustomer && event) {
+          // Filter samples for this customer/event/year
+          let specs = APP_STATE.customerSpecs.filter(
+            (spec) => spec.customer === selectedCustomer && spec.event === event
+          );
+
+          // Apply year filter if selected
+          if (selectedYear) {
+            specs = specs.filter((spec) => spec.year == selectedYear);
+          }
+
+          const samples = specs.map((spec) => spec.sample_id);
+
+          samples.forEach((sample) => {
+            sampleSelect.innerHTML += `<option value="${sample}">${sample}</option>`;
+          });
+        }
+      }
+
+      function autoFillSampleDetails() {
+        const customer = document.getElementById('calc-customer').value;
+        const event = document.getElementById('calc-event').value;
+        const sampleId = document.getElementById('calc-sample').value;
+
+        if (customer && event && sampleId) {
+          const spec = APP_STATE.customerSpecs.find(
+            (s) => s.customer === customer && s.event === event && s.sample_id === sampleId
+          );
+
+          if (spec) {
+            // Auto-fill blood type
+            if (spec.abo && spec.rh) {
+              document.getElementById('calc-blood-type').value = `${spec.abo} ${spec.rh}`;
+            }
+
+            // Auto-fill sample type based on indicators
+            if (spec.is_dat_positive) {
+              document.getElementById('calc-sample-type').value = 'dat_positive';
+            } else if (sampleId.includes('ELU')) {
+              document.getElementById('calc-sample-type').value = 'eluate';
+            } else {
+              document.getElementById('calc-sample-type').value = 'standard';
+            }
+
+            // Auto-fill volume and hematocrit from sample definitions
+            if (spec.sample_type_id && APP_STATE.sampleDefinitions.length > 0) {
+              const sampleDef = APP_STATE.sampleDefinitions.find(
+                (def) => def.sample_type_id === spec.sample_type_id
+              );
+              if (sampleDef) {
+                document.getElementById('calc-volume').value = sampleDef.fill_ml || 2;
+                document.getElementById('calc-hematocrit').value = sampleDef.hct_percent || 4;
+              }
+            }
+          }
+        }
+      }
+
+      function calculateBloodNeeds() {
+        // Get customer from dropdown or manual input
+        const customerDropdown = document.getElementById('calc-customer').value;
+        const customerManual = document.getElementById('calc-customer-manual')?.value?.trim() || '';
+        const customer = customerDropdown || customerManual;
+        const quantity = parseInt(document.getElementById('calc-quantity').value) || 0;
+        const volume = parseFloat(document.getElementById('calc-volume').value) || 0;
+        const hematocrit = parseFloat(document.getElementById('calc-hematocrit').value) || 0;
+        const sampleType = document.getElementById('calc-sample-type').value;
+
+        if (!quantity || !volume || !hematocrit) {
+          showAlert('error', 'Please fill in all required fields');
+          return;
+        }
+
+        // Calculate base volume
+        const hctDecimal = hematocrit / 100;
+        const baseVolume = quantity * volume * hctDecimal;
+        const retentionVolume = RETENTION_SAMPLES * volume * hctDecimal;
+
+        // Determine overage
+        let overageFactor;
+        if (sampleType === 'dat_positive' || sampleType === 'dat_c3') {
+          overageFactor = DAT_OVERAGE_MAX;
+        } else if (sampleType === 'eluate') {
+          overageFactor = ELU_OVERAGE_MAX;
+        } else {
+          // Use tiered overage for standard samples
+          for (let tier of OVERAGE_TIERS) {
+            if (quantity < tier.maxQuantity) {
+              overageFactor = tier.overage;
+              break;
+            }
+          }
+        }
+
+        // Calculate total volume
+        const totalVolume = (baseVolume + retentionVolume) * overageFactor;
+        const unitsNeeded = Math.ceil(totalVolume / RBC_UNIT_ML);
+
+        // Display results
+        document.getElementById('base-volume').textContent = `${baseVolume.toFixed(1)}p`;
+        document.getElementById('retention-volume').textContent = `${retentionVolume.toFixed(1)}p`;
+        document.getElementById('overage-factor').textContent = `${(
+          (overageFactor - 1) *
+          100
+        ).toFixed(0)}%`;
+        document.getElementById('total-volume').textContent = `${totalVolume.toFixed(1)}p`;
+        document.getElementById('units-needed').textContent = unitsNeeded;
+
+        document.getElementById('calc-results').style.display = 'block';
+      }
+
+      function showSharingWindow() {
+        const expirationDate = document.getElementById('calc-expiration').value;
+        const shipDate = document.getElementById('calc-ship-date').value;
+
+        if (!expirationDate || !shipDate) {
+          showAlert(
+            'warning',
+            'Please enter expiration and ship dates to calculate sharing window'
+          );
+          return;
+        }
+
+        const expiration = new Date(expirationDate);
+        const ship = new Date(shipDate);
+
+        // Calculate dates
+        const oldestBleed = new Date(expiration);
+        oldestBleed.setDate(oldestBleed.getDate() - MAX_BLOOD_AGE);
+
+        const latestBleed = new Date(ship);
+        latestBleed.setDate(latestBleed.getDate() - STANDARD_BUFFER);
+
+        const windowDays = Math.ceil((latestBleed - oldestBleed) / (1000 * 60 * 60 * 24));
+
+        const windowDiv = document.getElementById('sharing-window-info');
+        windowDiv.innerHTML = `
+                                                    <div class="sharing-window-display">
+                                                        <h4>Sharing Window Analysis</h4>
+                                                        <div class="sharing-window-dates">
+                                                            <div class="sharing-date-item">
+                                                                <div class="sharing-date-label">Event Expiration</div>
+                                                                <div class="sharing-date-value">${expiration.toLocaleDateString()}</div>
+                                                            </div>
+                                                            <div class="sharing-date-item">
+                                                                <div class="sharing-date-label">Event Ship Date</div>
+                                                                <div class="sharing-date-value">${ship.toLocaleDateString()}</div>
+                                                            </div>
+                                                            <div class="sharing-date-item">
+                                                                <div class="sharing-date-label">Oldest Acceptable Bleed</div>
+                                                                <div class="sharing-date-value">${oldestBleed.toLocaleDateString()}</div>
+                                                            </div>
+                                                            <div class="sharing-date-item">
+                                                                <div class="sharing-date-label">Latest Acceptable Bleed</div>
+                                                                <div class="sharing-date-value">${latestBleed.toLocaleDateString()}</div>
+                                                            </div>
+                                                            <div class="sharing-date-item">
+                                                                <div class="sharing-date-label">Total Window</div>
+                                                                <div class="sharing-date-value">${windowDays} days</div>
+                                                            </div>
+                                                        </div>
+                                                        <p style="margin-top: 1rem; font-size: 0.875rem; color: var(--gray);">
+                                                            Blood collected within this ${windowDays}-day window can be shared with this event.
+                                                            Check standing orders and other PT events within these dates for sharing opportunities.
+                                                        </p>
+                                                    </div>
+                                                `;
+        windowDiv.style.display = 'block';
+      }
+
+      // ===============================
+      // BUP Generator Functions
+      // ===============================
+
+      function populateBUPEvents() {
+        // Populate filter dropdowns
+        populateBUPFilters();
+        // Update event list
+        updateBUPEventList();
+      }
+
+      function populateBUPFilters() {
+        // Get unique customers
+        const customers = [...new Set(APP_STATE.customerSpecs.map((s) => s.customer))].sort();
+        const customerSelect = document.getElementById('bup-filter-customer');
+        customerSelect.innerHTML = '<option value="">All Customers</option>';
+        customers.forEach((customer) => {
+          customerSelect.innerHTML += `<option value="${customer}">${customer}</option>`;
+        });
+
+        // Get unique years
+        const years = [...new Set(APP_STATE.customerSpecs.map((s) => s.year).filter((y) => y))]
+          .sort()
+          .reverse();
+        const yearSelect = document.getElementById('bup-filter-year');
+        yearSelect.innerHTML = '<option value="">All Years</option>';
+        years.forEach((year) => {
+          yearSelect.innerHTML += `<option value="${year}">${year}</option>`;
+        });
+      }
+
+      function updateBUPEventList() {
+        const customerFilter = document.getElementById('bup-filter-customer').value;
+        const yearFilter = document.getElementById('bup-filter-year').value;
+        const searchFilter = document.getElementById('bup-filter-search').value.toLowerCase();
+
+        // Get unique events with filters applied
+        const events = {};
+        APP_STATE.customerSpecs.forEach((spec) => {
+          // Apply filters
+          if (customerFilter && spec.customer !== customerFilter) return;
+          if (yearFilter && spec.year != yearFilter) return;
+
+          const eventKey = `${spec.customer}|${spec.event}|${spec.year}`;
+          const eventLabel = `${spec.customer} - ${spec.event} (${spec.year})`;
+
+          if (searchFilter && !eventLabel.toLowerCase().includes(searchFilter)) return;
+
+          events[eventKey] = eventLabel;
+        });
+
+        // Generate checkbox list
+        const listDiv = document.getElementById('bup-events-list');
+        if (Object.keys(events).length === 0) {
+          listDiv.innerHTML =
+            '<p style="color: var(--gray); text-align: center;">No events match filters</p>';
+        } else {
+          listDiv.innerHTML = Object.keys(events)
+            .sort()
+            .map((key) => {
+              // Check if this event is already in the pool
+              const isInPool = APP_STATE.bupSelectedPool.has(key);
+              const buttonText = isInPool ? 'Remove from Pool' : 'Add to Pool';
+              const buttonClass = isInPool ? 'btn-danger' : 'btn-primary';
+
+              return `
+                <div style="margin-bottom: 0.5rem; display: flex; justify-content: space-between; align-items: center;">
+                  <span>${events[key]}</span>
+                  <button class="btn ${buttonClass} btn-sm" onclick="toggleEventInPool('${key}', '${events[
+                key
+              ].replace(/'/g, "\\'")}')">
+                    ${buttonText}
+                  </button>
+                </div>
+              `;
+            })
+            .join('');
+        }
+
+        updateSelectedPoolDisplay();
+      }
+
+      function toggleEventInPool(eventKey, eventLabel) {
+        if (APP_STATE.bupSelectedPool.has(eventKey)) {
+          APP_STATE.bupSelectedPool.delete(eventKey);
+        } else {
+          APP_STATE.bupSelectedPool.add(eventKey);
+        }
+
+        updateBUPEventList(); // Refresh the buttons
+        updateSelectedPoolDisplay();
+      }
+
+      function removeFromPool(eventKey) {
+        APP_STATE.bupSelectedPool.delete(eventKey);
+        updateBUPEventList();
+        updateSelectedPoolDisplay();
+      }
+
+      function clearSelectedPool() {
+        if (confirm('Remove all events from the selected pool?')) {
+          APP_STATE.bupSelectedPool.clear();
+          updateBUPEventList();
+          updateSelectedPoolDisplay();
+        }
+      }
+
+      function updateSelectedPoolDisplay() {
+        const poolDiv = document.getElementById('selected-events-pool');
+        const listDiv = document.getElementById('selected-events-list');
+        const emptyMessage = document.getElementById('empty-pool-message');
+        const count = APP_STATE.bupSelectedPool.size;
+
+        // Update count
+        document.getElementById('bup-selected-count').textContent = count;
+
+        if (count === 0) {
+          poolDiv.style.display = 'none';
+          emptyMessage.style.display = 'block';
+          listDiv.innerHTML = '';
+        } else {
+          poolDiv.style.display = 'block';
+          emptyMessage.style.display = 'none';
+
+          // Create event tags
+          listDiv.innerHTML = Array.from(APP_STATE.bupSelectedPool)
+            .map((key) => {
+              const [customer, event, year] = key.split('|');
+              const label = `${customer} - ${event} (${year})`;
+
+              return `
+              <div style="
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.5rem 0.75rem;
+                background: var(--hemo-blue);
+                color: white;
+                border-radius: 20px;
+                font-size: 0.875rem;
+              ">
+                <span>${label}</span>
+                <button onclick="removeFromPool('${key}')" style="
+                  background: none;
+                  border: none;
+                  color: white;
+                  cursor: pointer;
+                  font-size: 1.25rem;
+                  line-height: 1;
+                  padding: 0;
+                ">×</button>
+              </div>
+            `;
+            })
+            .join('');
+        }
+      }
+
+      function selectAllVisibleEvents() {
+        const customerFilter = document.getElementById('bup-filter-customer').value;
+        const yearFilter = document.getElementById('bup-filter-year').value;
+        const searchFilter = document.getElementById('bup-filter-search').value.toLowerCase();
+
+        // Get all events matching current filters
+        APP_STATE.customerSpecs.forEach((spec) => {
+          if (customerFilter && spec.customer !== customerFilter) return;
+          if (yearFilter && spec.year != yearFilter) return;
+
+          const eventKey = `${spec.customer}|${spec.event}|${spec.year}`;
+          const eventLabel = `${spec.customer} - ${spec.event} (${spec.year})`;
+
+          if (searchFilter && !eventLabel.toLowerCase().includes(searchFilter)) return;
+
+          // Add to pool
+          APP_STATE.bupSelectedPool.add(eventKey);
+        });
+
+        updateBUPEventList();
+        updateSelectedPoolDisplay();
+      }
+
+      function updateSelectedCount() {
+        const checked = document.querySelectorAll(
+          '#bup-events-list input[type="checkbox"]:checked'
+        );
+        document.getElementById('bup-selected-count').textContent = checked.length;
+      }
+
+      function getSelectedBUPEvents() {
+        // Now we get events from the pool instead of checkboxes
+        return Array.from(APP_STATE.bupSelectedPool).map((key) => {
+          const [customer, event, year] = key.split('|');
+          return { customer, event, year };
+        });
+      }
+
+      function generateBUP() {
+        const selectedEvents = getSelectedBUPEvents();
+        if (selectedEvents.length === 0) {
+          showAlert('error', 'Please select at least one event');
+          return;
+        }
+
+        // Get all samples for selected events
+        const samples = [];
+        selectedEvents.forEach(({ customer, event, year }) => {
+          const eventSpecs = APP_STATE.customerSpecs.filter(
+            (spec) => spec.customer === customer && spec.event === event && spec.year == year
+          );
+
+          eventSpecs.forEach((spec) => {
+            // Get sample definition for volume and hematocrit
+            const sampleDef = APP_STATE.sampleDefinitions.find(
+              (def) => def.sample_type_id === spec.sample_type_id
+            );
+
+            if (sampleDef && sampleDef.requires_rbc === 'TRUE') {
+              samples.push({
+                ...spec,
+                volume: parseFloat(sampleDef.fill_ml) || 2,
+                hematocrit: parseFloat(sampleDef.hct_percent) || 4,
+                quantity: getQuantityForSample(customer, event, spec.sample_id),
+              });
+            }
+          });
+        });
+
+        // Calculate blood requirements
+        const calculations = calculateBloodRequirements(samples);
+
+        // Group by blood type
+        const bloodGroups = groupByBloodType(calculations);
+
+        // Find sharing opportunities
+        const sharingPlan = findSharingOpportunities(bloodGroups, selectedEvents);
+
+        // NEW: Analyze flexible antigen opportunities
+        const standingOrderDefs = {
+          HQC: STANDING_ORDERS.find((o) => o.product === 'Hemo-QC')?.units || [],
+          Mirrscitech:
+            STANDING_ORDERS.find((o) => o.product === 'Korea FFMU/Mirrscitech')?.units || [],
+          C3: STANDING_ORDERS.find((o) => o.product === 'C3 Control Cells')?.units || [],
+        };
+
+        const flexibleOpportunities = analyzeFlexibleAntigens(bloodGroups, standingOrderDefs);
+
+        // Display results with optimization suggestions
+        displayBUPReport(bloodGroups, sharingPlan, selectedEvents, flexibleOpportunities);
+      }
+
+      function getQuantityForSample(customer, event, sampleId) {
+        // First check for specific sample quantity
+        let quantity = APP_STATE.quantities.find(
+          (q) => q.customer === customer && q.event === event && q.sample_id === sampleId
+        );
+
+        if (quantity) return parseInt(quantity.quantity) || 100;
+
+        // Then check for event-level quantity
+        quantity = APP_STATE.quantities.find(
+          (q) =>
+            q.customer === customer && q.event === event && (!q.sample_id || q.sample_id === 'All')
+        );
+
+        if (quantity) return parseInt(quantity.quantity) || 100;
+
+        // Default quantities by customer
+        const defaults = {
+          ISLA: 600,
+          Aurevia: 800,
+          OneWorld: 1000,
+          AABB: 100,
+        };
+
+        return defaults[customer] || 100;
+      }
+
+      function calculateBloodRequirements(samples) {
+        return samples.map((sample) => {
+          const quantity = sample.quantity || 100;
+          const volume = sample.volume || 2;
+          const hctDecimal = (sample.hematocrit || 4) / 100;
+
+          // Determine overage based on sample type
+          let overageMin, overageMax;
+
+          // Check for DAT positive samples
+          if (
+            sample.is_dat_positive === 'TRUE' ||
+            sample.is_dat_positive === true ||
+            sample.sample_id?.includes('DAT')
+          ) {
+            overageMin = 1.25;
+            overageMax = 1.3;
+          } else if (sample.sample_id?.includes('ELU')) {
+            overageMin = 1.25;
+            overageMax = 1.3;
+          } else {
+            // Standard tiered overage based on quantity
+            if (quantity < 200) {
+              overageMin = 1.15;
+              overageMax = 1.15;
+            } else if (quantity < 1000) {
+              overageMin = 1.1;
+              overageMax = 1.15;
+            } else if (quantity < 2000) {
+              overageMin = 1.08;
+              overageMax = 1.1;
+            } else {
+              overageMin = 1.06;
+              overageMax = 1.08;
+            }
+          }
+
+          // Calculate volumes using correct formula
+          const baseVolume = quantity * volume * hctDecimal;
+          const retentionVolume = RETENTION_SAMPLES * volume * hctDecimal;
+          const totalMinVolume = (baseVolume + retentionVolume) * overageMin;
+          const totalMaxVolume = (baseVolume + retentionVolume) * overageMax;
+
+          return {
+            ...sample,
+            baseVolume,
+            retentionVolume,
+            overageMin,
+            overageMax,
+            totalMinVolume,
+            totalMaxVolume,
+            bloodType: `${sample.abo} ${sample.rh}`.trim(),
+            antigens: sample.antigens || '',
+          };
+        });
+      }
+
+      function groupByBloodType(calculations) {
+        const groups = {};
+
+        calculations.forEach((calc) => {
+          // Group primarily by ABO/Rh, only separate for critical antigens
+          let key = calc.bloodType;
+
+          // Only add critical antigens to the key if they're specified
+          if (calc.antigens && calc.antigens !== 'As measured') {
+            // Extract only critical antigens like Fya/Fyb, K, etc.
+            const criticalAntigens = ['K', 'Fya', 'Fyb', 's'];
+            const antigenParts = calc.antigens.split(/[,\s]+/);
+            const critical = antigenParts
+              .filter((a) => criticalAntigens.some((c) => a.includes(c)))
+              .join(' ');
+            if (critical) key += `_${critical}`;
+          }
+
+          key = key.replace(/\s+/g, '_');
+
+          if (!groups[key]) {
+            groups[key] = {
+              bloodType: calc.bloodType,
+              antigens: calc.antigens,
+              samples: [],
+              totalMin: 0,
+              totalMax: 0,
+            };
+          }
+          groups[key].samples.push(calc);
+          groups[key].totalMin += calc.totalMinVolume;
+          groups[key].totalMax += calc.totalMaxVolume;
+        });
+
+        return groups;
+      }
+
+      // Debug: Log exactly what we're working with
+      console.log('=== BUP DEBUG for OneWorld 4th ===');
+      console.log('Selected Events:', selectedEvents);
+      console.log('Blood Groups after calculation:', bloodGroups);
+      console.log(
+        'Calendar entries:',
+        APP_STATE.manufacturingCalendar.filter(
+          (e) => e.description?.includes('HQC') || e.description?.includes('OneWorld')
+        )
+      );
+
+      function findSharingOpportunities(bloodGroups, selectedEvents) {
+        const opportunities = [];
+
+        // Define standing order inventory with CORRECT specifications
+        const standingOrders = {
+          HQC: [
+            { type: 'AsubB', rh: 'Pos', volume: 180, antigens: {} }, // HQC-1
+            { type: 'O', rh: 'Pos', volume: 180, antigens: { phenotype: 'R1r', Fya: 'neg' } }, // HQC-2
+            { type: 'A1', rh: 'Neg', volume: 180, antigens: { phenotype: 'rr' } }, // HQC-3 (Fya flexible)
+          ],
+          Mirrscitech: [
+            { type: 'A1', rh: 'Pos', volume: 22, antigens: { phenotype: 'R1R1' } },
+            { type: 'B', rh: 'Pos', volume: 22, antigens: { phenotype: 'R2R2' } },
+            { type: 'O', rh: 'Neg', volume: 22, antigens: { phenotype: 'rr' } },
+          ],
+          C3: [
+            { type: 'O', rh: 'Either', volume: 180 }, // Only ONE unit available - can be Pos OR Neg
+          ],
+        };
+
+        // Calculate HQC overage available for sharing
+        const HQC_OVERAGE_MIN = 77;
+        const HQC_OVERAGE_MAX = 98;
+
+        // Get date windows for all selected events
+        const eventDateWindows = {};
+        selectedEvents.forEach((event) => {
+          const eventKey = `${event.customer}_${event.event}_${event.year}`;
+
+          // Find calendar entries
+          const calendarEntries = APP_STATE.manufacturingCalendar.filter((e) => {
+            const desc = e.description?.toLowerCase() || '';
+            const customerMatch = event.customer
+              .toLowerCase()
+              .split(' ')
+              .some((part) => desc.includes(part.toLowerCase()));
+            const eventMatch =
+              desc.includes(event.event.toLowerCase()) ||
+              desc.includes(event.event.replace(/\s+/g, '').toLowerCase());
+            return customerMatch && eventMatch;
+          });
+
+          const bleedEntry = calendarEntries.find(
+            (e) => e.description?.includes('Bleed') || e.type === 'blood-arrival'
+          );
+
+          const shipEntry = calendarEntries.find(
+            (e) => e.description?.includes('Ship') || e.type === 'shipment'
+          );
+
+          let expireEntry = calendarEntries.find(
+            (e) => e.description?.includes('Expire') || e.type === 'reference'
+          );
+
+          // Calculate expiration if not found (standard 51 days after ship)
+          let expireDate = null;
+          if (expireEntry) {
+            expireDate = new Date(expireEntry.date);
+          } else if (shipEntry) {
+            expireDate = new Date(shipEntry.date);
+            expireDate.setDate(expireDate.getDate() + 51);
+          }
+
+          if (expireDate && shipEntry) {
+            const shipDate = new Date(shipEntry.date);
+
+            // Calculate acceptable window
+            const oldestAcceptable = new Date(expireDate);
+            oldestAcceptable.setDate(oldestAcceptable.getDate() - 77);
+
+            const latestAcceptable = new Date(shipDate);
+            latestAcceptable.setDate(latestAcceptable.getDate() - 10);
+
+            eventDateWindows[eventKey] = {
+              oldest: oldestAcceptable,
+              latest: latestAcceptable,
+              bleedDate: bleedEntry ? new Date(bleedEntry.date) : null,
+            };
+
+            console.log(
+              `Event ${eventKey} window: ${oldestAcceptable.toLocaleDateString()} to ${latestAcceptable.toLocaleDateString()}`
+            );
+          }
+        });
+
+        // Process each blood group
+        Object.keys(bloodGroups).forEach((groupKey) => {
+          const group = bloodGroups[groupKey];
+          let remaining = group.totalMin;
+          const sources = [];
+
+          // Parse blood type and antigens from the group
+          let [groupABO, groupRh] = (group.bloodType || '').split(' ');
+          const groupAntigens = group.antigens || '';
+
+          // Handle blank/empty specs as "any type acceptable"
+          const isABOFlexible = !groupABO || groupABO === '' || groupABO === 'undefined';
+          const isRhFlexible = !groupRh || groupRh === '' || groupRh === 'undefined';
+          const areAntigensFlexible =
+            !groupAntigens || groupAntigens === '' || groupAntigens === 'As measured';
+
+          console.log(
+            `Processing group: ABO=${isABOFlexible ? 'ANY' : groupABO}, Rh=${
+              isRhFlexible ? 'ANY' : groupRh
+            }, antigens=${areAntigensFlexible ? 'ANY' : groupAntigens}, volume=${remaining}p`
+          );
+
+          // Find which event this group belongs to
+          let applicableWindow = null;
+          for (const sample of group.samples) {
+            const eventKey = `${sample.customer}_${sample.event}_${sample.year}`;
+            if (eventDateWindows[eventKey]) {
+              applicableWindow = eventDateWindows[eventKey];
+              break;
+            }
+          }
+
+          // Check HQC availability
+          if (document.getElementById('include-hqc')?.checked && applicableWindow) {
+            // Find HQC entries within this specific event's window
+            const hqcEntries = APP_STATE.manufacturingCalendar.filter(
+              (e) =>
+                (e.description?.includes('HB HQC') || e.description?.includes('HQC')) &&
+                (e.description?.includes('Bleed') || e.type === 'blood-arrival')
+            );
+
+            // Find the one within our window
+            const validHqcEntry = hqcEntries.find((e) => {
+              const entryDate = new Date(e.date);
+              return entryDate >= applicableWindow.oldest && entryDate <= applicableWindow.latest;
+            });
+
+            if (validHqcEntry) {
+              const hqcBleedDate = new Date(validHqcEntry.date);
+              console.log(
+                `Found valid HQC bleed date within window: ${hqcBleedDate.toLocaleDateString()}`
+              );
+
+              // Find the ship date for this HQC entry
+              const hqcShipEntry = APP_STATE.manufacturingCalendar.find(
+                (e) =>
+                  e.description?.includes('HB HQC') &&
+                  e.description?.includes('Ship') &&
+                  e.type === 'shipment'
+              );
+
+              if (hqcShipEntry) {
+                const hqcShipDate = new Date(hqcShipEntry.date);
+                const hqcArrivalDate = new Date(hqcShipDate);
+                hqcArrivalDate.setDate(hqcArrivalDate.getDate() + 1); // Add 1 day for overnight shipping
+
+                // Find PT event ship date
+                const ptShipEntry = APP_STATE.manufacturingCalendar.find((e) => {
+                  const eventMatches = group.samples.some(
+                    (sample) =>
+                      e.description?.includes(sample.customer) &&
+                      e.description?.includes(sample.event)
+                  );
+                  return eventMatches && e.description?.includes('Ship');
+                });
+
+                if (ptShipEntry) {
+                  const ptShipDate = new Date(ptShipEntry.date);
+                  const daysBeforeShip = Math.floor(
+                    (ptShipDate - hqcArrivalDate) / (1000 * 60 * 60 * 24)
+                  );
+
+                  if (daysBeforeShip < 10) {
+                    console.log(
+                      `HQC arrives too late: only ${daysBeforeShip} days before PT ships (need 10)`
+                    );
+                    return; // ✅ Changed from continue to return
+                  }
+                  console.log(`HQC arrives ${daysBeforeShip} days before PT ships - OK!`);
+                }
+              }
+
+              // Check each HQC cell type
+              standingOrders.HQC.forEach((stock, index) => {
+                if (remaining > 0) {
+                  let compatible = false;
+                  let shareVolume = 0;
+                  let sourceDescription = '';
+                  let flexibleNote = '';
+
+                  console.log(
+                    `Checking HQC-${index + 1}: ${stock.type} ${stock.rh}, antigens:`,
+                    stock.antigens
+                  );
+
+                  // HQC-2: O Pos R1r Fya-neg
+                  if (index === 1) {
+                    // Check basic blood type compatibility (blank = any acceptable)
+                    if (
+                      (isABOFlexible || groupABO === 'O') &&
+                      (isRhFlexible || groupRh === 'Positive')
+                    ) {
+                      // Check antigen compatibility - group needs Fya-neg (or blank antigens = any acceptable)
+                      if (
+                        areAntigensFlexible ||
+                        (groupAntigens.toLowerCase().includes('fya') &&
+                          (groupAntigens.toLowerCase().includes('neg') ||
+                            groupAntigens.includes('-')))
+                      ) {
+                        compatible = true;
+                        shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                        sourceDescription = 'HQC-2 (O Pos R1r Fya-neg)';
+                        console.log('✓ HQC-2 is compatible with O Pos Fya-neg!');
+                      }
+                    }
+                  }
+                  // HQC-3: A1 Neg rr - can be specified as Fya-pos if needed
+                  else if (index === 2) {
+                    // Check basic blood type compatibility (A1 is compatible with A, blank = any acceptable)
+                    if (
+                      (isABOFlexible || groupABO === 'A' || groupABO === 'A1') &&
+                      (isRhFlexible || groupRh === 'Negative')
+                    ) {
+                      // Check if group needs Fya-pos (or blank antigens = any acceptable)
+                      if (
+                        areAntigensFlexible ||
+                        (groupAntigens.toLowerCase().includes('fya') &&
+                          (groupAntigens.toLowerCase().includes('pos') ||
+                            groupAntigens.includes('+')))
+                      ) {
+                        compatible = true;
+                        shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                        sourceDescription = 'HQC-3 (A1 Neg rr)';
+                        flexibleNote = 'Specify HQC-3 as Fya-pos ($35)';
+                        console.log('✓ HQC-3 can be specified as Fya-pos for sharing!');
+                      } else if (!groupAntigens.toLowerCase().includes('fya')) {
+                        // If no Fya requirement, still compatible
+                        compatible = true;
+                        shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                        sourceDescription = 'HQC-3 (A1 Neg rr)';
+                        console.log('✓ HQC-3 is compatible with A Neg!');
+                      }
+                    }
+                  }
+                  // HQC-1: AsubB Pos
+                  else if (index === 0) {
+                    if (
+                      (isABOFlexible || groupABO === 'AB') &&
+                      (isRhFlexible || groupRh === 'Positive')
+                    ) {
+                      compatible = true;
+                      shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                      sourceDescription = 'HQC-1 (AsubB Pos)';
+                    }
+                  }
+
+                  if (compatible && shareVolume > 0) {
+                    // Calculate proper min/max based on HQC overage possibilities
+                    const minShare = Math.min(remaining, HQC_OVERAGE_MIN);
+                    const maxShare = Math.min(remaining, HQC_OVERAGE_MAX);
+
+                    sources.push({
+                      source: sourceDescription,
+                      type: `${stock.type} ${stock.rh}`,
+                      volumeMin: minShare,
+                      volumeMax: maxShare,
+                      flexibleNote: flexibleNote,
+                    });
+                    remaining -= shareVolume;
+                    console.log(`Added ${shareVolume}p from ${sourceDescription}`);
+
+                    if (flexibleNote) {
+                      group.flexibleAntigenNote = flexibleNote;
+                    }
+                  }
+                }
+              });
+            } else {
+              console.log('No HQC entry found within date window');
+            }
+          }
+
+          // Check Mirrscitech availability
+          if (document.getElementById('include-mirrscitech')?.checked && applicableWindow) {
+            // Find Mirrscitech/Korea entries within this specific event's window
+            const mirrsEntries = APP_STATE.manufacturingCalendar.filter(
+              (e) =>
+                (e.description?.includes('HB Korea') ||
+                  e.description?.includes('Korea') ||
+                  e.description?.includes('Mirrscitech')) &&
+                (e.description?.includes('Bleed') || e.type === 'blood-arrival')
+            );
+
+            // Find the one within our window
+            const validMirrsEntry = mirrsEntries.find((e) => {
+              const entryDate = new Date(e.date);
+              return entryDate >= applicableWindow.oldest && entryDate <= applicableWindow.latest;
+            });
+
+            if (validMirrsEntry) {
+              const mirrsDate = new Date(validMirrsEntry.date);
+              console.log(
+                `Found valid Mirrscitech date within window: ${mirrsDate.toLocaleDateString()}`
+              );
+
+              standingOrders.Mirrscitech.forEach((stock, index) => {
+                if (remaining > 0) {
+                  // Check compatibility (blank = any acceptable)
+                  if (
+                    (isABOFlexible || stock.type === groupABO) &&
+                    (isRhFlexible || stock.rh === groupRh)
+                  ) {
+                    const used = Math.min(stock.volume, remaining);
+                    if (used > 0) {
+                      sources.push({
+                        source: `Korea-${index + 1}`,
+                        type: `${stock.type} ${stock.rh} ${stock.antigens.phenotype || ''}`,
+                        volumeMin: used,
+                        volumeMax: used,
+                      });
+                      remaining -= used;
+                    }
+                  }
+                }
+              });
+            } else {
+              console.log('No Mirrscitech entry found within date window');
+            }
+          }
+
+          // Check C3 availability
+          if (document.getElementById('include-c3')?.checked && applicableWindow) {
+            // Find C3 entries within this specific event's window
+            const c3Entries = APP_STATE.manufacturingCalendar.filter(
+              (e) =>
+                (e.description?.includes('HB C3') ||
+                  e.description?.includes('C3') ||
+                  e.description?.includes('C3 Control')) &&
+                (e.description?.includes('Bleed') || e.type === 'blood-arrival')
+            );
+
+            // Find the one within our window
+            const validC3Entry = c3Entries.find((e) => {
+              const entryDate = new Date(e.date);
+              return entryDate >= applicableWindow.oldest && entryDate <= applicableWindow.latest;
+            });
+
+            if (validC3Entry) {
+              const c3Date = new Date(validC3Entry.date);
+              console.log(`Found valid C3 date within window: ${c3Date.toLocaleDateString()}`);
+
+              // C3 has only ONE bonus unit available - can be O Pos OR O Neg
+              if (remaining > 0) {
+                // Check if group needs O (any Rh acceptable for C3)
+                if (isABOFlexible || groupABO === 'O') {
+                  // C3 can provide either Pos or Neg, so check compatibility
+                  const c3Compatible =
+                    isRhFlexible ||
+                    groupRh === 'Positive' || // Pos can receive either
+                    groupRh === 'Negative'; // Neg needs Neg, but C3 can be specified as Neg
+
+                  if (c3Compatible) {
+                    const used = Math.min(180, remaining); // C3 bonus is always 180mL
+                    sources.push({
+                      source: 'C3 Bonus',
+                      type: `O ${isRhFlexible ? 'Pos/Neg' : groupRh}`,
+                      volumeMin: used,
+                      volumeMax: used,
+                    });
+                    remaining -= used;
+                    console.log(`Added ${used}p from C3 Bonus`);
+                  }
+                }
+              }
+            } else {
+              console.log('No C3 entry found within date window');
+            }
+          }
+
+          // Check MQC availability
+          if (document.getElementById('include-mqc')?.checked && applicableWindow) {
+            // Find MQC entries within this specific event's window
+            const mqcEntries = APP_STATE.manufacturingCalendar.filter(
+              (e) =>
+                (e.description?.includes('HB MQC') ||
+                  e.description?.includes('MQC-CAT') ||
+                  e.description?.includes('MQC')) &&
+                (e.description?.includes('Bleed') || e.type === 'blood-arrival')
+            );
+
+            // Find the one within our window
+            const validMqcEntry = mqcEntries.find((e) => {
+              const entryDate = new Date(e.date);
+              return entryDate >= applicableWindow.oldest && entryDate <= applicableWindow.latest;
+            });
+
+            if (validMqcEntry) {
+              const mqcDate = new Date(validMqcEntry.date);
+              console.log(`Found valid MQC date within window: ${mqcDate.toLocaleDateString()}`);
+
+              // MQC has 2 cell types per your standing orders configuration
+              const mqcCells = [
+                { type: 'A1B', rh: 'Pos', volume: 180 }, // MQC-1
+                { type: 'O', rh: 'Neg', volume: 180, antigens: 'K+' }, // MQC-2
+              ];
+
+              mqcCells.forEach((stock, index) => {
+                if (remaining > 0) {
+                  // Check compatibility (blank = any acceptable)
+                  let compatible = false;
+
+                  if (index === 0) {
+                    // MQC-1: A1B Pos
+                    compatible =
+                      (isABOFlexible || groupABO === 'AB') &&
+                      (isRhFlexible || groupRh === 'Positive');
+                  } else if (index === 1) {
+                    // MQC-2: O Neg K+
+                    compatible =
+                      (isABOFlexible || groupABO === 'O') &&
+                      (isRhFlexible || groupRh === 'Negative');
+                    // Could add K+ antigen check here if needed
+                  }
+
+                  if (compatible) {
+                    const used = Math.min(stock.volume, remaining);
+                    if (used > 0) {
+                      sources.push({
+                        source: `MQC-${index + 1}`,
+                        type: `${stock.type} ${stock.rh}${
+                          stock.antigens ? ' ' + stock.antigens : ''
+                        }`,
+                        volumeMin: used,
+                        volumeMax: used,
+                      });
+                      remaining -= used;
+                      console.log(`Added ${used}p from MQC-${index + 1}`);
+                    }
+                  }
+                }
+              });
+            } else {
+              console.log('No MQC entry found within date window');
+            }
+          }
+
+          // ===============================
+          // PT-TO-PT EVENT SHARING SECTION
+          // ===============================
+
+          // Check for PT event sharing opportunities
+          if (applicableWindow) {
+            console.log('Checking for PT event sharing opportunities...');
+            // Debug: Show all calendar entries in window
+            const allEventsInWindow = APP_STATE.manufacturingCalendar.filter((e) => {
+              if (!e.date) return false;
+              const eventDate = new Date(e.date);
+              return eventDate >= applicableWindow.oldest && eventDate <= applicableWindow.latest;
+            });
+
+            console.log(
+              `All events in window:`,
+              allEventsInWindow.map((e) => ({
+                desc: e.description,
+                type: e.type,
+                eventType: e.eventType,
+                date: e.date,
+              }))
+            );
+
+            // Find ALL PT events in the calendar within the sharing window
+            const ptEvents = APP_STATE.manufacturingCalendar.filter((e) => {
+              if (
+                !e.date ||
+                !e.eventType ||
+                e.eventType !== 'PT' ||
+                !e.type ||
+                e.type !== 'blood-arrival'
+              ) {
+                return false;
+              }
+
+              const eventDate = new Date(e.date);
+              return eventDate >= applicableWindow.oldest && eventDate <= applicableWindow.latest;
+            });
+
+            console.log(`Found ${ptEvents.length} PT events within sharing window`);
+
+            // For each PT event, check if it has blood we can use
+            ptEvents.forEach((ptEvent) => {
+              if (remaining <= 0) return; // No more blood needed
+
+              // Parse the PT event description to get customer and event info
+              const eventDesc = ptEvent.description || '';
+
+              // Extract customer and event from description FIRST
+              // Format could be: "ISLA 3rd - Bleed" or "OneWorld 3rd - Bleed"
+              const cleanDesc = eventDesc.replace(' - Bleed', '').replace(' - Ship', '');
+              const parts = cleanDesc.split(' ');
+              if (parts.length < 2) return;
+
+              const ptCustomer = parts[0];
+              // Event might be "3rd", "3rd 2025", "PT 2025-01", etc.
+              const ptEventParts = parts.slice(1);
+
+              // Skip if this PT event is part of the same event we're currently analyzing
+              // (We don't want ISLA 3rd to share with ISLA 3rd)
+              const analyzingCustomer = group.samples[0]?.customer;
+              const analyzingEvent = group.samples[0]?.event;
+
+              // Check if this PT event matches what we're analyzing
+              if (
+                ptCustomer === analyzingCustomer &&
+                ptEventParts.some(
+                  (part) =>
+                    analyzingEvent && analyzingEvent.toLowerCase().includes(part.toLowerCase())
+                )
+              ) {
+                console.log(
+                  `Skipping same event: ${eventDesc} (analyzing ${analyzingCustomer} ${analyzingEvent})`
+                );
+                return;
+              }
+
+              console.log(`Checking PT event: ${eventDesc} (eventType: ${ptEvent.eventType})`);
+
+              // Find specs for this PT event - be more flexible in matching
+              const ptSpecs = APP_STATE.customerSpecs.filter((spec) => {
+                // Check customer match
+                const customerMatch =
+                  spec.customer && spec.customer.toLowerCase().includes(ptCustomer.toLowerCase());
+
+                // Check event match - be flexible
+                const eventMatch =
+                  spec.event &&
+                  ptEventParts.some((part) =>
+                    spec.event.toLowerCase().includes(part.toLowerCase())
+                  );
+
+                return customerMatch && eventMatch;
+              });
+
+              if (ptSpecs.length === 0) {
+                console.log(
+                  `No specs found for ${eventDesc} - customer: ${ptCustomer}, event parts: ${ptEventParts.join(
+                    ' '
+                  )}`
+                );
+                return;
+              } else {
+                // Log the first spec found to verify
+                console.log(
+                  `Found ${ptSpecs.length} specs for ${ptCustomer}: ${ptSpecs[0].event} (${ptSpecs[0].abo} ${ptSpecs[0].rh})`
+                );
+              }
+
+              // Check each spec for compatibility
+              ptSpecs.forEach((ptSpec) => {
+                if (remaining <= 0) return;
+
+                // Parse PT event blood type
+                const ptABO = ptSpec.abo || '';
+                const ptRh = ptSpec.rh || '';
+                const ptAntigens = ptSpec.antigens || '';
+
+                // Check blood type compatibility
+                let compatible = false;
+
+                // Check ABO compatibility
+                const aboCompatible =
+                  isABOFlexible ||
+                  ptABO === '' ||
+                  ptABO === groupABO ||
+                  groupABO === 'AB' || // AB can receive any
+                  (groupABO === 'A' && ptABO === 'O') || // A can receive O
+                  (groupABO === 'B' && ptABO === 'O'); // B can receive O
+
+                // Check Rh compatibility
+                const rhCompatible =
+                  isRhFlexible || ptRh === '' || ptRh === groupRh || groupRh === 'Positive'; // Pos can receive Neg
+
+                // Check antigen compatibility (simplified - in production would be more complex)
+                const antigenCompatible =
+                  areAntigensFlexible ||
+                  ptAntigens === '' ||
+                  ptAntigens === 'As measured' ||
+                  ptAntigens === groupAntigens;
+
+                compatible = aboCompatible && rhCompatible && antigenCompatible;
+
+                if (compatible) {
+                  // Calculate how much overage this PT event has available to share
+                  // First, find out how much this PT event actually needs
+                  const ptSampleDef = APP_STATE.sampleDefinitions.find(
+                    (def) => def.sample_type_id === ptSpec.sample_type_id
+                  );
+
+                  const ptQuantity = getQuantityForSample(
+                    ptSpec.customer,
+                    ptSpec.event,
+                    ptSpec.sample_id
+                  );
+                  const ptVolume = parseFloat(ptSampleDef?.fill_ml) || 2;
+                  const ptHematocrit = parseFloat(ptSampleDef?.hct_percent) || 4;
+                  const ptHctDecimal = ptHematocrit / 100;
+
+                  // Calculate what the PT event needs
+                  const ptBaseVolume = ptQuantity * ptVolume * ptHctDecimal;
+                  const ptRetentionVolume = RETENTION_SAMPLES * ptVolume * ptHctDecimal;
+
+                  // Determine overage factor for the PT event
+                  let ptOverageFactor = 1.1; // Default
+                  if (ptSpec.is_dat_positive === 'TRUE' || ptSpec.sample_id?.includes('DAT')) {
+                    ptOverageFactor = 1.3;
+                  } else if (ptQuantity < 200) {
+                    ptOverageFactor = 1.15;
+                  } else if (ptQuantity < 1000) {
+                    ptOverageFactor = 1.1;
+                  } else if (ptQuantity < 2000) {
+                    ptOverageFactor = 1.08;
+                  } else {
+                    ptOverageFactor = 1.06;
+                  }
+
+                  const ptTotalNeeded = (ptBaseVolume + ptRetentionVolume) * ptOverageFactor;
+                  const ptUnitsOrdered = Math.ceil(ptTotalNeeded / RBC_UNIT_ML);
+                  const ptActualOrdered = ptUnitsOrdered * RBC_UNIT_ML;
+                  const ptOverage = ptActualOrdered - ptTotalNeeded;
+
+                  console.log(
+                    `PT Event ${ptSpec.customer} ${ptSpec.event} ${
+                      ptSpec.sample_id
+                    }: needs ${ptTotalNeeded.toFixed(
+                      0
+                    )}mL, orders ${ptActualOrdered}mL, overage available: ${ptOverage.toFixed(0)}mL`
+                  );
+
+                  const shareVolume = Math.min(ptOverage, remaining);
+
+                  if (shareVolume > 0) {
+                    sources.push({
+                      source: `PT: ${ptSpec.customer} ${ptSpec.event}`,
+                      type: `${ptABO} ${ptRh}`,
+                      volumeMin: shareVolume,
+                      volumeMax: shareVolume,
+                      isPTEvent: true,
+                    });
+                    remaining -= shareVolume;
+
+                    console.log(
+                      `✓ Can share ${shareVolume.toFixed(0)}mL from ${ptSpec.customer} ${
+                        ptSpec.event
+                      }`
+                    );
+
+                    // Track this as a flexible opportunity if antigens were made compatible
+                    if (ptAntigens !== groupAntigens && !areAntigensFlexible) {
+                      group.ptSharingNote = `Consider matching antigens with ${ptSpec.customer} ${ptSpec.event} for sharing`;
+                    }
+                  }
+                } else {
+                  console.log(
+                    `✗ Not compatible: ${ptSpec.customer} ${ptSpec.event} (${ptABO} ${ptRh})`
+                  );
+                }
+              });
+            });
+
+            if (sources.filter((s) => s.isPTEvent).length > 0) {
+              console.log(
+                `Total PT event sharing: ${sources
+                  .filter((s) => s.isPTEvent)
+                  .reduce((sum, s) => sum + s.volumeMin, 0)}mL`
+              );
+            }
+          }
+
+          // ===============================
+          // END PT-TO-PT SHARING SECTION
+          // ===============================
+
+          // This is where we push the opportunities
+          opportunities.push({
+            bloodGroup: group,
+            sources,
+            remaining: Math.max(0, remaining),
+            unitsNeeded: Math.ceil(Math.max(0, remaining) / RBC_UNIT_ML),
+            flexibleAntigenNote: group.flexibleAntigenNote,
+          });
+        });
+
+        return opportunities;
+      }
+
+      function isCompatibleBlood(stock, group) {
+        // Parse blood types
+        const stockABO = stock.type.split(' ')[0];
+        const stockRh = stock.type.includes('Neg') ? 'Neg' : 'Pos';
+        const groupABO = group.bloodType.split(' ')[0];
+        const groupRh = group.bloodType.includes('Neg') ? 'Neg' : 'Pos';
+
+        // Check ABO compatibility
+        if (groupABO === stockABO) {
+          // Exact match
+        } else if (groupABO === 'AB') {
+          // AB can receive any type
+        } else if (groupABO === 'A' && stockABO === 'O') {
+          // A can receive O
+        } else if (groupABO === 'B' && stockABO === 'O') {
+          // B can receive O
+        } else {
+          return false;
+        }
+
+        // Check Rh compatibility
+        if (groupRh === 'Neg' && stockRh === 'Pos') {
+          return false;
+        }
+
+        // Check specific antigens if required
+        if (group.antigens && group.antigens !== 'As measured') {
+          if (stock.antigens) {
+            // Simplified antigen matching - in production would be more complex
+            return true;
+          }
+        }
+
+        return true;
+      }
+
+      function isCompatible(sourceType, targetType, targetAntigens) {
+        // Simplified compatibility check
+        const [sourceABO, sourceRh] = sourceType.split(/\s+/);
+        const [targetABO, targetRh] = targetType.split(/\s+/);
+
+        // Basic ABO/Rh compatibility
+        if (targetABO === 'O' && sourceABO !== 'O') return false;
+        if (targetABO === 'A' && !['A', 'O'].includes(sourceABO)) return false;
+        if (targetABO === 'B' && !['B', 'O'].includes(sourceABO)) return false;
+        if (targetABO === 'AB') return true; // Universal recipient
+
+        if (targetRh === 'Neg' && sourceRh === 'Pos') return false;
+
+        return true;
+      }
+
+      function isBaseBloodCompatible(stockType, neededType) {
+        // Extract ABO and Rh
+        const stockABO = stockType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || '';
+        const stockRh = stockType.includes('Neg') ? 'Neg' : 'Pos';
+        const neededABO = neededType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || '';
+        const neededRh = neededType.includes('Neg') ? 'Neg' : 'Pos';
+
+        // Check ABO compatibility
+        let aboCompatible = false;
+        if (stockABO === neededABO) {
+          aboCompatible = true;
+        } else if (neededABO === 'A' && (stockABO === 'A1' || stockABO === 'AsubB')) {
+          aboCompatible = true; // A subtypes are compatible
+        }
+
+        // Check Rh compatibility
+        const rhCompatible = stockRh === neededRh || (neededRh === 'Pos' && stockRh === 'Neg');
+
+        return aboCompatible && rhCompatible;
+      }
+
+      function identifyFlexibleAntigens(stock, group) {
+        const flexible = [];
+
+        // If group needs specific antigens that aren't in stock description
+        if (group.antigens && group.antigens !== 'As measured') {
+          const neededAntigens = group.antigens.split(/[,\s]+/);
+          const stockAntigens = stock.antigens ? stock.antigens.split(/[,\s]+/) : [];
+
+          neededAntigens.forEach((antigen) => {
+            if (
+              !stockAntigens.includes(antigen) &&
+              TRACKED_ANTIGENS.includes(antigen.replace(/pos|neg/i, '').trim())
+            ) {
+              flexible.push(antigen);
+            }
+          });
+        }
+
+        return flexible;
+      }
+
+      function calculateOptimizationSavings(volumeNeeded, antigenCount) {
+        const unitsAvoided = Math.ceil(volumeNeeded / RBC_UNIT_ML);
+        const bloodCost = unitsAvoided * BLOOD_UNIT_COSTS.standard;
+        const antigenCost = antigenCount * ANTIGEN_COSTS.standard;
+        return {
+          bloodCostAvoided: bloodCost,
+          antigenSpecCost: antigenCost,
+          netSavings: bloodCost - antigenCost,
+          unitsAvoided: unitsAvoided,
+        };
+      }
+
+      function generateOptimizationSuggestions(opportunities) {
+        if (opportunities.length === 0) return '';
+
+        let html = '<div class="alert alert-info" style="margin: 1rem 0;">';
+        html += '<strong>💡 Flexible Antigen Optimization Opportunities Detected:</strong><br><br>';
+
+        opportunities.forEach((opp, index) => {
+          const savings = calculateOptimizationSavings(
+            opp.volumeNeeded,
+            opp.flexibleAntigens.length
+          );
+          html += `
+                                          <div style="margin-bottom: 1rem; padding: 0.5rem; background: var(--white); border-radius: 4px;">
+                                            <strong>${index + 1}. ${opp.product} (${
+            opp.stockType
+          })</strong><br>
+                                            <span style="color: var(--gray);">Can share with: ${opp.samples.join(
+                                              ', '
+                                            )}</span><br>
+                                            <span style="color: var(--success);">Specify antigens: ${opp.flexibleAntigens.join(
+                                              ', '
+                                            )}</span><br>
+                                            <span style="color: var(--hemo-blue);">
+                                              Cost: $${savings.antigenSpecCost} | Save: $${
+            savings.bloodCostAvoided
+          } |
+                                              <strong>Net: $${savings.netSavings}</strong>
+                                            </span>
+                                          </div>
+                                        `;
+        });
+
+        html +=
+          '<small>Add these antigen specifications when ordering standing inventory to enable sharing.</small>';
+        html += '</div>';
+
+        return html;
+      }
+
+      // ===============================
+      // Flexible Antigen Optimization
+      // ===============================
+
+      function analyzeFlexibleAntigens(bloodGroups, standingOrders) {
+        const opportunities = [];
+
+        // For each blood group needed
+        Object.keys(bloodGroups).forEach((groupKey) => {
+          const group = bloodGroups[groupKey];
+
+          // Check each standing order for potential matches
+          ['HQC', 'Mirrscitech', 'C3'].forEach((productName) => {
+            const product = standingOrders[productName];
+            if (!product) return;
+
+            product.forEach((stock) => {
+              // Check if base ABO/Rh matches
+              if (isBaseBloodCompatible(stock.type, group.bloodType)) {
+                // Identify which antigens are flexible (not specified in original spec)
+                const flexibleAntigens = identifyFlexibleAntigens(stock, group);
+
+                if (flexibleAntigens.length > 0) {
+                  const volumeAvailable = stock.volume || 180;
+                  const volumeNeeded = group.totalMin;
+
+                  if (volumeAvailable >= volumeNeeded * 0.5) {
+                    // At least 50% coverage
+                    opportunities.push({
+                      product: productName,
+                      stockType: stock.type,
+                      bloodGroup: group.bloodType,
+                      flexibleAntigens: flexibleAntigens,
+                      volumeAvailable: volumeAvailable,
+                      volumeNeeded: volumeNeeded,
+                      samples: group.samples.map((s) => `${s.customer} ${s.sample_id}`),
+                      potentialSavings: calculateOptimizationSavings(
+                        volumeNeeded,
+                        flexibleAntigens.length
+                      ),
+                    });
+                  }
+                }
+              }
+            });
+          });
+        });
+
+        return opportunities;
+      }
+
+      function isBaseBloodCompatible(stockType, neededType) {
+        // Extract ABO and Rh
+        const stockABO = stockType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || '';
+        const stockRh = stockType.includes('Neg') ? 'Neg' : 'Pos';
+        const neededABO = neededType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || '';
+        const neededRh = neededType.includes('Neg') ? 'Neg' : 'Pos';
+
+        // Check ABO compatibility
+        let aboCompatible = false;
+        if (stockABO === neededABO) {
+          aboCompatible = true;
+        } else if (neededABO === 'A' && (stockABO === 'A1' || stockABO === 'AsubB')) {
+          aboCompatible = true; // A subtypes are compatible
+        }
+
+        // Check Rh compatibility
+        const rhCompatible = stockRh === neededRh || (neededRh === 'Pos' && stockRh === 'Neg');
+
+        return aboCompatible && rhCompatible;
+      }
+
+      function identifyFlexibleAntigens(stock, group) {
+        const flexible = [];
+
+        // If group needs specific antigens that aren't in stock description
+        if (group.antigens && group.antigens !== 'As measured') {
+          const neededAntigens = group.antigens.split(/[,\s]+/);
+          const stockAntigens = stock.antigens ? stock.antigens.split(/[,\s]+/) : [];
+
+          neededAntigens.forEach((antigen) => {
+            if (
+              !stockAntigens.includes(antigen) &&
+              TRACKED_ANTIGENS.includes(antigen.replace(/pos|neg/i, '').trim())
+            ) {
+              flexible.push(antigen);
+            }
+          });
+        }
+
+        return flexible;
+      }
+
+      function calculateOptimizationSavings(volumeNeeded, antigenCount) {
+        const unitsAvoided = Math.ceil(volumeNeeded / RBC_UNIT_ML);
+        const bloodCost = unitsAvoided * BLOOD_UNIT_COSTS.standard;
+        const antigenCost = antigenCount * ANTIGEN_COSTS.standard;
+        return {
+          bloodCostAvoided: bloodCost,
+          antigenSpecCost: antigenCost,
+          netSavings: bloodCost - antigenCost,
+          unitsAvoided: unitsAvoided,
+        };
+      }
+
+      function generateOptimizationSuggestions(opportunities) {
+        if (opportunities.length === 0) return '';
+
+        let html = '<div class="alert alert-info" style="margin: 1rem 0;">';
+        html += '<strong>💡 Flexible Antigen Optimization Opportunities Detected:</strong><br><br>';
+
+        opportunities.forEach((opp, index) => {
+          const savings = calculateOptimizationSavings(
+            opp.volumeNeeded,
+            opp.flexibleAntigens.length
+          );
+          html += `
+                                          <div style="margin-bottom: 1rem; padding: 0.5rem; background: var(--white); border-radius: 4px;">
+                                            <strong>${index + 1}. ${opp.product} (${
+            opp.stockType
+          })</strong><br>
+                                            <span style="color: var(--gray);">Can share with: ${opp.samples.join(
+                                              ', '
+                                            )}</span><br>
+                                            <span style="color: var(--success);">Specify antigens: ${opp.flexibleAntigens.join(
+                                              ', '
+                                            )}</span><br>
+                                            <span style="color: var(--hemo-blue);">
+                                              Cost: $${savings.antigenSpecCost} | Save: $${
+            savings.bloodCostAvoided
+          } |
+                                              <strong>Net: $${savings.netSavings}</strong>
+                                            </span>
+                                          </div>
+                                        `;
+        });
+
+        html +=
+          '<small>Add these antigen specifications when ordering standing inventory to enable sharing.</small>';
+        html += '</div>';
+
+        return html;
+      }
+
+      function displayBUPReport(bloodGroups, sharingPlan, selectedEvents, flexibleOpportunities) {
+        const reportDiv = document.getElementById('bup-report');
+        const summaryDiv = document.getElementById('bup-summary');
+        const contentDiv = document.getElementById('bup-content');
+
+        // Calculate summary statistics
+        let totalVolumeNeeded = 0;
+        let totalVolumeFromInventory = 0;
+        let totalNewVolume = 0;
+        let totalUnitsNeeded = 0;
+
+        sharingPlan.forEach((plan) => {
+          totalVolumeNeeded += plan.bloodGroup.totalMin || 0;
+          plan.sources.forEach((source) => {
+            // Use volumeMin since we changed to min/max structure
+            totalVolumeFromInventory += source.volumeMin || source.volume || 0;
+          });
+          totalNewVolume += plan.remaining || 0;
+          totalUnitsNeeded += plan.unitsNeeded || 0;
+        });
+
+        // Display optimization opportunities if any
+        if (flexibleOpportunities && flexibleOpportunities.length > 0) {
+          summaryDiv.innerHTML = generateOptimizationSuggestions(flexibleOpportunities);
+          summaryDiv.innerHTML += '<hr style="margin: 1rem 0;">';
+        } else {
+          summaryDiv.innerHTML = '';
+        }
+
+        // Calculate max volumes for ranges
+        let totalMaxVolumeNeeded = 0;
+        let totalMaxVolumeFromInventory = 0;
+        let totalMaxNewVolume = 0;
+
+        sharingPlan.forEach((plan) => {
+          totalMaxVolumeNeeded += plan.bloodGroup.totalMax || plan.bloodGroup.totalMin || 0;
+          plan.sources.forEach((source) => {
+            totalMaxVolumeFromInventory +=
+              source.volumeMax || source.volumeMin || source.volume || 0;
+          });
+          // Calculate max new volume based on what's left
+          const maxRemaining =
+            (plan.bloodGroup.totalMax || plan.bloodGroup.totalMin) -
+            plan.sources.reduce((sum, s) => sum + (s.volumeMin || 0), 0);
+          totalMaxNewVolume += Math.max(0, maxRemaining);
+        });
+
+        // Display summary with ranges
+        summaryDiv.innerHTML += `
+        <strong>BUP Summary:</strong><br>
+        Events: ${selectedEvents.map((e) => `${e.customer} ${e.event}`).join(', ')}<br>
+        Total pRBC needed: ${totalVolumeNeeded.toFixed(0)}-${totalMaxVolumeNeeded.toFixed(0)}p<br>
+        Pull from inventory: ${totalVolumeFromInventory.toFixed(
+          0
+        )}-${totalMaxVolumeFromInventory.toFixed(0)}p<br>
+        New blood to order: ${totalNewVolume.toFixed(0)}-${totalMaxNewVolume.toFixed(0)}p<br>
+        <strong>Units to order: ${totalUnitsNeeded} units</strong>
+      `;
+
+        // Display detailed report organized like manual BUP
+        let html = '<div class="bup-section">';
+        html += '<div class="bup-header">Order Requirements</div>';
+        html += '<div class="bup-content">';
+
+        // Group by order status (new orders vs pull from inventory)
+        let orderNumber = 1;
+        let pullNumber = 1;
+
+        // First show items that need new orders
+        html += '<h4>Order New:</h4>';
+        sharingPlan.forEach((plan) => {
+          if (plan.unitsNeeded > 0) {
+            const group = plan.bloodGroup;
+            // Calculate proper min/max for new orders based on remaining overage
+            const orderMin = plan.remaining;
+            const orderMax =
+              plan.remaining > 0
+                ? plan.bloodGroup.totalMax - (plan.bloodGroup.totalMin - plan.remaining)
+                : 0;
+
+            html += `
+        <div style="margin-bottom: 1rem; padding: 0.75rem; background: var(--light); border-radius: 6px;">
+          <strong>${orderNumber}. ${group.bloodType}${
+              group.antigens && group.antigens !== 'As measured' ? ' ' + group.antigens : ''
+            }</strong> = ${orderMin > 0 ? orderMin.toFixed(0) : '0'}-${
+              orderMax > 0 ? orderMax.toFixed(0) : '0'
+            }p (${plan.unitsNeeded} unit${plan.unitsNeeded > 1 ? 's' : ''})<br>
+                      <div style="margin-left: 1.5rem; margin-top: 0.5rem;">
+                  `;
+
+            // List samples contributing to this group with their ranges
+            group.samples.forEach((sample) => {
+              html += `${sample.customer} ${sample.sample_id}: ${sample.totalMinVolume.toFixed(
+                0
+              )}-${sample.totalMaxVolume.toFixed(0)}p<br>`;
+            });
+
+            html += '</div></div>';
+            orderNumber++;
+          }
+        });
+
+        if (orderNumber === 1) {
+          html += '<p style="color: var(--gray);">No new orders needed</p>';
+        }
+
+        // Then show items pulled from inventory
+        html += '<h4 style="margin-top: 1.5rem;">Pull from Inventory:</h4>';
+        sharingPlan.forEach((plan) => {
+          if (plan.sources.length > 0) {
+            const group = plan.bloodGroup;
+            html += `
+                                      <div style="margin-bottom: 1rem; padding: 0.75rem; background: var(--light); border-radius: 6px;">
+                                        <strong>${pullNumber}. ${group.bloodType}${
+              group.antigens && group.antigens !== 'As measured' ? ' ' + group.antigens : ''
+            }</strong> = ${
+              group.totalMin > 0
+                ? group.totalMin.toFixed(0) + '-' + group.totalMax.toFixed(0) + 'p'
+                : '0p'
+            }<br>
+                                        <div style="margin-left: 1.5rem; margin-top: 0.5rem;">
+                                    `;
+
+            // Show source breakdown with ranges
+            plan.sources.forEach((source) => {
+              const volumeDisplay =
+                source.volumeMin && source.volumeMax
+                  ? `${source.volumeMin.toFixed(0)}-${source.volumeMax.toFixed(0)}p`
+                  : `${source.volume.toFixed(1)}p`;
+              html += `<span style="color: var(--success);">→ ${source.source}: ${volumeDisplay}</span><br>`;
+              if (source.flexibleNote) {
+                html += `<span style="color: var(--info); margin-left: 2rem; font-size: 0.875rem;">💡 ${source.flexibleNote}</span><br>`;
+              }
+            });
+
+            // List samples
+            html +=
+              '<div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid var(--border);">';
+            group.samples.forEach((sample) => {
+              html += `${sample.customer} ${sample.sample_id}: ${sample.totalMinVolume.toFixed(
+                0
+              )}-${sample.totalMaxVolume.toFixed(0)}p<br>`;
+            });
+            html += '</div>';
+
+            html += '</div></div>';
+            pullNumber++;
+          }
+        });
+
+        if (pullNumber === 1) {
+          html += '<p style="color: var(--gray);">No inventory available for sharing</p>';
+        }
+
+        html += '</div></div>';
+        contentDiv.innerHTML = html;
+
+        reportDiv.style.display = 'block';
+        APP_STATE.bupAnalysis.optimizedPlan = sharingPlan;
+      }
+
+      function toggleBUPView() {
+        showAlert('info', 'Alternative view coming in next version');
+      }
+
+      function exportBUP() {
+        const plan = APP_STATE.bupAnalysis.optimizedPlan;
+        if (!plan) {
+          showAlert('error', 'No BUP to export');
+          return;
+        }
+
+        // Create text report
+        let text = 'BLOOD UTILIZATION PLAN\n';
+        text += '='.repeat(50) + '\n\n';
+        text += `Generated: ${new Date().toLocaleString()}\n\n`;
+
+        plan.forEach((item, index) => {
+          text += `${index + 1}. ${item.bloodGroup.bloodType} ${item.bloodGroup.antigens}\n`;
+          text += `   Volume: ${item.bloodGroup.totalMin.toFixed(
+            1
+          )}-${item.bloodGroup.totalMax.toFixed(1)}p\n`;
+          if (item.sources.length > 0) {
+            text += '   Sources:\n';
+            item.sources.forEach((s) => {
+              text += `     - ${s.source}: ${s.volume.toFixed(1)}p\n`;
+            });
+          }
+          if (item.remaining > 0) {
+            text += `   Order: ${item.remaining.toFixed(1)}p (${item.unitsNeeded} units)\n`;
+          }
+          text += '\n';
+        });
+
+        // Download file
+        const blob = new Blob([text], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `BUP_${new Date().toISOString().split('T')[0]}.txt`;
+        a.click();
+        URL.revokeObjectURL(url);
+
+        showAlert('success', 'BUP exported successfully');
+      }
+
+      function exportBUP() {
+        showAlert('info', 'BUP Export - Full implementation coming soon');
+      }
+
+      // ===============================
+      // Calendar Functions
+      // ===============================
+
+      // Initialize calendar dropdowns
+      function initializeCalendarDropdowns() {
+        const modalSelect = document.getElementById('modal-calendar-type');
+        const manualSelect = document.getElementById('calendar-type');
+
+        // Build the same HTML for both dropdowns
+        let optionsHTML = '';
+        for (const [category, items] of Object.entries(CALENDAR_CATEGORIES)) {
+          optionsHTML += `<optgroup label="${category}">`;
+          items.forEach((item) => {
+            optionsHTML += `<option value="${item.value}">${item.label}</option>`;
+          });
+          optionsHTML += '</optgroup>';
+        }
+
+        if (modalSelect) modalSelect.innerHTML = optionsHTML;
+        if (manualSelect) manualSelect.innerHTML = optionsHTML;
+      }
+
+      // Handle type change
+      function handleTypeChange(formType) {
+        const type = document.getElementById(
+          formType === 'modal' ? 'modal-calendar-type' : 'calendar-type'
+        ).value;
+        const recurrenceDiv = document.getElementById(`${formType}-recurrence-settings`);
+
+        // Check if type belongs to recurring category
+        const isRecurring = CALENDAR_CATEGORIES[RECURRENCE_ENABLED_CATEGORY]?.some(
+          (item) => item.value === type
+        );
+
+        if (recurrenceDiv) {
+          recurrenceDiv.style.display = isRecurring ? 'block' : 'none';
+        }
+      }
+
+      // Handle unit change
+      function handleUnitChange(formType) {
+        const unit = document.getElementById(`${formType}-recurrence-unit`).value;
+        const customGroup = document.getElementById(`${formType}-custom-pattern-group`);
+
+        if (customGroup) {
+          customGroup.style.display = unit === 'custom' ? 'block' : 'none';
+        }
+      }
+
+      // Handle end type change
+      function handleEndTypeChange(formType) {
+        const endType = document.getElementById(`${formType}-recurrence-end-type`).value;
+        const countGroup = document.getElementById(`${formType}-end-count-group`);
+        const dateGroup = document.getElementById(`${formType}-end-date-group`);
+
+        if (countGroup) countGroup.style.display = endType === 'count' ? 'block' : 'none';
+        if (dateGroup) dateGroup.style.display = endType === 'date' ? 'block' : 'none';
+      }
+
+      // Generate recurring instances
+      function generateRecurringInstances(baseEntry, recurrenceSettings) {
+        const instances = [];
+        const startDate = new Date(baseEntry.date);
+        const parentId = 'recurring_' + Date.now();
+
+        // Calculate end condition
+        let maxInstances = 100; // Safety limit
+        let endDate = null;
+
+        if (recurrenceSettings.endType === 'count') {
+          maxInstances = parseInt(recurrenceSettings.endCount);
+        } else if (recurrenceSettings.endType === 'date') {
+          endDate = new Date(recurrenceSettings.endDate);
+        } else {
+          // Never ends - generate 2 years worth
+          endDate = new Date(startDate);
+          endDate.setFullYear(endDate.getFullYear() + 2);
+        }
+
+        // Generate instances
+        for (let i = 0; i < maxInstances; i++) {
+          const instanceDate = new Date(startDate);
+
+          if (recurrenceSettings.unit === 'days') {
+            instanceDate.setDate(instanceDate.getDate() + i * recurrenceSettings.interval);
+          } else if (recurrenceSettings.unit === 'weeks') {
+            instanceDate.setDate(instanceDate.getDate() + i * recurrenceSettings.interval * 7);
+          } else if (recurrenceSettings.unit === 'months') {
+            instanceDate.setMonth(instanceDate.getMonth() + i * recurrenceSettings.interval);
+          } else if (recurrenceSettings.unit === 'custom') {
+            // For custom patterns, just create single instance for now
+            // Future enhancement: parse custom pattern
+            if (i > 0) break;
+          }
+
+          // Check end date
+          if (endDate && instanceDate > endDate) break;
+
+          // Create instance
+          instances.push({
+            id: `${parentId}_${i}`,
+            date: instanceDate.toISOString().split('T')[0],
+            type: baseEntry.type,
+            description: baseEntry.description + (i === 0 ? ' 🔄' : ''),
+            recurrence: {
+              ...recurrenceSettings,
+              parentId: parentId,
+              instanceNumber: i,
+            },
+          });
+        }
+
+        return instances;
+      }
+
+      // Show recurrence modification dialog
+      function showRecurrenceModificationDialog(action, callback) {
+        const dialog = document.createElement('div');
+        dialog.className = 'modal active';
+        dialog.innerHTML = `
+                                            <div class="modal-content" style="max-width: 500px;">
+                                                <div class="modal-header">
+                                                    <h3 class="modal-title">${
+                                                      action === 'edit' ? 'Edit' : 'Delete'
+                                                    } Recurring Event</h3>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p>This is a recurring event. Apply changes to:</p>
+                                                    <div style="margin: 1rem 0;">
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="single" checked>
+                                                            Only this instance
+                                                        </label>
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="future">
+                                                            This and all future instances
+                                                        </label>
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="all">
+                                                            All instances (past and future)
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button class="btn btn-outline" onclick="this.closest('.modal').remove()">Cancel</button>
+                                                    <button class="btn ${
+                                                      action === 'delete'
+                                                        ? 'btn-danger'
+                                                        : 'btn-primary'
+                                                    }"
+                                                            onclick="handleRecurrenceScope('${action}', this)">
+                                                        ${action === 'edit' ? 'Apply' : 'Delete'}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        `;
+        document.body.appendChild(dialog);
+      }
+
+      // Handle recurrence scope selection
+      function handleRecurrenceScope(action, button) {
+        const modal = button.closest('.modal');
+        const scope = modal.querySelector('input[name="recurrence-scope"]:checked').value;
+        modal.remove();
+
+        // Store scope for use in save/delete operations
+        window.currentRecurrenceScope = scope;
+
+        if (action === 'delete') {
+          performRecurringDelete(scope);
+        }
+      }
+
+      // Perform recurring delete
+      function performRecurringDelete(scope) {
+        const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === editingCalendarEntryId);
+        if (!entry || !entry.recurrence) return;
+
+        const parentId = entry.recurrence.parentId;
+        const instanceNumber = entry.recurrence.instanceNumber;
+
+        if (scope === 'single') {
+          // Delete only this instance
+          APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+            (e) => e.id !== editingCalendarEntryId
+          );
+        } else if (scope === 'future') {
+          // Delete this and future instances
+          APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+            (e) =>
+              !(
+                e.recurrence?.parentId === parentId && e.recurrence.instanceNumber >= instanceNumber
+              )
+          );
+        } else if (scope === 'all') {
+          // Delete all instances
+          APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+            (e) => e.recurrence?.parentId !== parentId
+          );
+        }
+
+        logActivity('Deleted recurring calendar entry', entry.description);
+        showAlert('success', 'Calendar entry deleted');
+        renderCalendar();
+        autoSave();
+        closeCalendarEntryModal();
+      }
+
+      function initializeCalendar() {
+        // Initialize dropdowns
+        initializeCalendarDropdowns();
+
+        renderCalendar();
+      }
+
+      function renderCalendar() {
+        const year = APP_STATE.currentYear;
+        const month = APP_STATE.currentMonth;
+
+        // Update header
+        const monthNames = [
+          'January',
+          'February',
+          'March',
+          'April',
+          'May',
+          'June',
+          'July',
+          'August',
+          'September',
+          'October',
+          'November',
+          'December',
+        ];
+        document.getElementById('calendar-month-year').textContent = `${monthNames[month]} ${year}`;
+
+        // Calculate calendar days
+        const firstDay = new Date(year, month, 1).getDay();
+        const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+        let html = '';
+
+        // Weekday headers
+        const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        weekdays.forEach((day) => {
+          html += `<div class="calendar-weekday">${day}</div>`;
+        });
+
+        // Empty cells before first day
+        for (let i = 0; i < firstDay; i++) {
+          html += '<div class="calendar-day"></div>';
+        }
+
+        // Days of month
+        for (let day = 1; day <= daysInMonth; day++) {
+          const date = new Date(year, month, day);
+          const dateStr = date.toISOString().split('T')[0];
+
+          // Get events for this day
+          const events = APP_STATE.manufacturingCalendar.filter((event) => event.date === dateStr);
+
+          html += `<div class="calendar-day" data-date="${dateStr}" onclick="openAddEventModal('${dateStr}')">
+                                                <div class="calendar-day-number">${day}</div>`;
+
+          events.forEach((event) => {
+            if (event.hidden) return; // Skip hidden reference entries
+            const eventClass = event.eventType === 'Product' ? 'standing-order' : event.type;
+            const sharingIndicator = event.eventType === 'PT' ? ' 🔄' : '';
+            html += `<div class="calendar-event ${eventClass}" onclick="openCalendarEntry(event, '${
+              event.id
+            }')" style="cursor: pointer;" title="${event.eventType || ''}">
+                                                    ${event.description}${sharingIndicator}
+                                                </div>`;
+          });
+
+          html += '</div>';
+        }
+
+        document.getElementById('calendar-grid').innerHTML = html;
+      }
+
+      function resetCalendarAddEventModal() {
+        editingCalendarEntryId = null;
+        const submitButton = document.getElementById('calendar-add-event-submit');
+        if (submitButton) {
+          submitButton.textContent = 'Add Event';
+          submitButton.onclick = addCalendarEvent;
+        }
+
+        const title = document.getElementById('calendar-add-event-modal-title');
+        if (title) {
+          title.textContent = 'Add Event';
+        }
+
+        const deleteButton = document.getElementById('modal-delete-event-btn');
+        if (deleteButton) {
+          deleteButton.style.display = 'none';
+        }
+
+        const arrivalGroup = document.getElementById('modal-arrival-date-group');
+        if (arrivalGroup) {
+          arrivalGroup.style.display = 'none';
+        }
+
+        const arrivalInput = document.getElementById('modal-arrival-date');
+        if (arrivalInput) {
+          arrivalInput.value = '';
+        }
+
+        const mainDateLabel = document.getElementById('modal-main-date-label');
+        if (mainDateLabel) {
+          mainDateLabel.textContent = 'Date';
+        }
+      }
+
+      function toggleShipmentFields() {
+        const typeSelect = document.getElementById('modal-calendar-type');
+        const arrivalGroup = document.getElementById('modal-arrival-date-group');
+        const arrivalInput = document.getElementById('modal-arrival-date');
+        const mainDateLabel = document.getElementById('modal-main-date-label');
+
+        if (!arrivalGroup || !mainDateLabel) {
+          return;
+        }
+
+        const selectedType = typeSelect ? typeSelect.value : '';
+        const isShipment = selectedType === 'blood-shipment';
+
+        arrivalGroup.style.display = isShipment ? 'block' : 'none';
+        mainDateLabel.textContent = isShipment ? 'Ship Date' : 'Date';
+
+        if (!isShipment && arrivalInput) {
+          arrivalInput.value = '';
+        }
+      }
+
+      function openAddEventModal(dateStr) {
+        resetCalendarAddEventModal();
+
+        const modal = document.getElementById('calendar-add-event-modal');
+        if (!modal) return;
+
+        const deleteButton = document.getElementById('modal-delete-event-btn');
+        if (deleteButton) {
+          deleteButton.style.display = 'none';
+        }
+
+        const dateInput = document.getElementById('modal-calendar-date');
+        if (dateInput) {
+          dateInput.value = dateStr;
+        }
+
+        const typeSelect = document.getElementById('modal-calendar-type');
+        if (typeSelect) {
+          typeSelect.selectedIndex = -1;
+          typeSelect.value = '';
+        }
+
+        const arrivalField = document.getElementById('modal-arrival-date');
+        if (arrivalField) {
+          arrivalField.value = '';
+        }
+
+        const notesField = document.getElementById('modal-calendar-notes');
+        if (notesField) {
+          notesField.value = '';
+        }
+
+        toggleShipmentFields();
+
+        modal.classList.add('active');
+      }
+
+      function closeCalendarAddEventModal() {
+        const modal = document.getElementById('calendar-add-event-modal');
+        if (modal) {
+          modal.classList.remove('active');
+        }
+
+        resetCalendarAddEventModal();
+      }
+
+      function getCalendarTypeLabel(type) {
+        for (const items of Object.values(CALENDAR_CATEGORIES)) {
+          const match = items.find((item) => item.value === type);
+          if (match) {
+            return match.label;
+          }
+        }
+        return type;
+      }
+
+      function buildCalendarDescription(type, notes) {
+        const trimmedNotes = notes ? notes.trim() : '';
+        if (trimmedNotes) {
+          return trimmedNotes;
+        }
+        return getCalendarTypeLabel(type);
+      }
+
+      function addCalendarEvent() {
+        const dateInput = document.getElementById('modal-calendar-date');
+        const typeSelect = document.getElementById('modal-calendar-type');
+        const notesField = document.getElementById('modal-calendar-notes');
+        const arrivalInput = document.getElementById('modal-arrival-date');
+
+        const date = dateInput ? dateInput.value : '';
+        const type = typeSelect ? typeSelect.value : '';
+        const notes = notesField ? notesField.value.trim() : '';
+
+        if (!date || !type) {
+          showAlert('error', 'Please fill in all required fields');
+          return;
+        }
+
+        if (type === 'blood-shipment') {
+          const arrivalDate = arrivalInput ? arrivalInput.value : '';
+
+          if (!arrivalDate) {
+            showAlert('error', 'Please provide both ship and arrival dates');
+            return;
+          }
+
+          if (arrivalDate < date) {
+            showAlert('error', 'Arrival date cannot be before the ship date');
+            return;
+          }
+
+          const baseDescription = buildCalendarDescription(type, notes);
+          const timestamp = Date.now();
+          const shipmentId = 'ship_' + timestamp;
+
+          const shipEvent = {
+            id: 'cal_' + timestamp,
+            date: date,
+            type: 'shipment',
+            description: `${baseDescription} - Departs`,
+            shipmentId,
+          };
+
+          const arrivalEvent = {
+            id: 'cal_' + (timestamp + 1),
+            date: arrivalDate,
+            type: 'blood-arrival',
+            description: `${baseDescription} - Arrives`,
+            shipmentId,
+          };
+
+          if (notes) {
+            shipEvent.notes = notes;
+            arrivalEvent.notes = notes;
+          }
+
+          APP_STATE.manufacturingCalendar.push(shipEvent, arrivalEvent);
+
+          logActivity(
+            'Added blood shipment',
+            `${baseDescription} (${date} → ${arrivalDate})`
+          );
+          showAlert('success', 'Blood shipment scheduled');
+        } else {
+          const description = buildCalendarDescription(type, notes);
+
+          const newEvent = {
+            id: 'cal_' + Date.now(),
+            date: date,
+            type: type,
+            description: description,
+          };
+
+          if (notes) {
+            newEvent.notes = notes;
+          }
+
+          APP_STATE.manufacturingCalendar.push(newEvent);
+
+          logActivity('Added calendar event', description);
+          showAlert('success', 'Calendar event added');
+        }
+
+        renderCalendar();
+        autoSave();
+
+        closeCalendarAddEventModal();
+      }
+
+      function previousMonth() {
+        APP_STATE.currentMonth--;
+        if (APP_STATE.currentMonth < 0) {
+          APP_STATE.currentMonth = 11;
+          APP_STATE.currentYear--;
+        }
+        renderCalendar();
+      }
+
+      function nextMonth() {
+        APP_STATE.currentMonth++;
+        if (APP_STATE.currentMonth > 11) {
+          APP_STATE.currentMonth = 0;
+          APP_STATE.currentYear++;
+        }
+        renderCalendar();
+      }
+
+      function goToToday() {
+        const today = new Date();
+        APP_STATE.currentMonth = today.getMonth();
+        APP_STATE.currentYear = today.getFullYear();
+        renderCalendar();
+      }
+
+      function openCalendarEntry(event, entryId) {
+        // Stop event propagation to prevent day click
+        if (event) {
+          event.stopPropagation();
+        }
+
+        const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === entryId);
+
+        if (entry) {
+          const dateInput = document.getElementById('modal-calendar-date');
+          const typeSelect = document.getElementById('modal-calendar-type');
+          const notesField = document.getElementById('modal-calendar-notes');
+          const arrivalField = document.getElementById('modal-arrival-date');
+          const title = document.getElementById('calendar-add-event-modal-title');
+          const submitButton = document.getElementById('calendar-add-event-submit');
+          const deleteButton = document.getElementById('modal-delete-event-btn');
+
+          let pairedEntry = null;
+          if (entry.shipmentId) {
+            pairedEntry = APP_STATE.manufacturingCalendar.find(
+              (e) => e.shipmentId === entry.shipmentId && e.id !== entry.id
+            );
+          }
+
+          if (dateInput) {
+            if (entry.shipmentId && entry.type === 'blood-arrival' && pairedEntry) {
+              dateInput.value = pairedEntry.date;
+            } else {
+              dateInput.value = entry.date;
+            }
+          }
+
+          if (arrivalField) {
+            if (entry.shipmentId) {
+              const arrivalDate =
+                entry.type === 'blood-arrival'
+                  ? entry.date
+                  : pairedEntry?.date || '';
+              arrivalField.value = arrivalDate;
+            } else {
+              arrivalField.value = '';
+            }
+          }
+
+          if (typeSelect) {
+            typeSelect.value = entry.shipmentId ? 'blood-shipment' : entry.type;
+          }
+
+          if (notesField) {
+            if (entry.shipmentId) {
+              const baseNotes = entry.notes ?? entry.description?.replace(/ - (Departs|Arrives)$/i, '') ?? '';
+              notesField.value = baseNotes;
+            } else {
+              notesField.value = entry.notes ?? entry.description ?? '';
+            }
+          }
+          if (title) title.textContent = 'Edit Event';
+          if (submitButton) {
+            submitButton.textContent = 'Save Changes';
+            submitButton.onclick = saveCalendarEntry;
+          }
+          if (deleteButton) {
+            deleteButton.style.display = 'block';
+          }
+
+          toggleShipmentFields();
+
+          editingCalendarEntryId = entry.id;
+          document.getElementById('calendar-add-event-modal').classList.add('active');
+        }
+      }
+
+      function closeCalendarEntryModal() {
+        closeCalendarAddEventModal();
+      }
+
+      function saveCalendarEntry() {
+        let entryIndex = -1;
+        let existingEntry = null;
+
+        if (editingCalendarEntryId) {
+          entryIndex = APP_STATE.manufacturingCalendar.findIndex(
+            (e) => e.id === editingCalendarEntryId
+          );
+
+          if (entryIndex > -1) {
+            existingEntry = APP_STATE.manufacturingCalendar[entryIndex];
+
+            if (existingEntry.shipmentId) {
+              alert(
+                'Editing linked shipment events is not yet supported. Please delete the existing events and create a new one.'
+              );
+              return;
+            }
+          }
+        }
+
+        const date = document.getElementById('modal-calendar-date').value;
+        const type = document.getElementById('modal-calendar-type').value;
+        const notesField = document.getElementById('modal-calendar-notes');
+        const notes = notesField ? notesField.value.trim() : '';
+        const description = buildCalendarDescription(type, notes);
+
+        if (!date || !type) {
+          showAlert('error', 'Please fill in all required fields');
+          return;
+        }
+
+        if (editingCalendarEntryId) {
+          if (entryIndex > -1 && existingEntry) {
+            existingEntry.date = date;
+            existingEntry.type = type;
+            existingEntry.description = description;
+            if (notes) {
+              existingEntry.notes = notes;
+            } else {
+              delete existingEntry.notes;
+            }
+            logActivity('Updated calendar event', description);
+            showAlert('success', 'Calendar event updated');
+          }
+        } else {
+          const newEntry = {
+            id: 'cal_' + Date.now(),
+            date: date,
+            type: type,
+            description: description,
+          };
+          if (notes) {
+            newEntry.notes = notes;
+          }
+          APP_STATE.manufacturingCalendar.push(newEntry);
+          logActivity('Added calendar event', description);
+          showAlert('success', 'Calendar event added');
+        }
+
+        renderCalendar();
+        autoSave();
+        closeCalendarEntryModal();
+      }
+
+      function deleteCalendarEvent() {
+        if (!editingCalendarEntryId) {
+          return;
+        }
+
+        const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === editingCalendarEntryId);
+        if (!entry) {
+          return;
+        }
+
+        const confirmed = confirm('Are you sure you want to delete this event?');
+        if (!confirmed) {
+          return;
+        }
+
+        if (entry.shipmentId) {
+          const shipmentId = entry.shipmentId;
+          const relatedEvents = APP_STATE.manufacturingCalendar.filter(
+            (e) => e.shipmentId === shipmentId
+          );
+
+          APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+            (e) => e.shipmentId !== shipmentId
+          );
+
+          const summary = relatedEvents
+            .map((e) => `${e.description ?? e.type ?? ''} (${e.date})`)
+            .join(' | ');
+
+          logActivity('Deleted blood shipment', summary || shipmentId);
+          showAlert('success', 'Blood shipment deleted');
+        } else {
+          APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+            (e) => e.id !== editingCalendarEntryId
+          );
+
+          logActivity('Deleted calendar event', entry.description ?? entry.type ?? '');
+          showAlert('success', 'Calendar event deleted');
+        }
+
+        renderCalendar();
+        autoSave();
+        closeCalendarAddEventModal();
+      }
+      // ===============================
+      // Sharing Analysis
+      // ===============================
+
+      function analyzeSharingOpportunities() {
+        const startDate = document.getElementById('sharing-start-date').value;
+        const endDate = document.getElementById('sharing-end-date').value;
+
+        if (!startDate || !endDate) {
+          showAlert('error', 'Please select date range');
+          return;
+        }
+
+        // Find all PT events in range
+        const ptEvents = APP_STATE.manufacturingCalendar.filter((event) => {
+          return (
+            event.eventType === 'PT' &&
+            event.date >= startDate &&
+            event.date <= endDate &&
+            event.type === 'blood-arrival'
+          );
+        });
+
+        let html = '<h4>Sharing Opportunities Analysis</h4>';
+
+        ptEvents.forEach((event) => {
+          // Calculate sharing window for this event
+          const bleedDate = new Date(event.date);
+
+          // Find the expiration entry for this event
+          const baseDescription = event.description.replace(' - Bleed', '');
+          const expirationEntry = APP_STATE.manufacturingCalendar.find(
+            (e) => e.description === baseDescription + ' - Expires'
+          );
+
+          if (expirationEntry) {
+            const expDate = new Date(expirationEntry.date);
+            const oldestBleed = new Date(expDate);
+            oldestBleed.setDate(oldestBleed.getDate() - 77);
+
+            // Find compatible events
+            const compatible = APP_STATE.manufacturingCalendar.filter((other) => {
+              if (other.id === event.id || other.type !== 'blood-arrival') return false;
+              const otherDate = new Date(other.date);
+              return otherDate >= oldestBleed && otherDate <= bleedDate;
+            });
+
+            html += `
+                                                            <div class="sharing-window-display">
+                                                                <h5>${baseDescription}</h5>
+                                                                <p>Bleed: ${event.date}, Expires: ${
+              expirationEntry.date
+            }</p>
+                                                                <p>Can share with: ${
+                                                                  compatible.length
+                                                                } events</p>
+                                                                <ul>
+                                                                    ${compatible
+                                                                      .map(
+                                                                        (c) =>
+                                                                          `<li>${c.description} (${c.date})</li>`
+                                                                      )
+                                                                      .join('')}
+                                                                </ul>
+                                                            </div>
+                                                        `;
+          }
+        });
+
+        document.getElementById('sharing-analysis-results').innerHTML =
+          html || '<p>No PT events found in range</p>';
+      }
+
+      // ===============================
+      // CSV Import Functions
+      // ===============================
+
+      function handleSampleCSV(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function (e) {
+          const csv = e.target.result;
+          const lines = csv.split('\n');
+          const headers = lines[0].split(',').map((h) => h.trim());
+
+          let count = 0;
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '') continue;
+
+            const values = lines[i].split(',');
+            const sample = {};
+
+            headers.forEach((header, index) => {
+              sample[header] = values[index]?.trim();
+            });
+
+            APP_STATE.sampleDefinitions.push(sample);
+            count++;
+          }
+
+          updateSampleTable();
+          logActivity('Imported sample definitions', `${count} samples`);
+          showAlert('success', `Loaded ${count} sample definitions`);
+          autoSave();
+          updateDashboard();
+        };
+
+        reader.readAsText(file);
+      }
+
+      function handleSpecCSV(event) {
+        const files = event.target.files;
+        let totalSpecs = 0;
+
+        Array.from(files).forEach((file) => {
+          const reader = new FileReader();
+          reader.onload = function (e) {
+            const csv = e.target.result;
+            const lines = csv.split('\n');
+            const headers = lines[0].split(',').map((h) => h.trim());
+
+            let count = 0;
+            for (let i = 1; i < lines.length; i++) {
+              if (lines[i].trim() === '') continue;
+
+              const values = lines[i].split(',');
+              const spec = {};
+
+              headers.forEach((header, index) => {
+                spec[header] = values[index]?.trim();
+              });
+
+              APP_STATE.customerSpecs.push(spec);
+              count++;
+            }
+
+            totalSpecs += count;
+            updateSpecTable();
+            populateSpecFilters();
+            logActivity('Imported specifications', `${count} from ${file.name}`);
+            showAlert('success', `Loaded ${count} specifications from ${file.name}`);
+            autoSave();
+            updateDashboard();
+
+            // Refresh calculator dropdowns after import
+            populateCalculatorDropdowns();
+          };
+
+          reader.readAsText(file);
+        });
+      }
+
+      function handleScheduleCSV(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function (e) {
+          const csv = e.target.result;
+          const lines = csv.split('\n');
+          const headers = lines[0].split(',').map((h) => h.trim());
+
+          let imported = 0;
+          let skipped = 0;
+
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '') continue;
+
+            const values = lines[i].split(',').map((v) => v.trim());
+            const row = {};
+
+            headers.forEach((header, index) => {
+              row[header] = values[index] || '';
+            });
+
+            // Add bleed date entry
+            if (row.bleed_date) {
+              const bleedId = `sched_bleed_${row.customer}_${row.event}_${Date.now()}`;
+              const existingBleed = APP_STATE.manufacturingCalendar.find(
+                (e) =>
+                  e.date === row.bleed_date &&
+                  e.description.includes(row.customer) &&
+                  e.description.includes('Bleed')
+              );
+
+              if (!existingBleed) {
+                APP_STATE.manufacturingCalendar.push({
+                  id: bleedId,
+                  date: row.bleed_date,
+                  type: 'blood-arrival',
+                  description: `${row.customer} ${row.event} - Bleed`,
+                  imported: true,
+                  eventType: row.type,
+                });
+                imported++;
+              } else {
+                skipped++;
+              }
+            }
+
+            // Add ship date entry
+            if (row.ship_date) {
+              const shipId = `sched_ship_${row.customer}_${row.event}_${Date.now()}`;
+              const existingShip = APP_STATE.manufacturingCalendar.find(
+                (e) =>
+                  e.date === row.ship_date &&
+                  e.description.includes(row.customer) &&
+                  e.description.includes('Ship')
+              );
+
+              if (!existingShip) {
+                APP_STATE.manufacturingCalendar.push({
+                  id: shipId,
+                  date: row.ship_date,
+                  type: 'shipment',
+                  description: `${row.customer} ${row.event} - Ship`,
+                  imported: true,
+                  eventType: row.type,
+                });
+                imported++;
+              } else {
+                skipped++;
+              }
+            }
+
+            // Add expiration as reference (not shown on calendar but stored)
+            if (row.expiration_date) {
+              const expId = `sched_exp_${row.customer}_${row.event}_${Date.now()}`;
+              APP_STATE.manufacturingCalendar.push({
+                id: expId,
+                date: row.expiration_date,
+                type: 'reference',
+                description: `${row.customer} ${row.event} - Expires`,
+                imported: true,
+                hidden: true,
+                eventType: row.type,
+              });
+            }
+          }
+
+          // Update status
+          const statusDiv = document.getElementById('schedule-import-status');
+          statusDiv.innerHTML = `
+                                                        <div class="alert alert-success">
+                                                            ✅ Schedule imported: ${imported} entries added, ${skipped} duplicates skipped
+                                                        </div>
+                                                    `;
+
+          renderCalendar();
+          logActivity('Imported schedule', `${file.name}: ${imported} entries`);
+          autoSave();
+          showAlert('success', `Schedule imported successfully`);
+
+          // Clear the file input so same file can be re-imported if needed
+          document.getElementById('schedule-csv').value = '';
+        };
+
+        reader.readAsText(file);
+      }
+
+      function handleQuantitiesCSV(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function (e) {
+          const csv = e.target.result;
+          const lines = csv.split('\n');
+          const headers = lines[0].split(',').map((h) => h.trim());
+
+          let count = 0;
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '') continue;
+
+            const values = lines[i].split(',');
+            const quantity = {};
+
+            headers.forEach((header, index) => {
+              quantity[header] = values[index]?.trim();
+            });
+
+            // Add to state
+            APP_STATE.quantities.push({
+              ...quantity,
+              id: 'qty_' + Date.now() + '_' + i,
+              quantity: parseInt(quantity.quantity) || 0,
+            });
+            count++;
+          }
+
+          updateQuantitiesTable();
+          populateQuantityFilters();
+          logActivity('Imported quantities', `${count} records`);
+          showAlert('success', `Loaded ${count} quantity records`);
+          autoSave();
+        };
+
+        reader.readAsText(file);
+      }
+
+      function updateQuantitiesTable() {
+        const tbody = document.querySelector('#quantities-table tbody');
+
+        // Apply filters
+        let quantities = APP_STATE.quantities;
+
+        if (APP_STATE.quantityFilters.customer) {
+          quantities = quantities.filter((q) => q.customer === APP_STATE.quantityFilters.customer);
+        }
+        if (APP_STATE.quantityFilters.event) {
+          quantities = quantities.filter((q) => q.event === APP_STATE.quantityFilters.event);
+        }
+        if (APP_STATE.quantityFilters.year) {
+          quantities = quantities.filter((q) => q.year == APP_STATE.quantityFilters.year);
+        }
+        if (APP_STATE.quantityFilters.sampleId) {
+          quantities = quantities.filter(
+            (q) =>
+              q.sample_id &&
+              q.sample_id.toLowerCase().includes(APP_STATE.quantityFilters.sampleId.toLowerCase())
+          );
+        }
+        if (APP_STATE.quantityFilters.poNumber) {
+          quantities = quantities.filter(
+            (q) =>
+              q.po_number &&
+              q.po_number.toLowerCase().includes(APP_STATE.quantityFilters.poNumber.toLowerCase())
+          );
+        }
+
+        APP_STATE.quantityFilters.filteredQuantities = quantities;
+
+        // Update count
+        const countEl = document.getElementById('qty-filter-count');
+        if (countEl) {
+          if (quantities.length === APP_STATE.quantities.length) {
+            countEl.textContent = `Showing all ${quantities.length} quantities`;
+          } else {
+            countEl.textContent = `Showing ${quantities.length} of ${APP_STATE.quantities.length} quantities (filtered)`;
+          }
+        }
+
+        if (quantities.length === 0) {
+          tbody.innerHTML = `
+                  <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray);">
+                          ${
+                            APP_STATE.quantities.length === 0
+                              ? 'No quantities loaded'
+                              : 'No quantities match filters'
+                          }
+                      </td>
+                  </tr>
+                `;
+          return;
+        }
+
+        tbody.innerHTML = quantities
+          .map(
+            (qty) => `
+                    <tr>
+                        <td>${qty.customer}</td>
+                        <td>${qty.event}</td>
+                        <td>${qty.year}</td>
+                        <td>${qty.sample_id || 'All'}</td>
+                        <td><strong>${qty.quantity}</strong></td>
+                        <td>${qty.po_number || '-'}</td>
+                        <td><span class="status-tag ${
+                          qty.status === 'Confirmed' ? 'available' : 'limited'
+                        }">${qty.status || 'Pending'}</span></td>
+                        <td>
+                            <button class="btn btn-outline btn-sm" onclick="editQuantity('${
+                              qty.id
+                            }')">Edit</button>
+                            <button class="btn btn-danger btn-sm" onclick="deleteQuantity('${
+                              qty.id
+                            }')">Delete</button>
+                        </td>
+                    </tr>
+                  `
+          )
+          .join('');
+      }
+
+      function populateQuantityFilters() {
+        // Populate customer filter
+        const customers = [
+          ...new Set(APP_STATE.quantities.map((q) => q.customer).filter((c) => c)),
+        ].sort();
+        const customerSelect = document.getElementById('qty-filter-customer');
+        if (customerSelect) {
+          customerSelect.innerHTML =
+            '<option value="">All Customers</option>' +
+            customers.map((c) => `<option value="${c}">${c}</option>`).join('');
+        }
+
+        // Populate event filter
+        const events = [
+          ...new Set(APP_STATE.quantities.map((q) => q.event).filter((e) => e)),
+        ].sort();
+        const eventSelect = document.getElementById('qty-filter-event');
+        if (eventSelect) {
+          eventSelect.innerHTML =
+            '<option value="">All Events</option>' +
+            events.map((e) => `<option value="${e}">${e}</option>`).join('');
+        }
+
+        // Populate year filter
+        const years = [...new Set(APP_STATE.quantities.map((q) => q.year).filter((y) => y))].sort(
+          (a, b) => b - a
+        );
+        const yearSelect = document.getElementById('qty-filter-year');
+        if (yearSelect) {
+          yearSelect.innerHTML =
+            '<option value="">All Years</option>' +
+            years.map((y) => `<option value="${y}">${y}</option>`).join('');
+        }
+      }
+
+      function filterQuantities() {
+        APP_STATE.quantityFilters.customer =
+          document.getElementById('qty-filter-customer')?.value || '';
+        APP_STATE.quantityFilters.event = document.getElementById('qty-filter-event')?.value || '';
+        APP_STATE.quantityFilters.year = document.getElementById('qty-filter-year')?.value || '';
+        APP_STATE.quantityFilters.sampleId =
+          document.getElementById('qty-filter-sample')?.value || '';
+        APP_STATE.quantityFilters.poNumber = document.getElementById('qty-filter-po')?.value || '';
+
+        updateQuantitiesTable();
+      }
+
+      function clearQuantityFilters() {
+        document.getElementById('qty-filter-customer').value = '';
+        document.getElementById('qty-filter-event').value = '';
+        document.getElementById('qty-filter-year').value = '';
+        document.getElementById('qty-filter-sample').value = '';
+        document.getElementById('qty-filter-po').value = '';
+
+        APP_STATE.quantityFilters = {
+          customer: '',
+          event: '',
+          year: '',
+          sampleId: '',
+          poNumber: '',
+          filteredQuantities: [],
+        };
+
+        updateQuantitiesTable();
+      }
+
+      function deleteAllQuantities() {
+        if (!APP_STATE.writeAccess) return;
+
+        const count = APP_STATE.quantities.length;
+        if (count === 0) {
+          showAlert('warning', 'No quantities to delete');
+          return;
+        }
+
+        if (
+          confirm(
+            `Are you sure you want to delete ALL ${count} quantity records?\n\nThis action cannot be undone.`
+          )
+        ) {
+          APP_STATE.quantities = [];
+          updateQuantitiesTable();
+          populateQuantityFilters();
+          logActivity('Deleted all quantities', `${count} records deleted`);
+          autoSave();
+          showAlert('success', `Deleted ${count} quantity records`);
+        }
+      }
+
+      function deleteFilteredQuantities() {
+        if (!APP_STATE.writeAccess) return;
+
+        const filtered = APP_STATE.quantityFilters.filteredQuantities;
+        const count = filtered.length;
+
+        if (count === 0) {
+          showAlert('warning', 'No filtered quantities to delete');
+          return;
+        }
+
+        if (
+          confirm(
+            `Are you sure you want to delete ${count} filtered quantity records?\n\nThis action cannot be undone.`
+          )
+        ) {
+          // Remove filtered items from main array
+          const idsToDelete = filtered.map((q) => q.id);
+          APP_STATE.quantities = APP_STATE.quantities.filter((q) => !idsToDelete.includes(q.id));
+
+          clearQuantityFilters();
+          populateQuantityFilters();
+          updateQuantitiesTable();
+          logActivity('Deleted filtered quantities', `${count} records deleted`);
+          autoSave();
+          showAlert('success', `Deleted ${count} quantity records`);
+        }
+      }
+
+      function deleteQuantity(id) {
+        if (!APP_STATE.writeAccess) return;
+
+        APP_STATE.quantities = APP_STATE.quantities.filter((q) => q.id !== id);
+        updateQuantitiesTable();
+        logActivity('Deleted quantity record');
+        autoSave();
+      }
+
+      function openQuantityModal(quantityId = null) {
+        if (!APP_STATE.writeAccess) {
+          showAlert('warning', 'Please complete setup to manage quantities');
+          return;
+        }
+
+        const modal = document.getElementById('quantity-modal');
+        const title = document.getElementById('quantity-modal-title');
+
+        if (quantityId) {
+          // Editing existing quantity
+          const quantity = APP_STATE.quantities.find((q) => q.id === quantityId);
+          if (quantity) {
+            title.textContent = 'Edit Quantity';
+            document.getElementById('qty-modal-customer').value = quantity.customer || '';
+            document.getElementById('qty-modal-event').value = quantity.event || '';
+            document.getElementById('qty-modal-year').value = quantity.year || '';
+            document.getElementById('qty-modal-sample').value = quantity.sample_id || '';
+            document.getElementById('qty-modal-quantity').value = quantity.quantity || '';
+            document.getElementById('qty-modal-po').value = quantity.po_number || '';
+            document.getElementById('qty-modal-status').value = quantity.status || 'Confirmed';
+            APP_STATE.editingQuantityId = quantityId;
+          }
+        } else {
+          // Adding new quantity
+          title.textContent = 'Add Quantity';
+          document.getElementById('qty-modal-customer').value = '';
+          document.getElementById('qty-modal-event').value = '';
+          document.getElementById('qty-modal-year').value = new Date().getFullYear();
+          document.getElementById('qty-modal-sample').value = '';
+          document.getElementById('qty-modal-quantity').value = '';
+          document.getElementById('qty-modal-po').value = '';
+          document.getElementById('qty-modal-status').value = 'Confirmed';
+          APP_STATE.editingQuantityId = null;
+        }
+
+        modal.classList.add('active');
+      }
+
+      function editQuantity(quantityId) {
+        openQuantityModal(quantityId);
+      }
+
+      function closeQuantityModal() {
+        document.getElementById('quantity-modal').classList.remove('active');
+        APP_STATE.editingQuantityId = null;
+      }
+
+      function saveQuantity() {
+        const customer = document.getElementById('qty-modal-customer').value.trim();
+        const event = document.getElementById('qty-modal-event').value.trim();
+        const year = document.getElementById('qty-modal-year').value;
+        const sampleId = document.getElementById('qty-modal-sample').value.trim();
+        const quantity = parseInt(document.getElementById('qty-modal-quantity').value);
+        const poNumber = document.getElementById('qty-modal-po').value.trim();
+        const status = document.getElementById('qty-modal-status').value;
+
+        // Validation
+        if (!customer || !event || !year || !quantity) {
+          showAlert('error', 'Customer, event, year, and quantity are required');
+          return;
+        }
+
+        if (APP_STATE.editingQuantityId) {
+          // Update existing
+          const index = APP_STATE.quantities.findIndex((q) => q.id === APP_STATE.editingQuantityId);
+          if (index !== -1) {
+            APP_STATE.quantities[index] = {
+              ...APP_STATE.quantities[index],
+              customer,
+              event,
+              year,
+              sample_id: sampleId || null,
+              quantity,
+              po_number: poNumber || null,
+              status,
+            };
+            logActivity('Updated quantity', `${customer} ${event} ${year}`);
+            showAlert('success', 'Quantity updated successfully');
+          }
+        } else {
+          // Add new
+          const newQuantity = {
+            id: 'qty_' + Date.now(),
+            customer,
+            event,
+            year,
+            sample_id: sampleId || null,
+            quantity,
+            po_number: poNumber || null,
+            status,
+          };
+          APP_STATE.quantities.push(newQuantity);
+          logActivity('Added quantity', `${customer} ${event} ${year}`);
+          showAlert('success', 'Quantity added successfully');
+        }
+
+        updateQuantitiesTable();
+        populateQuantityFilters();
+        autoSave();
+        closeQuantityModal();
+      }
+
+      // ===============================
+      // Table Updates
+      // ===============================
+
+      function updateSampleTable() {
+        const tbody = document.querySelector('#sample-table tbody');
+
+        if (APP_STATE.sampleDefinitions.length === 0) {
+          tbody.innerHTML = `
+                                                        <tr>
+                                                            <td colspan="6" class="text-center" style="color: var(--gray);">
+                                                                No sample definitions loaded
+                                                            </td>
+                                                        </tr>
+                                                    `;
+          return;
+        }
+
+        tbody.innerHTML = APP_STATE.sampleDefinitions
+          .map(
+            (sample, index) => `
+                                                    <tr>
+                                                        <td>${sample.sample_type_id}</td>
+                                                        <td>${sample.sample_type_name}</td>
+                                                        <td>${sample.fill_ml}</td>
+                                                        <td>${sample.hct_percent}</td>
+                                                        <td>${
+                                                          sample.requires_rbc === 'TRUE' ||
+                                                          sample.requires_rbc === 'true'
+                                                            ? '✓'
+                                                            : ''
+                                                        }</td>
+                                                        <td>
+                                                            <button class="btn btn-danger btn-sm" onclick="deleteSample(${index})" ${
+              !APP_STATE.writeAccess ? 'disabled' : ''
+            }>Delete</button>
+                                                        </td>
+                                                    </tr>
+                                                `
+          )
+          .join('');
+      }
+
+      function populateSpecFilters() {
+        // Get unique values for each filter
+        const years = [
+          ...new Set(APP_STATE.customerSpecs.map((s) => s.year).filter((y) => y)),
+        ].sort((a, b) => b - a);
+        const sampleIds = [
+          ...new Set(APP_STATE.customerSpecs.map((s) => s.sample_id).filter((s) => s)),
+        ].sort();
+        const sampleTypes = [
+          ...new Set(APP_STATE.customerSpecs.map((s) => s.sample_type_id).filter((s) => s)),
+        ].sort();
+        const events = [
+          ...new Set(APP_STATE.customerSpecs.map((s) => s.event).filter((e) => e)),
+        ].sort();
+
+        // Populate event filter
+        const eventSelect = document.getElementById('spec-filter-event');
+        if (eventSelect) {
+          const currentValue = eventSelect.value;
+          eventSelect.innerHTML = '<option value="">All Events</option>';
+          events.forEach((event) => {
+            eventSelect.innerHTML += `<option value="${event}">${event}</option>`;
+          });
+          eventSelect.value = currentValue;
+        }
+
+        // Populate year filter
+        const yearSelect = document.getElementById('spec-filter-year');
+        if (yearSelect) {
+          const currentValue = yearSelect.value;
+          yearSelect.innerHTML = '<option value="">All Years</option>';
+          years.forEach((year) => {
+            yearSelect.innerHTML += `<option value="${year}">${year}</option>`;
+          });
+          yearSelect.value = currentValue;
+        }
+
+        // Populate sample ID filter
+        const sampleIdSelect = document.getElementById('spec-filter-sample-id');
+        if (sampleIdSelect) {
+          const currentValue = sampleIdSelect.value;
+          sampleIdSelect.innerHTML = '<option value="">All Sample IDs</option>';
+          sampleIds.forEach((id) => {
+            sampleIdSelect.innerHTML += `<option value="${id}">${id}</option>`;
+          });
+          sampleIdSelect.value = currentValue;
+        }
+
+        // Populate sample type filter
+        const sampleTypeSelect = document.getElementById('spec-filter-sample-type');
+        if (sampleTypeSelect) {
+          const currentValue = sampleTypeSelect.value;
+          sampleTypeSelect.innerHTML = '<option value="">All Sample Types</option>';
+          sampleTypes.forEach((type) => {
+            sampleTypeSelect.innerHTML += `<option value="${type}">${type}</option>`;
+          });
+          sampleTypeSelect.value = currentValue;
+        }
+      }
+
+      function updateSpecTable() {
+        const tbody = document.querySelector('#spec-table tbody');
+
+        // Apply filters
+        let specs = APP_STATE.customerSpecs;
+
+        // Text search
+        if (APP_STATE.specPagination.searchTerm) {
+          const search = APP_STATE.specPagination.searchTerm.toLowerCase();
+          specs = specs.filter(
+            (spec) =>
+              spec.customer?.toLowerCase().includes(search) ||
+              spec.event?.toLowerCase().includes(search) ||
+              spec.sample_id?.toLowerCase().includes(search) ||
+              spec.abo?.toLowerCase().includes(search) ||
+              spec.antibody_1?.toLowerCase().includes(search) ||
+              spec.antibody_2?.toLowerCase().includes(search)
+          );
+        }
+
+        // Event filter
+        if (APP_STATE.specPagination.filterEvent) {
+          specs = specs.filter((spec) => spec.event === APP_STATE.specPagination.filterEvent);
+        }
+
+        // Year filter
+        if (APP_STATE.specPagination.filterYear) {
+          specs = specs.filter((spec) => spec.year == APP_STATE.specPagination.filterYear);
+        }
+
+        // Sample ID filter
+        if (APP_STATE.specPagination.filterSampleId) {
+          specs = specs.filter(
+            (spec) => spec.sample_id === APP_STATE.specPagination.filterSampleId
+          );
+        }
+
+        // Sample Type filter
+        if (APP_STATE.specPagination.filterSampleType) {
+          specs = specs.filter(
+            (spec) => spec.sample_type_id === APP_STATE.specPagination.filterSampleType
+          );
+        }
+
+        APP_STATE.specPagination.filteredSpecs = specs;
+
+        if (specs.length === 0) {
+          tbody.innerHTML = `
+                                                <tr>
+                                                    <td colspan="8" class="text-center" style="color: var(--gray);">
+                                                        ${
+                                                          APP_STATE.specPagination.searchTerm
+                                                            ? 'No specifications match your search'
+                                                            : 'No specifications loaded'
+                                                        }
+                                                    </td>
+                                                </tr>
+                                            `;
+          updateSpecPaginationControls();
+          return;
+        }
+
+        // Calculate pagination
+        const pageSize =
+          APP_STATE.specPagination.pageSize === 'all'
+            ? specs.length
+            : parseInt(APP_STATE.specPagination.pageSize);
+        const totalPages = Math.ceil(specs.length / pageSize);
+        const currentPage = Math.min(APP_STATE.specPagination.currentPage, totalPages);
+        APP_STATE.specPagination.currentPage = currentPage;
+
+        const startIndex = (currentPage - 1) * pageSize;
+        const endIndex = Math.min(startIndex + pageSize, specs.length);
+        const pageSpecs = specs.slice(startIndex, endIndex);
+
+        tbody.innerHTML = pageSpecs
+          .map(
+            (spec, index) => `
+                                            <tr>
+                                                <td>${spec.customer}</td>
+                                                <td>${spec.event}</td>
+                                                <td>${spec.year}</td>
+                                                <td>${spec.sample_id}</td>
+                                                <td>${spec.sample_type_id}</td>
+                                                <td>
+                                                    <span class="blood-tag ${(
+                                                      spec.abo +
+                                                      '-' +
+                                                      spec.rh
+                                                    )
+                                                      .toLowerCase()
+                                                      .replace(' ', '-')
+                                                      .replace('+', 'pos')}">
+                                                        ${spec.abo} ${spec.rh}
+                                                    </span>
+                                                </td>
+                                                <td>
+                                                    ${
+                                                      spec.antibody_1
+                                                        ? `<span class="status-tag">${spec.antibody_1}</span>`
+                                                        : ''
+                                                    }
+                                                    ${
+                                                      spec.antibody_2
+                                                        ? `<span class="status-tag">${spec.antibody_2}</span>`
+                                                        : ''
+                                                    }
+                                                </td>
+                                                <td>
+                                                    <button class="btn btn-danger btn-sm" onclick="deleteSpec(${index})"
+                                                    })"
+                                                            ${
+                                                              !APP_STATE.writeAccess
+                                                                ? 'disabled'
+                                                                : ''
+                                                            }>Delete</button>
+                                                </td>
+                                            </tr>
+                                        `
+          )
+          .join('');
+
+        updateSpecPaginationControls();
+      }
+
+      function updateAllTables() {
+        updateSampleTable();
+        updateSpecTable();
+        updateQuantitiesTable(); // ADD THIS LINE - was missing!
+      }
+
+      function deleteSample(index) {
+        if (!APP_STATE.writeAccess) return;
+
+        if (confirm('Delete this sample definition?')) {
+          APP_STATE.sampleDefinitions.splice(index, 1);
+          updateSampleTable();
+          logActivity('Deleted sample definition');
+          autoSave();
+        }
+      }
+
+      function deleteAllSamples() {
+        if (!APP_STATE.writeAccess) return;
+
+        const count = APP_STATE.sampleDefinitions.length;
+
+        if (count === 0) {
+          showAlert('warning', 'No sample definitions to delete');
+          return;
+        }
+
+        if (
+          confirm(
+            `Are you sure you want to delete all ${count} sample definitions?\n\nThis action cannot be undone.`
+          )
+        ) {
+          APP_STATE.sampleDefinitions = [];
+          updateSampleTable();
+          logActivity('Deleted all sample definitions', `${count} items deleted`);
+          autoSave();
+          updateDashboard();
+          showAlert('success', `Deleted ${count} sample definitions`);
+        }
+      }
+
+      function deleteSpec(index) {
+        if (!APP_STATE.writeAccess) return;
+
+        // Get the actual spec from the filtered list
+        const filteredSpecs = APP_STATE.specPagination.filteredSpecs;
+        const specToDelete = filteredSpecs[index];
+
+        if (!specToDelete) {
+          showAlert('error', 'Could not find specification to delete');
+          return;
+        }
+
+        if (confirm('Delete this specification?')) {
+          // Find and remove from the main array
+          const mainIndex = APP_STATE.customerSpecs.findIndex(
+            (spec) =>
+              spec.customer === specToDelete.customer &&
+              spec.event === specToDelete.event &&
+              spec.year === specToDelete.year &&
+              spec.sample_id === specToDelete.sample_id
+          );
+
+          if (mainIndex > -1) {
+            APP_STATE.customerSpecs.splice(mainIndex, 1);
+            updateSpecTable();
+            populateSpecFilters(); // Refresh filter dropdowns
+            logActivity('Deleted specification');
+            autoSave();
+            updateDashboard();
+          } else {
+            showAlert('error', 'Could not find specification in main list');
+          }
+        }
+      }
+
+      function deleteAllSpecs() {
+        if (!APP_STATE.writeAccess) return;
+
+        const filteredSpecs = APP_STATE.specPagination.filteredSpecs;
+        const count = filteredSpecs.length;
+
+        if (count === 0) {
+          showAlert('warning', 'No specifications to delete');
+          return;
+        }
+
+        const filterDescription = [];
+        if (APP_STATE.specPagination.searchTerm) {
+          filterDescription.push(`search: "${APP_STATE.specPagination.searchTerm}"`);
+        }
+        if (APP_STATE.specPagination.filterEvent) {
+          filterDescription.push(`event: ${APP_STATE.specPagination.filterEvent}`);
+        }
+        if (APP_STATE.specPagination.filterYear) {
+          filterDescription.push(`year: ${APP_STATE.specPagination.filterYear}`);
+        }
+        if (APP_STATE.specPagination.filterSampleId) {
+          filterDescription.push(`sample: ${APP_STATE.specPagination.filterSampleId}`);
+        }
+        if (APP_STATE.specPagination.filterSampleType) {
+          filterDescription.push(`type: ${APP_STATE.specPagination.filterSampleType}`);
+        }
+
+        const filterText =
+          filterDescription.length > 0 ? ` matching filters (${filterDescription.join(', ')})` : '';
+
+        if (
+          confirm(
+            `Are you sure you want to delete ${count} specifications${filterText}?\n\nThis action cannot be undone.`
+          )
+        ) {
+          // Remove all filtered specs from the main array
+          filteredSpecs.forEach((specToDelete) => {
+            const index = APP_STATE.customerSpecs.findIndex(
+              (spec) =>
+                spec.customer === specToDelete.customer &&
+                spec.event === specToDelete.event &&
+                spec.year === specToDelete.year &&
+                spec.sample_id === specToDelete.sample_id
+            );
+            if (index > -1) {
+              APP_STATE.customerSpecs.splice(index, 1);
+            }
+          });
+
+          updateSpecTable();
+          populateSpecFilters();
+          logActivity('Bulk deleted specifications', `${count} items deleted`);
+          autoSave();
+          updateDashboard();
+          showAlert('success', `Deleted ${count} specifications`);
+        }
+      }
+
+      function updateSpecPaginationControls() {
+        const specs = APP_STATE.specPagination.filteredSpecs;
+        const pageSize =
+          APP_STATE.specPagination.pageSize === 'all'
+            ? specs.length
+            : parseInt(APP_STATE.specPagination.pageSize);
+        const totalPages = Math.ceil(specs.length / pageSize);
+        const currentPage = APP_STATE.specPagination.currentPage;
+
+        // Update info text
+        const startIndex = Math.min((currentPage - 1) * pageSize + 1, specs.length);
+        const endIndex = Math.min(currentPage * pageSize, specs.length);
+        const infoEl = document.getElementById('spec-pagination-info');
+        if (infoEl) {
+          infoEl.textContent =
+            specs.length > 0
+              ? `Showing ${startIndex}-${endIndex} of ${specs.length} entries`
+              : 'No entries';
+        }
+
+        // Update page numbers
+        const pageNumbersEl = document.getElementById('spec-page-numbers');
+        if (pageNumbersEl) {
+          let pageHTML = '';
+
+          // Show max 5 page numbers
+          let startPage = Math.max(1, currentPage - 2);
+          let endPage = Math.min(totalPages, startPage + 4);
+          if (endPage - startPage < 4) {
+            startPage = Math.max(1, endPage - 4);
+          }
+
+          if (startPage > 1) {
+            pageHTML += `<button class="btn btn-outline btn-sm" onclick="specGoToPage(1)">1</button>`;
+            if (startPage > 2) pageHTML += `<span>...</span>`;
+          }
+
+          for (let i = startPage; i <= endPage; i++) {
+            const activeClass = i === currentPage ? 'btn-primary' : 'btn-outline';
+            pageHTML += `<button class="btn ${activeClass} btn-sm" onclick="specGoToPage(${i})">${i}</button>`;
+          }
+
+          if (endPage < totalPages) {
+            if (endPage < totalPages - 1) pageHTML += `<span>...</span>`;
+            pageHTML += `<button class="btn btn-outline btn-sm" onclick="specGoToPage(${totalPages})">${totalPages}</button>`;
+          }
+
+          pageNumbersEl.innerHTML = pageHTML;
+        }
+
+        // Enable/disable prev/next buttons
+        const prevBtn = document.querySelector('#spec-pagination-controls button:first-child');
+        const nextBtn = document.querySelector('#spec-pagination-controls button:last-child');
+        if (prevBtn) prevBtn.disabled = currentPage === 1;
+        if (nextBtn) nextBtn.disabled = currentPage === totalPages || totalPages === 0;
+        // Update selected count display
+        const countEl = document.getElementById('spec-selected-count');
+        if (countEl) {
+          const filterActive =
+            APP_STATE.specPagination.searchTerm ||
+            APP_STATE.specPagination.filterEvent ||
+            APP_STATE.specPagination.filterYear ||
+            APP_STATE.specPagination.filterSampleId ||
+            APP_STATE.specPagination.filterSampleType;
+
+          if (filterActive) {
+            countEl.textContent = `${specs.length} specifications match current filters`;
+            countEl.style.color = 'var(--hemo-blue)';
+          } else {
+            countEl.textContent = `${specs.length} total specifications`;
+            countEl.style.color = 'var(--gray)';
+          }
+        }
+      }
+
+      function filterSpecs() {
+        const searchTerm = document.getElementById('spec-search').value;
+        const filterEvent = document.getElementById('spec-filter-event').value;
+        const filterYear = document.getElementById('spec-filter-year').value;
+        const filterSampleId = document.getElementById('spec-filter-sample-id').value;
+        const filterSampleType = document.getElementById('spec-filter-sample-type').value;
+
+        APP_STATE.specPagination.searchTerm = searchTerm;
+        APP_STATE.specPagination.filterEvent = filterEvent;
+        APP_STATE.specPagination.filterYear = filterYear;
+        APP_STATE.specPagination.filterSampleId = filterSampleId;
+        APP_STATE.specPagination.filterSampleType = filterSampleType;
+        APP_STATE.specPagination.currentPage = 1;
+
+        updateSpecTable();
+      }
+
+      function updateSpecPagination() {
+        const pageSize = document.getElementById('spec-page-size').value;
+        APP_STATE.specPagination.pageSize = pageSize === 'all' ? 'all' : parseInt(pageSize);
+        APP_STATE.specPagination.currentPage = 1;
+        updateSpecTable();
+      }
+
+      function specChangePage(direction) {
+        const specs = APP_STATE.specPagination.filteredSpecs;
+        const pageSize =
+          APP_STATE.specPagination.pageSize === 'all'
+            ? specs.length
+            : parseInt(APP_STATE.specPagination.pageSize);
+        const totalPages = Math.ceil(specs.length / pageSize);
+
+        if (direction === 'prev' && APP_STATE.specPagination.currentPage > 1) {
+          APP_STATE.specPagination.currentPage--;
+        } else if (direction === 'next' && APP_STATE.specPagination.currentPage < totalPages) {
+          APP_STATE.specPagination.currentPage++;
+        }
+
+        updateSpecTable();
+      }
+
+      function specGoToPage(page) {
+        APP_STATE.specPagination.currentPage = page;
+        updateSpecTable();
+      }
+
+      function clearSpecFilters() {
+        document.getElementById('spec-search').value = '';
+        document.getElementById('spec-filter-event').value = '';
+        document.getElementById('spec-filter-year').value = '';
+        document.getElementById('spec-filter-sample-id').value = '';
+        document.getElementById('spec-filter-sample-type').value = '';
+
+        APP_STATE.specPagination.searchTerm = '';
+        APP_STATE.specPagination.filterEvent = '';
+        APP_STATE.specPagination.filterYear = '';
+        APP_STATE.specPagination.filterSampleId = '';
+        APP_STATE.specPagination.filterSampleType = '';
+        APP_STATE.specPagination.currentPage = 1;
+
+        updateSpecTable();
+      }
+
+      // ===============================
+      // Unit Management
+      // ===============================
+
+      function openUnitModal() {
+        showAlert('info', 'Unit management - Coming soon');
+      }
+
+      // ===============================
+      // Export/Import Functions
+      // ===============================
+
+      function exportAllData() {
+        const data = {
+          version: APP_STATE.version,
+          exportDate: new Date().toISOString(),
+          exportedBy: APP_STATE.currentUser,
+          customers: APP_STATE.customers,
+          sampleDefinitions: APP_STATE.sampleDefinitions,
+          customerSpecs: APP_STATE.customerSpecs,
+          quantities: APP_STATE.quantities,
+          antibodies: APP_STATE.antibodies,
+          bloodUnits: APP_STATE.bloodUnits,
+          manufacturingCalendar: APP_STATE.manufacturingCalendar,
+          activityLog: APP_STATE.activityLog,
+          decisions: APP_STATE.decisions,
+          futureSpecs: APP_STATE.futureSpecs, // ADD THIS LINE
+        };
+
+        const json = JSON.stringify(data, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `blood_platform_backup_${new Date().toISOString().split('T')[0]}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+
+        logActivity('Exported all data');
+        showAlert('success', 'Data exported successfully');
+      }
+
+      function importBackup() {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.json';
+        input.onchange = function (e) {
+          const file = e.target.files[0];
+          const reader = new FileReader();
+          reader.onload = function (event) {
+            try {
+              const data = JSON.parse(event.target.result);
+
+              // Validate structure
+              if (!data.version) {
+                throw new Error('Invalid backup file');
+              }
+
+              // Import data
+              APP_STATE.customers = data.customers || [];
+              APP_STATE.sampleDefinitions = data.sampleDefinitions || [];
+              APP_STATE.customerSpecs = data.customerSpecs || [];
+              APP_STATE.quantities = data.quantities || [];
+              APP_STATE.antibodies = data.antibodies || [];
+              APP_STATE.bloodUnits = data.bloodUnits || [];
+              APP_STATE.manufacturingCalendar = data.manufacturingCalendar || [];
+              APP_STATE.activityLog = data.activityLog || [];
+              APP_STATE.decisions = data.decisions || [];
+              APP_STATE.futureSpecs = data.futureSpecs || {
+                entries: [],
+                versions: {},
+                metadata: {},
+              };
+
+              // Update all views
+              updateDashboard();
+              updateCustomerList();
+              updateAntibodyList();
+              updateActivityLog();
+              updateAllTables();
+              renderCalendar();
+
+              logActivity('Imported backup', `From ${data.exportDate}`);
+              autoSave();
+              showAlert('success', 'Data imported successfully');
+            } catch (err) {
+              showAlert('error', 'Failed to import backup: ' + err.message);
+            }
+          };
+          reader.readAsText(file);
+        };
+        input.click();
+      }
+
+      // ===============================
+      // Utility Functions
+      // ===============================
+
+      function showAlert(type, message) {
+        const alert = document.createElement('div');
+        alert.className = `alert alert-${type}`;
+        alert.textContent = message;
+
+        const activePanel = document.querySelector('.panel.active .content-body');
+        if (activePanel) {
+          activePanel.insertBefore(alert, activePanel.firstChild);
+
+          setTimeout(() => {
+            alert.remove();
+          }, 5000);
+        }
+      }
+
+      function initializeDragAndDrop() {
+        const uploadAreas = document.querySelectorAll('.upload-area');
+
+        uploadAreas.forEach((area) => {
+          area.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            area.classList.add('dragging');
+          });
+
+          area.addEventListener('dragleave', () => {
+            area.classList.remove('dragging');
+          });
+
+          area.addEventListener('drop', (e) => {
+            e.preventDefault();
+            area.classList.remove('dragging');
+
+            const input = area.querySelector('input[type="file"]');
+            input.files = e.dataTransfer.files;
+            input.dispatchEvent(new Event('change'));
+          });
+        });
+      }
+
+      // =======================================
+      // Future Spec Optimization Engine
+      // =======================================
+
+      function runFutureSpecOptimization() {
+        console.log('Running Future Spec Optimization...');
+        const futureSpecs = APP_STATE.futureSpecs.entries;
+        if (!futureSpecs || futureSpecs.length === 0) {
+          console.log('No future specs to optimize.');
+          return;
+        }
+
+        // Clear previous suggestions
+        futureSpecs.forEach((spec) => {
+          spec.optimizationSuggestions = [];
+        });
+
+        // Process each future spec
+        for (const spec of futureSpecs) {
+          optimizeFutureSpecSample(spec);
+        }
+
+        console.log('Future Spec Optimization completed');
+      }
+
+      function optimizeFutureSpecSample(spec) {
+        if (!spec || spec.abo === 'TBD' || spec.rh === 'TBD') {
+          // Skip specs that don't have blood types assigned yet
+          return;
+        }
+
+        const fulfillmentWindow = calculateSpecFulfillmentWindow(spec);
+        if (!fulfillmentWindow) {
+          return;
+        }
+
+        // Search current inventory for compatible units
+        searchInventoryForSpec(spec, fulfillmentWindow);
+
+        // Search manufacturing calendar for standing orders
+        searchStandingOrdersForSpec(spec, fulfillmentWindow);
+
+        // Search other PT events for sharing opportunities
+        searchPTEventsForSpec(spec, fulfillmentWindow);
+      }
+
+      function calculateSpecFulfillmentWindow(spec) {
+        // For future specs, we need to estimate dates based on typical patterns
+        // In a real implementation, these dates would come from scheduling data
+
+        // Estimate ship date as beginning of the year + event quarter
+        const shipDate = new Date(spec.year, (parseInt(spec.event.replace(/\D/g, '')) - 1) * 3, 1);
+
+        // Estimate expiration date (typically 51 days after ship)
+        const expirationDate = new Date(shipDate);
+        expirationDate.setDate(expirationDate.getDate() + 51);
+
+        // Calculate acceptable window using 77-day rule
+        const earliestBleed = new Date(expirationDate);
+        earliestBleed.setDate(earliestBleed.getDate() - 77); // Max 77 days before expiration
+
+        const latestBleed = new Date(shipDate);
+        latestBleed.setDate(latestBleed.getDate() - 10); // Manufacturing buffer
+
+        return {
+          earliest: earliestBleed,
+          latest: latestBleed,
+          ship: shipDate,
+          expiration: expirationDate,
+        };
+      }
+
+      function searchInventoryForSpec(spec, window) {
+        if (!APP_STATE.bloodUnits || APP_STATE.bloodUnits.length === 0) {
+          return;
+        }
+
+        APP_STATE.bloodUnits.forEach((unit) => {
+          if (isBloodUnitCompatible(spec, unit) && isDateInWindow(unit.bleed_date, window)) {
+            addOptimizationSuggestion(spec, {
+              sourceType: 'Current Inventory',
+              sourceId: unit.id,
+              description: `Inventory Unit ${unit.id}`,
+              details: `Bleed: ${unit.bleed_date}, Type: ${unit.abo} ${unit.rh}`,
+              compatibility: 'Exact Match',
+              volume: unit.volume || 180,
+              savings: calculateUnitSavings(unit),
+            });
+          }
+        });
+      }
+
+      function searchStandingOrdersForSpec(spec, window) {
+        // Check HQC standing orders
+        const hqcCompatibility = checkHQCCompatibility(spec);
+        if (hqcCompatibility.compatible) {
+          addOptimizationSuggestion(spec, {
+            sourceType: 'Standing Order',
+            sourceId: `HQC-${hqcCompatibility.cellId}`,
+            description: `HQC-${hqcCompatibility.cellId} Standing Order`,
+            details: `${hqcCompatibility.description} - Overage available`,
+            compatibility: hqcCompatibility.exactMatch
+              ? 'Exact Match'
+              : 'Compatible with flexibility',
+            volume: 180, // Standard unit volume
+            savings: calculateStandingOrderSavings(),
+          });
+        }
+
+        // Check other standing orders (C3, Korea, MQC)
+        checkOtherStandingOrders(spec, window);
+      }
+
+      function searchPTEventsForSpec(spec, window) {
+        // Look for other PT events in the same timeframe that might have overage
+        const otherPTEvents = APP_STATE.futureSpecs.entries.filter(
+          (otherSpec) =>
+            otherSpec.customer !== spec.customer &&
+            otherSpec.abo !== 'TBD' &&
+            isSpecCompatible(spec, otherSpec)
+        );
+
+        otherPTEvents.forEach((otherSpec) => {
+          const otherWindow = calculateSpecFulfillmentWindow(otherSpec);
+          if (otherWindow && isWindowOverlapping(window, otherWindow)) {
+            addOptimizationSuggestion(spec, {
+              sourceType: 'PT Event Sharing',
+              sourceId: `${otherSpec.customer}_${otherSpec.event}_${otherSpec.year}`,
+              description: `${otherSpec.customer} ${otherSpec.event} ${otherSpec.year}`,
+              details: `Compatible PT event with potential overage`,
+              compatibility: 'Cross-Event Compatible',
+              volume: 90, // Estimate half unit sharing
+              savings: calculatePTSharingSavings(),
+            });
+          }
+        });
+      }
+
+      // Helper functions for compatibility checking (reusing existing logic)
+      function isBloodUnitCompatible(spec, unit) {
+        // Reuse existing compatibility logic
+        const specABO = spec.abo || '';
+        const specRh = spec.rh || '';
+        const unitABO = unit.abo || '';
+        const unitRh = unit.rh || '';
+
+        // Handle blank specs as "any type acceptable"
+        const isABOFlexible = !specABO || specABO === '';
+        const isRhFlexible = !specRh || specRh === '';
+
+        // Check ABO compatibility
+        const aboCompatible =
+          isABOFlexible ||
+          specABO === unitABO ||
+          specABO === 'AB' || // AB can receive any
+          (specABO === 'A' && unitABO === 'O') || // A can receive O
+          (specABO === 'B' && unitABO === 'O'); // B can receive O
+
+        // Check Rh compatibility
+        const rhCompatible = isRhFlexible || specRh === unitRh || specRh === 'Positive'; // Pos can receive Neg
+
+        return aboCompatible && rhCompatible;
+      }
+
+      function checkHQCCompatibility(spec) {
+        const specABO = spec.abo || '';
+        const specRh = spec.rh || '';
+        const specAntigens = spec.antigens || [];
+
+        // Check HQC-1: AsubB Pos (RhD+ required; others flexible)
+        if ((specABO === 'AsubB' || specABO === '') && (specRh === 'Positive' || specRh === '')) {
+          return {
+            compatible: true,
+            cellId: 1,
+            description: 'AsubB Pos',
+            exactMatch: specABO === 'AsubB',
+          };
+        }
+
+        // Check HQC-2: O Pos, R1r, Fya− (Rh fixed: D+, C+, E−, c+, e+; Fy(a−))
+        if ((specABO === 'O' || specABO === '') && (specRh === 'Positive' || specRh === '')) {
+          const needsFyaNeg = specAntigens.some(
+            (ag) => ag.antigen === 'Fya' && ag.status === 'Negative'
+          );
+          if (needsFyaNeg || specAntigens.length === 0) {
+            return {
+              compatible: true,
+              cellId: 2,
+              description: 'O Pos R1r Fya-',
+              exactMatch: specABO === 'O',
+            };
+          }
+        }
+
+        // Check HQC-3: A1 Neg, rr (Rh fixed: D−, C−, E−, c+, e+)
+        if (
+          (specABO === 'A1' || specABO === 'A' || specABO === '') &&
+          (specRh === 'Negative' || specRh === '')
+        ) {
+          return {
+            compatible: true,
+            cellId: 3,
+            description: 'A1 Neg rr',
+            exactMatch: specABO === 'A1',
+          };
+        }
+
+        return { compatible: false };
+      }
+
+      function checkOtherStandingOrders(spec, window) {
+        // Simplified check for other standing orders
+        // In production, this would check C3, Korea, and MQC compatibility
+      }
+
+      function isSpecCompatible(spec1, spec2) {
+        return isBloodUnitCompatible(spec1, { abo: spec2.abo, rh: spec2.rh });
+      }
+
+      function isDateInWindow(dateStr, window) {
+        if (!dateStr || !window) return false;
+        const date = new Date(dateStr);
+        return date >= window.earliest && date <= window.latest;
+      }
+
+      function isWindowOverlapping(window1, window2) {
+        return window1.latest >= window2.earliest && window2.latest >= window1.earliest;
+      }
+
+      function addOptimizationSuggestion(spec, suggestion) {
+        if (!spec.optimizationSuggestions) {
+          spec.optimizationSuggestions = [];
+        }
+        spec.optimizationSuggestions.push(suggestion);
+      }
+
+      function calculateUnitSavings(unit) {
+        return { cost: 450, description: 'Avoids new unit purchase' };
+      }
+
+      function calculateStandingOrderSavings() {
+        return { cost: 350, description: 'Uses existing overage' };
+      }
+
+      function calculatePTSharingSavings() {
+        return { cost: 300, description: 'Cross-event sharing' };
+      }
+
+      // ===============================
+      // Future Specifications Functions
+      // ===============================
+
+      function updateFutureCopyOptions() {
+        const customer = document.getElementById('future-spec-customer').value;
+        const copySelect = document.getElementById('future-spec-copy-from');
+
+        if (!customer) {
+          copySelect.innerHTML = '<option value="">Manual Entry</option>';
+          return;
+        }
+
+        // Find all events for this customer from historical specs
+        const customerEvents = {};
+        APP_STATE.customerSpecs
+          .filter((spec) => spec.customer === customer)
+          .forEach((spec) => {
+            const key = `${spec.event} ${spec.year}`;
+            if (!customerEvents[key]) {
+              customerEvents[key] = {
+                event: spec.event,
+                year: spec.year,
+              };
+            }
+          });
+
+        copySelect.innerHTML = '<option value="">Manual Entry</option>';
+
+        // Sort by year (descending) then event
+        const sortedEvents = Object.values(customerEvents).sort((a, b) => {
+          if (b.year !== a.year) return b.year - a.year;
+          return a.event.localeCompare(b.event);
+        });
+
+        sortedEvents.forEach((item) => {
+          const optionValue = `${customer} ${item.event} ${item.year}`;
+          const optionText = `${customer} ${item.event} ${item.year}`;
+          copySelect.innerHTML += `<option value="${optionValue}">${optionText}</option>`;
+        });
+
+        // Auto-calculate forecasted quantity
+        calculateForecastedQuantity(customer);
+      }
+
+      function calculateForecastedQuantity(customer) {
+        // Get historical quantities for trend analysis
+        const historicalQty = APP_STATE.quantities
+          .filter((q) => q.customer === customer)
+          .sort((a, b) => b.year - a.year);
+
+        if (historicalQty.length === 0) {
+          document.getElementById('future-spec-quantity').placeholder = 'No historical data';
+          return;
+        }
+
+        // Simple trend analysis (can be made more sophisticated)
+        if (historicalQty.length >= 3) {
+          const recent = historicalQty.slice(0, 3).map((q) => parseInt(q.quantity));
+          const avg = Math.round(recent.reduce((a, b) => a + b, 0) / recent.length);
+
+          // Check for trend
+          const trend = recent[0] - recent[2]; // Most recent minus oldest
+          const forecast = avg + Math.round(trend / 2); // Apply half the trend
+
+          document.getElementById('future-spec-quantity').value = forecast;
+        } else {
+          // Use simple average if less than 3 years
+          const avg = Math.round(
+            historicalQty.reduce((sum, q) => sum + parseInt(q.quantity), 0) / historicalQty.length
+          );
+          document.getElementById('future-spec-quantity').value = avg;
+        }
+      }
+
+      function createFutureSpec() {
+        const customer = document.getElementById('future-spec-customer').value;
+        const event = document.getElementById('future-spec-event').value;
+        const year = document.getElementById('future-spec-year').value;
+        const copyFrom = document.getElementById('future-spec-copy-from').value;
+        const quantity = document.getElementById('future-spec-quantity').value || 100;
+
+        if (!customer || !event || !year) {
+          showAlert('error', 'Please fill in all required fields');
+          return;
+        }
+
+        const specKey = `${customer}_${event}_${year}`;
+
+        // Initialize futureSpecs if it doesn't exist
+        if (!APP_STATE.futureSpecs) {
+          APP_STATE.futureSpecs = {
+            entries: [],
+            versions: {},
+            metadata: {},
+          };
+        }
+
+        // Check if already exists
+        if (APP_STATE.futureSpecs.metadata[specKey]) {
+          showAlert('error', 'This specification already exists');
+          return;
+        }
+
+        let samples = [];
+
+        if (copyFrom) {
+          // Parse the copyFrom string correctly
+          // Format is "Customer Event Year" e.g. "OneWorld 4th 2025"
+          const copyParts = copyFrom.split(' ');
+          let copyCustomer = '';
+          let copyEvent = '';
+          let copyYear = '';
+
+          // Handle multi-word customer names (shouldn't be an issue with current customers but good practice)
+          // Since we know the format ends with year, work backwards
+          copyYear = copyParts[copyParts.length - 1];
+
+          // Everything between customer and year is the event
+          // For "OneWorld 4th 2025", we know OneWorld is single word
+          if (
+            customer === 'OneWorld' ||
+            customer === 'WSLH' ||
+            customer === 'ISLA' ||
+            customer === 'Aurevia' ||
+            customer === 'AABB'
+          ) {
+            copyEvent = copyParts.slice(1, -1).join(' '); // Join in case event has spaces
+          }
+
+          console.log(`Copying from: customer=${customer}, event=${copyEvent}, year=${copyYear}`);
+
+          // Filter source specs with correct criteria
+          const sourceSpecs = APP_STATE.customerSpecs.filter((spec) => {
+            const match =
+              spec.customer === customer &&
+              spec.event === copyEvent &&
+              String(spec.year) === String(copyYear);
+            if (match) {
+              console.log('Found matching spec:', spec);
+            }
+            return match;
+          });
+
+          console.log(`Found ${sourceSpecs.length} source specs to copy`);
+
+          if (sourceSpecs.length === 0) {
+            showAlert(
+              'warning',
+              `No specifications found for ${customer} ${copyEvent} ${copyYear}`
+            );
+            // Still create empty structure
+            samples = [];
+          } else {
+            // Create new samples with updated year and TBD blood types
+            samples = sourceSpecs.map((spec) => ({
+              customer: customer,
+              event: event,
+              year: parseInt(year),
+              sample_id: spec.sample_id.replace(copyYear, year), // Update year in sample ID
+              sample_type_id: spec.sample_type_id,
+              abo: 'TBD',
+              rh: 'TBD',
+              antigens: [], // Changed from empty string to empty array
+              antibodies: [], // Changed from antibody_1/antibody_2 to single array
+              dat_status: 'Negative', // Changed from is_dat_positive to dat_status
+              status: 'draft',
+            }));
+          }
+        } else {
+          // Manual entry - create empty structure
+          showAlert('info', 'Manual entry mode - add samples individually');
+          samples = [];
+        }
+
+        // Add to futureSpecs
+        APP_STATE.futureSpecs.entries.push(...samples);
+        APP_STATE.futureSpecs.metadata[specKey] = {
+          created: new Date().toISOString(),
+          lastModified: new Date().toISOString(),
+          currentVersion: 1,
+          status: 'draft',
+          quantity: parseInt(quantity),
+        };
+
+        // Save initial version
+        APP_STATE.futureSpecs.versions[`${specKey}_v1`] = {
+          timestamp: new Date().toISOString(),
+          samples: JSON.parse(JSON.stringify(samples)),
+        };
+
+        logActivity('Created future specification', `${customer} ${event} ${year}`);
+        showAlert('success', `Created ${customer} ${event} ${year} with ${samples.length} samples`);
+        updateFutureSpecsList();
+        autoSave();
+
+        // Clear the form after successful creation
+        document.getElementById('future-spec-event').value = '';
+        document.getElementById('future-spec-year').value = '2026';
+        document.getElementById('future-spec-copy-from').value = '';
+        document.getElementById('future-spec-quantity').value = '';
+      }
+
+      function updateFutureSpecsList() {
+        const listDiv = document.getElementById('future-specs-list');
+
+        // Group specs by customer/event/year
+        const grouped = {};
+        APP_STATE.futureSpecs.entries.forEach((spec) => {
+          const key = `${spec.customer}_${spec.event}_${spec.year}`;
+          if (!grouped[key]) {
+            grouped[key] = [];
+          }
+          grouped[key].push(spec);
+        });
+
+        if (Object.keys(grouped).length === 0) {
+          listDiv.innerHTML =
+            '<p class="text-center" style="color: var(--gray);">No future specifications created yet</p>';
+          return;
+        }
+
+        let html = '';
+        Object.keys(grouped).forEach((key) => {
+          const specs = grouped[key];
+          const metadata = APP_STATE.futureSpecs.metadata[key] || {};
+          const [customer, event, year] = key.split('_');
+
+          // Count assigned vs TBD
+          const assigned = specs.filter((s) => s.abo !== 'TBD').length;
+          const total = specs.length;
+
+          html += `
+      <div class="card mb-2" style="background: var(--light); border: 1px solid var(--border);">
+        <div class="card-header">
+          <h4>${customer} ${event} ${year}</h4>
+          <span class="status-tag ${metadata.status === 'approved' ? 'available' : 'limited'}">
+            ${metadata.status || 'draft'}
+          </span>
+        </div>
+        <div style="padding: 1rem;">
+          <p>Samples: ${total} (${assigned} assigned, ${total - assigned} TBD)</p>
+          <p>Quantity: ${metadata.quantity || 'Not set'}</p>
+          <p>Version: v${metadata.currentVersion || 1}</p>`;
+
+          // Add optimization suggestions if they exist
+          const specsWithSuggestions = specs.filter(
+            (s) => s.optimizationSuggestions && s.optimizationSuggestions.length > 0
+          );
+          if (specsWithSuggestions.length > 0) {
+            const totalSuggestions = specsWithSuggestions.reduce(
+              (sum, s) => sum + s.optimizationSuggestions.length,
+              0
+            );
+            html += `
+            <div class="alert alert-info" style="margin: 0.5rem 0; padding: 0.75rem; background: #e3f2fd; border: 1px solid #1976d2; border-radius: 4px;">
+              <strong>💡 ${totalSuggestions} Optimization Opportunities Found!</strong><br>
+              <small>Compatible blood sources identified for ${specsWithSuggestions.length} samples</small>
+              <details style="margin-top: 0.5rem;">
+                <summary style="cursor: pointer; font-weight: 500;">View Suggestions</summary>
+                <div style="margin-top: 0.5rem;">`;
+
+            specsWithSuggestions.forEach((spec) => {
+              html += `<div style="margin: 0.5rem 0; padding: 0.5rem; background: white; border-radius: 3px;">
+                <strong>Sample ${spec.sample_id} (${spec.abo} ${spec.rh}):</strong><br>`;
+
+              spec.optimizationSuggestions.forEach((suggestion) => {
+                html += `<div style="margin-left: 1rem; margin-top: 0.25rem;">
+                  • <strong>${suggestion.sourceType}:</strong> ${suggestion.description}<br>
+                  <small style="color: #666;">${suggestion.details} | ${suggestion.compatibility}</small>
+                </div>`;
+              });
+              html += '</div>';
+            });
+
+            html += `</div></details>
+            </div>`;
+          }
+
+          html += `<div class="btn-group mt-2">
+            <button class="btn btn-primary btn-sm" onclick="optimizeFutureSpec('${key}')">
+              Optimize
+            </button>
+            <button class="btn btn-outline btn-sm" onclick="viewFutureSpec('${key}')">
+              View/Edit
+            </button>
+            <button class="btn btn-outline btn-sm" onclick="approveFutureSpec('${key}')">
+              ${metadata.status === 'approved' ? 'Unapprove' : 'Approve'}
+            </button>
+            <button class="btn btn-danger btn-sm" onclick="deleteFutureSpec('${key}')">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+        });
+
+        listDiv.innerHTML = html;
+      }
+
+      function optimizeFutureSpec(specKey) {
+        const [customer, event, year] = specKey.split('_');
+        const specs = APP_STATE.futureSpecs.entries.filter(
+          (s) => s.customer === customer && s.event === event && s.year == year
+        );
+
+        if (specs.length === 0) {
+          showAlert('error', 'No samples found for this specification');
+          return;
+        }
+
+        // Show optimization results
+        const resultsCard = document.getElementById('optimization-results');
+        const contentDiv = document.getElementById('optimization-content');
+
+        // Find available blood in sharing window
+        const available = findAvailableBlood(customer, event, year);
+
+        // Run optimization algorithm
+        const optimized = runOptimization(specs, available);
+
+        // Display results
+        let html = `
+    <h4>Optimization for ${customer} ${event} ${year}</h4>
+    <div class="alert alert-info">
+      <strong>Sharing Window:</strong> ${available.window.start} to ${available.window.end}<br>
+      <strong>Available Sources:</strong> ${available.sources.length} opportunities found
+    </div>
+    
+    <h5>Optimization Results:</h5>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Sample ID</th>
+            <th>Type</th>
+            <th>Volume Needed</th>
+            <th>Current</th>
+            <th>Optimized</th>
+            <th>Source</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+  `;
+
+        optimized.assignments.forEach((assignment, idx) => {
+          html += `
+      <tr>
+        <td>${assignment.sample_id}</td>
+        <td>${assignment.sample_type_id}</td>
+        <td>${assignment.volumeNeeded.toFixed(1)}mL</td>
+        <td>${assignment.currentAbo} ${assignment.currentRh}</td>
+        <td>
+          <select id="opt-abo-${idx}" class="form-select" style="width: 80px; display: inline;">
+            <option value="TBD">TBD</option>
+            <option value="O" ${assignment.suggestedAbo === 'O' ? 'selected' : ''}>O</option>
+            <option value="A" ${assignment.suggestedAbo === 'A' ? 'selected' : ''}>A</option>
+            <option value="B" ${assignment.suggestedAbo === 'B' ? 'selected' : ''}>B</option>
+            <option value="AB" ${assignment.suggestedAbo === 'AB' ? 'selected' : ''}>AB</option>
+          </select>
+          <select id="opt-rh-${idx}" class="form-select" style="width: 80px; display: inline;">
+            <option value="TBD">TBD</option>
+            <option value="Pos" ${assignment.suggestedRh === 'Pos' ? 'selected' : ''}>Pos</option>
+            <option value="Neg" ${assignment.suggestedRh === 'Neg' ? 'selected' : ''}>Neg</option>
+          </select>
+        </td>
+        <td>${assignment.source}</td>
+        <td>
+          <button class="btn btn-success btn-sm" onclick="acceptOptimization('${specKey}', ${idx})">
+            Accept
+          </button>
+        </td>
+      </tr>
+    `;
+        });
+
+        html += `
+        </tbody>
+      </table>
+    </div>
+    
+    <div class="mt-3">
+      <h5>Summary:</h5>
+      <p><strong>Units to order:</strong> ${optimized.unitsToOrder} (without sharing: ${
+          optimized.unitsWithoutSharing
+        })</p>
+      <p><strong>Savings:</strong> $${optimized.savings}</p>
+      <p><strong>Sharing sources used:</strong> ${optimized.sourcesUsed.join(', ')}</p>
+    </div>
+    
+    <div class="btn-group mt-3">
+      <button class="btn btn-primary" onclick="acceptAllOptimizations('${specKey}')">
+        Accept All Suggestions
+      </button>
+      <button class="btn btn-outline" onclick="saveVersion('${specKey}')">
+        Save as New Version
+      </button>
+    </div>
+  `;
+
+        contentDiv.innerHTML = html;
+        resultsCard.style.display = 'block';
+
+        // Store optimization results for later use
+        APP_STATE.lastOptimization = optimized;
+      }
+
+      function findAvailableBlood(customer, event, year) {
+        // This is a simplified version - you'd expand this with real calendar data
+        const scheduleEntry = APP_STATE.manufacturingCalendar.find(
+          (e) => e.description && e.description.includes(customer) && e.description.includes(event)
+        );
+
+        // Mock data for testing WSLH 1st 2026
+        return {
+          window: {
+            start: '2026-09-15',
+            end: '2026-10-05',
+          },
+          sources: [
+            { type: 'HQC-1', abo: 'AsubB', rh: 'Pos', volume: 77, date: '2026-09-28' },
+            { type: 'HQC-2', abo: 'O', rh: 'Pos', volume: 77, date: '2026-09-28' },
+            { type: 'HQC-3', abo: 'A', rh: 'Neg', volume: 77, date: '2026-09-28' },
+            { type: 'Korea-1', abo: 'A1', rh: 'Pos', volume: 22, date: '2026-09-15' },
+            { type: 'Korea-2', abo: 'B', rh: 'Pos', volume: 22, date: '2026-09-15' },
+            { type: 'Korea-3', abo: 'O', rh: 'Neg', volume: 22, date: '2026-09-15' },
+          ],
+        };
+      }
+
+      function runOptimization(specs, available) {
+        const metadata =
+          APP_STATE.futureSpecs.metadata[`${specs[0].customer}_${specs[0].event}_${specs[0].year}`];
+        const quantity = metadata?.quantity || 150;
+
+        const assignments = [];
+        const sourcesUsed = new Set();
+        let totalVolume = 0;
+        let sharedVolume = 0;
+
+        // Copy available sources to track usage
+        const availableCopy = JSON.parse(JSON.stringify(available.sources));
+
+        specs.forEach((spec) => {
+          // Get sample definition for volume calculation
+          const sampleDef = APP_STATE.sampleDefinitions.find(
+            (def) => def.sample_type_id === spec.sample_type_id
+          );
+
+          const volume = parseFloat(sampleDef?.fill_ml) || 2;
+          const hct = parseFloat(sampleDef?.hct_percent) || 4;
+          const volumeNeeded = quantity * volume * (hct / 100) * 1.1; // 10% overage
+
+          totalVolume += volumeNeeded;
+
+          // Find best match from available sources
+          let bestMatch = null;
+          let bestSource = null;
+
+          for (let source of availableCopy) {
+            if (source.volume >= volumeNeeded) {
+              bestMatch = { abo: source.abo, rh: source.rh };
+              bestSource = source.type;
+              source.volume -= volumeNeeded;
+              sharedVolume += volumeNeeded;
+              sourcesUsed.add(source.type);
+              break;
+            }
+          }
+
+          assignments.push({
+            sample_id: spec.sample_id,
+            sample_type_id: spec.sample_type_id,
+            volumeNeeded: volumeNeeded,
+            currentAbo: spec.abo,
+            currentRh: spec.rh,
+            suggestedAbo: bestMatch?.abo || 'TBD',
+            suggestedRh: bestMatch?.rh || 'TBD',
+            source: bestSource || 'NEW ORDER',
+          });
+        });
+
+        const unitsWithoutSharing = Math.ceil(totalVolume / 180);
+        const unitsToOrder = Math.ceil((totalVolume - sharedVolume) / 180);
+        const savings = (unitsWithoutSharing - unitsToOrder) * 450;
+
+        return {
+          assignments,
+          sourcesUsed: Array.from(sourcesUsed),
+          unitsToOrder,
+          unitsWithoutSharing,
+          savings,
+          totalVolume,
+          sharedVolume,
+        };
+      }
+
+      function acceptOptimization(specKey, index) {
+        const abo = document.getElementById(`opt-abo-${index}`).value;
+        const rh = document.getElementById(`opt-rh-${index}`).value;
+        const antigens = document.getElementById(`opt-antigens-${index}`).value.trim();
+        const assignment = APP_STATE.lastOptimization.assignments[index];
+
+        // Update the spec
+        const spec = APP_STATE.futureSpecs.entries.find(
+          (s) => s.sample_id === assignment.sample_id
+        );
+
+        if (spec) {
+          spec.abo = abo;
+          spec.rh = rh;
+          spec.antigens = antigens; // Add this line
+
+          // Update metadata
+          const metadata = APP_STATE.futureSpecs.metadata[specKey];
+          metadata.lastModified = new Date().toISOString();
+
+          showAlert(
+            'success',
+            `Updated ${assignment.sample_id} to ${abo} ${rh} ${
+              antigens ? 'with antigens: ' + antigens : ''
+            }`
+          );
+          updateFutureSpecsList();
+          autoSave();
+        }
+      }
+
+      function acceptAllOptimizations(specKey) {
+        if (!APP_STATE.lastOptimization) return;
+
+        APP_STATE.lastOptimization.assignments.forEach((assignment, idx) => {
+          const spec = APP_STATE.futureSpecs.entries.find(
+            (s) => s.sample_id === assignment.sample_id
+          );
+
+          if (spec && assignment.suggestedAbo !== 'TBD') {
+            spec.abo = assignment.suggestedAbo;
+            spec.rh = assignment.suggestedRh;
+          }
+        });
+
+        // Update version
+        const metadata = APP_STATE.futureSpecs.metadata[specKey];
+        metadata.currentVersion++;
+        metadata.lastModified = new Date().toISOString();
+
+        // Save new version
+        APP_STATE.futureSpecs.versions[`${specKey}_v${metadata.currentVersion}`] = {
+          timestamp: new Date().toISOString(),
+          samples: JSON.parse(
+            JSON.stringify(
+              APP_STATE.futureSpecs.entries.filter((s) => {
+                const [customer, event, year] = specKey.split('_');
+                return s.customer === customer && s.event === event && s.year == year;
+              })
+            )
+          ),
+        };
+
+        showAlert(
+          'success',
+          'All optimizations applied and saved as version ' + metadata.currentVersion
+        );
+        updateFutureSpecsList();
+        document.getElementById('optimization-results').style.display = 'none';
+        autoSave();
+      }
+
+      function closeOptimization() {
+        document.getElementById('optimization-results').style.display = 'none';
+      }
+
+      function viewFutureSpec(specKey) {
+        const [customer, event, year] = specKey.split('_');
+        let specs = APP_STATE.futureSpecs.entries.filter(
+          (s) => s.customer === customer && s.event === event && s.year == year
+        );
+
+        if (specs.length === 0) {
+          showAlert('error', 'No samples found for this specification');
+          return;
+        }
+
+        // Migrate data if needed
+        migrateFutureSpecsFormat();
+
+        // Re-fetch after migration
+        specs = APP_STATE.futureSpecs.entries.filter(
+          (s) => s.customer === customer && s.event === event && s.year == year
+        );
+
+        const modal = document.createElement('div');
+        modal.className = 'modal active';
+        modal.id = 'future-spec-edit-modal';
+
+        window.currentEditingSpecs = specs;
+
+        let tableRows = specs
+          .map((spec, idx) => {
+            const specId = `spec_${idx}`;
+
+            // Generate antigen rows
+            let antigenHTML = '<div class="antigen-container" id="antigens-' + specId + '">';
+            if (spec.antigens && spec.antigens.length > 0) {
+              spec.antigens.forEach((antigenObj, antIdx) => {
+                const elemId = generateElementId();
+                antigenHTML += `
+          <div class="antigen-row" id="${elemId}" style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
+            <select class="form-select" style="width: 100px;">
+              ${ANTIGEN_ORDER.map(
+                (a) =>
+                  `<option value="${a}" ${a === antigenObj.antigen ? 'selected' : ''}>${a}</option>`
+              ).join('')}
+            </select>
+            <select class="form-select" style="width: 100px;">
+              <option value="Positive" ${
+                antigenObj.status === 'Positive' ? 'selected' : ''
+              }>Positive</option>
+              <option value="Negative" ${
+                antigenObj.status === 'Negative' ? 'selected' : ''
+              }>Negative</option>
+            </select>
+            <button class="btn btn-danger btn-sm" onclick="removeAntigenRow('${elemId}')">×</button>
+          </div>
+        `;
+              });
+            }
+            antigenHTML += '</div>';
+            antigenHTML += `<button class="btn btn-outline btn-sm" onclick="addAntigenRow('antigens-${specId}')">+ Add Antigen</button>`;
+
+            // Generate antibody rows
+            let antibodyHTML = '<div class="antibody-container" id="antibodies-' + specId + '">';
+            if (spec.antibodies && spec.antibodies.length > 0) {
+              spec.antibodies.forEach((antibody, abIdx) => {
+                const elemId = generateElementId();
+                antibodyHTML += `
+          <div class="antibody-row" id="${elemId}" style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
+            <select class="form-select" style="width: 150px;">
+              ${AVAILABLE_ANTIBODIES.map(
+                (a) => `<option value="${a}" ${a === antibody ? 'selected' : ''}>${a}</option>`
+              ).join('')}
+            </select>
+            <button class="btn btn-danger btn-sm" onclick="removeAntibodyRow('${elemId}')">×</button>
+          </div>
+        `;
+              });
+            }
+            antibodyHTML += '</div>';
+            antibodyHTML += `<button class="btn btn-outline btn-sm" onclick="addAntibodyRow('antibodies-${specId}')">+ Add Antibody</button>`;
+
+            return `
+      <tr>
+        <td>${spec.sample_id}</td>
+        <td>${spec.sample_type_id}</td>
+        <td>
+          <select class="form-select" id="edit-abo-${idx}" style="width: 80px;">
+            <option value="TBD" ${spec.abo === 'TBD' ? 'selected' : ''}>TBD</option>
+            <option value="O" ${spec.abo === 'O' ? 'selected' : ''}>O</option>
+            <option value="A" ${spec.abo === 'A' ? 'selected' : ''}>A</option>
+            <option value="B" ${spec.abo === 'B' ? 'selected' : ''}>B</option>
+            <option value="AB" ${spec.abo === 'AB' ? 'selected' : ''}>AB</option>
+          </select>
+        </td>
+        <td>
+          <select class="form-select" id="edit-rh-${idx}" style="width: 80px;">
+            <option value="TBD" ${spec.rh === 'TBD' ? 'selected' : ''}>TBD</option>
+            <option value="Pos" ${spec.rh === 'Pos' ? 'selected' : ''}>Pos</option>
+            <option value="Neg" ${spec.rh === 'Neg' ? 'selected' : ''}>Neg</option>
+          </select>
+        </td>
+        <td style="min-width: 250px;">
+          ${antigenHTML}
+        </td>
+        <td style="min-width: 200px;">
+          ${antibodyHTML}
+        </td>
+        <td>
+          <select class="form-select" id="edit-dat-${idx}" style="width: 100px;">
+            <option value="Negative" ${
+              spec.dat_status !== 'Positive' ? 'selected' : ''
+            }>Negative</option>
+            <option value="Positive" ${
+              spec.dat_status === 'Positive' ? 'selected' : ''
+            }>Positive</option>
+          </select>
+        </td>
+      </tr>
+    `;
+          })
+          .join('');
+
+        modal.innerHTML = `
+    <div class="modal-content" style="max-width: 95%; width: 1400px;">
+      <div class="modal-header">
+        <h3 class="modal-title">Edit Future Specification: ${customer} ${event} ${year}</h3>
+        <button class="close-btn" onclick="closeFutureSpecModal()">×</button>
+      </div>
+      <div class="modal-body" style="max-height: 600px; overflow-y: auto;">
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                <th>Sample ID</th>
+                <th>Type</th>
+                <th>ABO</th>
+                <th>Rh</th>
+                <th>Antigens</th>
+                <th>Antibodies</th>
+                <th>DAT</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${tableRows}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-outline" onclick="closeFutureSpecModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="saveFutureSpecEdits('${specKey}', ${specs.length})">Save Changes</button>
+      </div>
+    </div>
+  `;
+
+        document.body.appendChild(modal);
+      }
+
+      function addAntigenRow(containerId) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        // Check for duplicates
+        const existingAntigens = [];
+        container.querySelectorAll('.antigen-row select:first-child').forEach((sel) => {
+          existingAntigens.push(sel.value);
+        });
+
+        // Find first unused antigen
+        let newAntigen = ANTIGEN_ORDER.find((a) => !existingAntigens.includes(a));
+        if (!newAntigen) {
+          showAlert('warning', 'All antigens have been added');
+          return;
+        }
+
+        const elemId = generateElementId();
+        const newRow = document.createElement('div');
+        newRow.className = 'antigen-row';
+        newRow.id = elemId;
+        newRow.style = 'display: flex; gap: 0.5rem; margin-bottom: 0.5rem;';
+        newRow.innerHTML = `
+    <select class="form-select" style="width: 100px;" onchange="validateAntigenDuplicates('${containerId}')">
+      ${ANTIGEN_ORDER.map(
+        (a) => `<option value="${a}" ${a === newAntigen ? 'selected' : ''}>${a}</option>`
+      ).join('')}
+    </select>
+    <select class="form-select" style="width: 100px;">
+      <option value="Positive">Positive</option>
+      <option value="Negative">Negative</option>
+    </select>
+    <button class="btn btn-danger btn-sm" onclick="removeAntigenRow('${elemId}')">×</button>
+  `;
+        container.appendChild(newRow);
+      }
+
+      function removeAntigenRow(elemId) {
+        const elem = document.getElementById(elemId);
+        if (elem) elem.remove();
+      }
+
+      function addAntibodyRow(containerId) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        // Check for duplicates
+        const existingAntibodies = [];
+        container.querySelectorAll('.antibody-row select').forEach((sel) => {
+          existingAntibodies.push(sel.value);
+        });
+
+        // Find first unused antibody
+        let newAntibody = AVAILABLE_ANTIBODIES.find((a) => !existingAntibodies.includes(a));
+        if (!newAntibody) {
+          showAlert('warning', 'All antibodies have been added');
+          return;
+        }
+
+        const elemId = generateElementId();
+        const newRow = document.createElement('div');
+        newRow.className = 'antibody-row';
+        newRow.id = elemId;
+        newRow.style = 'display: flex; gap: 0.5rem; margin-bottom: 0.5rem;';
+        newRow.innerHTML = `
+    <select class="form-select" style="width: 150px;" onchange="validateAntibodyDuplicates('${containerId}')">
+      ${AVAILABLE_ANTIBODIES.map(
+        (a) => `<option value="${a}" ${a === newAntibody ? 'selected' : ''}>${a}</option>`
+      ).join('')}
+    </select>
+    <button class="btn btn-danger btn-sm" onclick="removeAntibodyRow('${elemId}')">×</button>
+  `;
+        container.appendChild(newRow);
+      }
+
+      function removeAntibodyRow(elemId) {
+        const elem = document.getElementById(elemId);
+        if (elem) elem.remove();
+      }
+
+      function validateAntigenDuplicates(containerId) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        const antigens = [];
+        const selects = container.querySelectorAll('.antigen-row select:first-child');
+
+        selects.forEach((sel) => {
+          if (antigens.includes(sel.value)) {
+            showAlert(
+              'warning',
+              `Duplicate antigen ${sel.value} detected. Please remove or change one.`
+            );
+            // Find first unused antigen
+            const unused = ANTIGEN_ORDER.find((a) => !antigens.includes(a));
+            if (unused) sel.value = unused;
+          } else {
+            antigens.push(sel.value);
+          }
+        });
+      }
+
+      function validateAntibodyDuplicates(containerId) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        const antibodies = [];
+        const selects = container.querySelectorAll('.antibody-row select');
+
+        selects.forEach((sel) => {
+          if (antibodies.includes(sel.value)) {
+            showAlert(
+              'warning',
+              `Duplicate antibody ${sel.value} detected. Please remove or change one.`
+            );
+            // Find first unused antibody
+            const unused = AVAILABLE_ANTIBODIES.find((a) => !antibodies.includes(a));
+            if (unused) sel.value = unused;
+          } else {
+            antibodies.push(sel.value);
+          }
+        });
+      }
+
+      function closeFutureSpecModal() {
+        const modal = document.getElementById('future-spec-edit-modal');
+        if (modal) modal.remove();
+        window.currentEditingSpecs = null;
+      }
+
+      function saveFutureSpecEdits(specKey, specCount) {
+        const [customer, event, year] = specKey.split('_');
+        const specs = APP_STATE.futureSpecs.entries.filter(
+          (s) => s.customer === customer && s.event === event && s.year == year
+        );
+
+        // Update each spec with edited values
+        specs.forEach((spec, idx) => {
+          spec.abo = document.getElementById(`edit-abo-${idx}`).value;
+          spec.rh = document.getElementById(`edit-rh-${idx}`).value;
+          spec.dat_status = document.getElementById(`edit-dat-${idx}`).value;
+
+          // Collect antigens
+          spec.antigens = [];
+          const antigenContainer = document.getElementById(`antigens-spec_${idx}`);
+          if (antigenContainer) {
+            antigenContainer.querySelectorAll('.antigen-row').forEach((row) => {
+              const antigenSelect = row.querySelector('select:first-child');
+              const statusSelect = row.querySelector('select:last-child');
+              if (antigenSelect && statusSelect) {
+                spec.antigens.push({
+                  antigen: antigenSelect.value,
+                  status: statusSelect.value,
+                });
+              }
+            });
+          }
+
+          // Collect antibodies
+          spec.antibodies = [];
+          const antibodyContainer = document.getElementById(`antibodies-spec_${idx}`);
+          if (antibodyContainer) {
+            antibodyContainer.querySelectorAll('.antibody-row select').forEach((sel) => {
+              spec.antibodies.push(sel.value);
+            });
+          }
+        });
+
+        // Update metadata
+        const metadata = APP_STATE.futureSpecs.metadata[specKey];
+        metadata.lastModified = new Date().toISOString();
+        metadata.currentVersion++;
+
+        // Save new version
+        APP_STATE.futureSpecs.versions[`${specKey}_v${metadata.currentVersion}`] = {
+          timestamp: new Date().toISOString(),
+          samples: JSON.parse(JSON.stringify(specs)),
+        };
+
+        // Close modal
+        closeFutureSpecModal();
+
+        showAlert(
+          'success',
+          `Saved changes to ${customer} ${event} ${year} (Version ${metadata.currentVersion})`
+        );
+        updateFutureSpecsList();
+        autoSave();
+      }
+
+      function approveFutureSpec(specKey) {
+        const metadata = APP_STATE.futureSpecs.metadata[specKey];
+
+        if (metadata.status === 'approved') {
+          if (confirm('This spec was already approved. Are you sure you want to unapprove it?')) {
+            metadata.status = 'draft';
+            showAlert('warning', 'Specification unapproved');
+          }
+        } else {
+          metadata.status = 'approved';
+          showAlert('success', 'Specification approved for production');
+        }
+
+        updateFutureSpecsList();
+        autoSave();
+      }
+
+      function deleteFutureSpec(specKey) {
+        if (!confirm('Are you sure you want to delete this future specification?')) {
+          return;
+        }
+
+        const [customer, event, year] = specKey.split('_');
+
+        // Remove entries
+        APP_STATE.futureSpecs.entries = APP_STATE.futureSpecs.entries.filter(
+          (s) => !(s.customer === customer && s.event === event && s.year == year)
+        );
+
+        // Remove metadata
+        delete APP_STATE.futureSpecs.metadata[specKey];
+
+        // Keep versions for history
+
+        showAlert('success', 'Future specification deleted');
+        updateFutureSpecsList();
+        autoSave();
+      }
+
+      function saveVersion(specKey) {
+        const metadata = APP_STATE.futureSpecs.metadata[specKey];
+        metadata.currentVersion++;
+
+        const [customer, event, year] = specKey.split('_');
+        const currentSpecs = APP_STATE.futureSpecs.entries.filter(
+          (s) => s.customer === customer && s.event === event && s.year == year
+        );
+
+        APP_STATE.futureSpecs.versions[`${specKey}_v${metadata.currentVersion}`] = {
+          timestamp: new Date().toISOString(),
+          samples: JSON.parse(JSON.stringify(currentSpecs)),
+        };
+
+        showAlert('success', `Saved as version ${metadata.currentVersion}`);
+        updateFutureSpecsList();
+        autoSave();
+      }
+    </script>
+  </body>
+</html>

--- a/Blood Optimization Platform - v0.4.4.html
+++ b/Blood Optimization Platform - v0.4.4.html
@@ -3308,6 +3308,7 @@
         ],
         Shipping: [
           { value: 'external-testing', label: 'External Testing Ship' },
+          // Only keep the dual-date shipment option to avoid legacy single-date entries
           { value: 'blood-shipment', label: 'Blood Shipment' },
         ],
         Administrative: [

--- a/Blood Optimization Platform - v0.4.4.html
+++ b/Blood Optimization Platform - v0.4.4.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blood Optimization Platform v0.4.3 - Megedition | Hemo bioscience</title>
+    <title>Blood Optimization Platform v0.4.4 - Megedition | Hemo bioscience</title>
     <style>
       * {
         margin: 0;
@@ -1730,7 +1730,7 @@
       <!-- Header Bar -->
       <header class="header-bar">
         <div class="header-left">
-          <div class="version-badge">v0.4.3 - Megedition</div>
+          <div class="version-badge">v0.4.4 - Megedition</div>
           <div class="active-users" id="active-users" style="display: none">
             <span>👤 Active:</span>
             <span id="active-user-list">-</span>
@@ -3224,7 +3224,7 @@
       // ===============================
 
       const APP_STATE = {
-        version: '0.4.3', // Update version
+        version: '0.4.4', // Update version
         customers: [],
         sampleDefinitions: [],
         customerSpecs: [],
@@ -3308,9 +3308,7 @@
         ],
         Shipping: [
           { value: 'external-testing', label: 'External Testing Ship' },
-          { value: 'blood-shipment', label: 'Blood Shipment (Ship/Arrival)' },
-          { value: 'blood-arrival', label: 'Blood Arrival' },
-          { value: 'shipment', label: 'Shipment' },
+          { value: 'blood-shipment', label: 'Blood Shipment' },
         ],
         Administrative: [
           { value: 'timesheets', label: 'Timesheets Due' },


### PR DESCRIPTION
## Summary
- bump the platform HTML to v0.4.2 and update the visible version metadata
- remove the legacy manual calendar entry and import card from the manufacturing calendar panel
- convert the calendar modal into an "Add Event" flow with delete support plus supporting JavaScript helpers for opening, closing, saving, and deleting events
- move the editingCalendarEntryId state to the top-level script scope to prevent a ReferenceError when opening the add-event modal
- trigger renderCalendar() whenever the calendar panel is activated so it no longer appears blank on first load

## Testing
- not run (HTML change only)

------
https://chatgpt.com/codex/tasks/task_e_68d17bed6fcc832da1a19e490c1f3853