### PR TITLE
Bump UI version to v0.7.7 and decouple dropdown initialization

### DIFF
--- a/Blood Optimization Platform - v0.7.6.html
+++ b/Blood Optimization Platform - v0.7.6.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blood Optimization Platform v0.7.6 | Hemo bioscience</title>
+    <title>Blood Optimization Platform v0.7.7 | Hemo bioscience</title>
     <style>
       * {
         margin: 0;
@@ -1853,7 +1853,7 @@
       <!-- Header Bar -->
       <header class="header-bar">
         <div class="header-left">
-        <div class="version-badge">v0.7.6</div>
+        <div class="version-badge">v0.7.7</div>
           <div class="active-users" id="active-users" style="display: none">
             <span>👤 Active:</span>
             <span id="active-user-list">-</span>
@@ -7261,32 +7261,6 @@
             select.value = '';
           }
         });
-
-        if (typeof updateFutureCopyOptions === 'function') {
-          updateFutureCopyOptions();
-        }
-        if (typeof updateYearOptions === 'function') {
-          updateYearOptions();
-        }
-        if (typeof updateEventOptions === 'function') {
-          updateEventOptions();
-        }
-        if (typeof updateSampleOptions === 'function') {
-          updateSampleOptions();
-        }
-
-        if (typeof filterQuantities === 'function') {
-          filterQuantities();
-        }
-        if (typeof filterHistoricalQuantities === 'function') {
-          filterHistoricalQuantities();
-        }
-        if (typeof filterSpecs === 'function') {
-          filterSpecs();
-        }
-        if (typeof updateBUPEventList === 'function') {
-          updateBUPEventList();
-        }
       }
 
       // ===============================


### PR DESCRIPTION
## Summary
- update the displayed version to v0.7.7 in the HTML title and badge
- remove chained UI update calls from populateCustomerDropdowns so it only fills dropdown options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc31458f4c832d882cc7229f3c473b