### PR TITLE
Implement v1.0.1 forecasting and BUP enhancements

### DIFF
--- a/Blood Optimization Platform - v1.0.1.html
+++ b/Blood Optimization Platform - v1.0.1.html
@@ -1,0 +1,17808 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blood Optimization Platform v1.0.1 | Hemo bioscience</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      :root {
+        --hemo-blue: #0073cf;
+        --hemo-blue-dark: #005299;
+        --hemo-blue-light: #e6f2ff;
+        --hemo-blue-lighter: #f0f8ff;
+        --success: #16a34a;
+        --warning: #f59e0b;
+        --danger: #dc2626;
+        --info: #3b82f6;
+        --dark: #1f2937;
+        --gray: #6b7280;
+        --gray-light: #9ca3af;
+        --light: #f9fafb;
+        --border: #e5e7eb;
+        --white: #ffffff;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
+      }
+
+      /* Dark mode variables */
+      [data-theme='dark'] {
+        --dark: #f9fafb;
+        --gray: #d1d5db;
+        --gray-light: #9ca3af;
+        --light: #1f2937;
+        --border: #374151;
+        --white: #111827;
+        --hemo-blue-light: #1a3a52;
+        --hemo-blue-lighter: #0f2536;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.3);
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+          sans-serif;
+        background: var(--light);
+        color: var(--dark);
+        line-height: 1.6;
+        transition: background 0.3s ease, color 0.3s ease;
+      }
+
+      /* Layout */
+      .app-container {
+        display: flex;
+        height: 100vh;
+      }
+
+      /* Header Bar */
+      .header-bar {
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 280px;
+        background: var(--white);
+        padding: 0.75rem 2rem;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        z-index: 100;
+        transition: all 0.3s ease;
+      }
+
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .version-badge {
+        background: var(--hemo-blue-light);
+        color: var(--hemo-blue);
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.875rem;
+        font-weight: 500;
+      }
+
+      .header-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .storage-status {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+        color: var(--gray);
+      }
+
+      .storage-status .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--warning);
+        animation: pulse 2s infinite;
+      }
+
+      .storage-status.connected .dot {
+        background: var(--success);
+        animation: none;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+
+        50% {
+          opacity: 0.5;
+        }
+      }
+
+      .user-info {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 8px;
+        font-size: 0.875rem;
+      }
+
+      .user-avatar {
+        width: 28px;
+        height: 28px;
+        background: var(--hemo-blue);
+        color: white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+      }
+
+      .active-users {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.375rem 0.75rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        color: var(--gray);
+      }
+
+      /* Theme Toggle */
+      .theme-toggle {
+        background: var(--hemo-blue-lighter);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        padding: 4px;
+        cursor: pointer;
+        width: 60px;
+        height: 32px;
+        position: relative;
+        transition: all 0.3s ease;
+      }
+
+      .theme-toggle-slider {
+        position: absolute;
+        width: 24px;
+        height: 24px;
+        background: var(--white);
+        border-radius: 50%;
+        transition: transform 0.3s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+
+      [data-theme='dark'] .theme-toggle-slider {
+        transform: translateX(28px);
+      }
+
+      /* Sidebar */
+      .sidebar {
+        width: 280px;
+        background: var(--white);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        position: fixed;
+        height: 100vh;
+        transition: all 0.3s ease;
+        overflow-y: auto;
+        z-index: 200; /* ADD THIS LINE */
+      }
+
+      .sidebar-header {
+        padding: 1.5rem;
+        border-bottom: 1px solid var(--border);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .logo {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .logo-icon {
+        width: 48px;
+        height: 48px;
+        background: var(--hemo-blue);
+        color: white;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        font-weight: bold;
+        box-shadow: 0 4px 12px rgba(0, 115, 207, 0.2);
+      }
+
+      .logo-text {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .logo-main {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      .logo-sub {
+        font-size: 0.75rem;
+        color: var(--gray);
+        font-style: italic;
+      }
+
+      .nav-menu {
+        flex: 1;
+        padding: 1rem 0;
+        overflow-y: auto;
+      }
+
+      .nav-section {
+        margin-bottom: 1.5rem;
+      }
+
+      .nav-section-title {
+        padding: 0.5rem 1.5rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--gray-light);
+      }
+
+      .nav-item {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 1.5rem;
+        color: var(--gray);
+        text-decoration: none;
+        transition: all 0.2s;
+        cursor: pointer;
+        border: none;
+        background: none;
+        width: 100%;
+        text-align: left;
+        font-size: 0.95rem;
+      }
+
+      .nav-item:hover {
+        background: var(--hemo-blue-lighter);
+        color: var(--dark);
+      }
+
+      .nav-item.active {
+        background: var(--hemo-blue-light);
+        color: var(--hemo-blue);
+        border-left: 3px solid var(--hemo-blue);
+        font-weight: 500;
+      }
+
+      .nav-item.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .nav-item.placeholder {
+        font-style: italic;
+        opacity: 0.7;
+      }
+
+      .nav-icon {
+        width: 20px;
+        text-align: center;
+      }
+
+      /* Main Content */
+      .main-content {
+        flex: 1;
+        margin-left: 280px;
+        margin-top: 60px;
+        overflow-y: auto;
+        background: var(--light);
+        transition: all 0.3s ease;
+      }
+
+      .content-header {
+        background: var(--white);
+        padding: 1.5rem 2rem;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .content-title {
+        font-size: 1.75rem;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        color: var(--dark);
+      }
+
+      .content-subtitle {
+        color: var(--gray);
+        font-size: 0.95rem;
+      }
+
+      .content-body {
+        padding: 2rem;
+      }
+
+      /* Panels */
+      .panel {
+        display: none;
+      }
+
+      .panel.active {
+        display: block;
+        animation: fadeIn 0.3s ease;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Cards */
+      .card {
+        background: var(--white);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      .card:hover {
+        box-shadow: var(--shadow-lg);
+      }
+
+      .card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+      }
+
+      .card-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      /* Tabs */
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        border-bottom: 2px solid var(--border);
+        margin-bottom: 1.5rem;
+        overflow-x: auto;
+      }
+
+      .tab {
+        padding: 0.75rem 1.25rem;
+        background: none;
+        border: none;
+        color: var(--gray);
+        font-size: 0.95rem;
+        cursor: pointer;
+        border-bottom: 3px solid transparent;
+        margin-bottom: -2px;
+        transition: all 0.2s;
+        white-space: nowrap;
+      }
+
+      .tab:hover {
+        color: var(--dark);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .tab.active {
+        color: var(--hemo-blue);
+        border-bottom-color: var(--hemo-blue);
+        font-weight: 500;
+      }
+
+      .tab-content {
+        display: none;
+      }
+
+      .tab-content.active {
+        display: block;
+      }
+
+      /* Forms */
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1rem;
+      }
+
+      .form-group {
+        margin-bottom: 1rem;
+      }
+
+      .form-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--dark);
+        margin-bottom: 0.5rem;
+      }
+
+      .form-label .required {
+        color: var(--danger);
+      }
+
+      .form-input,
+      .form-select,
+      .form-textarea {
+        width: 100%;
+        padding: 0.625rem;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-size: 0.95rem;
+        transition: all 0.2s;
+        background: var(--white);
+        color: var(--dark);
+      }
+
+      .form-input:focus,
+      .form-select:focus,
+      .form-textarea:focus {
+        outline: none;
+        border-color: var(--hemo-blue);
+        box-shadow: 0 0 0 3px rgba(0, 115, 207, 0.1);
+      }
+
+      .form-textarea {
+        resize: vertical;
+        min-height: 100px;
+      }
+
+      .form-hint {
+        font-size: 0.8125rem;
+        color: var(--gray-light);
+        margin-top: 0.25rem;
+      }
+      .sample-input-wrapper {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      .sample-input-wrapper > div {
+        flex: 1;
+      }
+
+      .date-display {
+        margin-top: 1.5rem;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        background: var(--white);
+      }
+
+      .date-display-header {
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+        color: var(--dark);
+      }
+
+      .date-display-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }
+
+      .date-display-item {
+        padding: 0.75rem;
+        border-radius: 6px;
+        background: var(--hemo-blue-lighter);
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .date-label {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--gray);
+      }
+
+      .date-value {
+        font-size: 1.0625rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      .sharing-results {
+        margin-top: 1.5rem;
+      }
+
+      .sharing-results table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .sharing-results th,
+      .sharing-results td {
+        padding: 0.75rem;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+      }
+
+      .sharing-results tbody tr:hover {
+        background: var(--hemo-blue-lighter);
+      }
+
+
+      /* Buttons */
+      .btn {
+        padding: 0.625rem 1.25rem;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
+
+      .btn:active {
+        transform: translateY(0);
+      }
+
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .btn-primary {
+        background: var(--hemo-blue);
+        color: white;
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        background: var(--hemo-blue-dark);
+      }
+
+      .btn-success {
+        background: var(--success);
+        color: white;
+      }
+
+      .btn-danger {
+        background: var(--danger);
+        color: white;
+      }
+
+      .btn-warning {
+        background: var(--warning);
+        color: white;
+      }
+
+      .btn-secondary {
+        background: var(--gray);
+        color: white;
+      }
+
+      .btn-outline {
+        background: var(--white);
+        border: 1px solid var(--border);
+        color: var(--dark);
+      }
+
+      .btn-outline:hover {
+        background: var(--hemo-blue-lighter);
+        border-color: var(--hemo-blue);
+        color: var(--hemo-blue);
+      }
+
+      .btn-sm {
+        padding: 0.375rem 0.875rem;
+        font-size: 0.8125rem;
+      }
+
+      .btn-group {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      /* Tables */
+      .table-container {
+        overflow-x: auto;
+        background: var(--white);
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th {
+        background: var(--hemo-blue-lighter);
+        padding: 0.875rem;
+        text-align: left;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--dark);
+        border-bottom: 2px solid var(--border);
+        white-space: nowrap;
+      }
+
+      td {
+        padding: 0.875rem;
+        border-bottom: 1px solid var(--border);
+        font-size: 0.875rem;
+        color: var(--dark);
+      }
+
+      tbody tr:hover {
+        background: var(--hemo-blue-lighter);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      .table-pagination {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: 0.75rem;
+        background: var(--white);
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+      }
+
+      .table-pagination .pagination-group {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .table-pagination .pagination-info {
+        color: var(--gray);
+        font-size: 0.875rem;
+      }
+
+      .table-pagination button[disabled] {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      /* File Upload */
+      .upload-area {
+        border: 2px dashed var(--border);
+        border-radius: 8px;
+        padding: 2rem;
+        text-align: center;
+        transition: all 0.2s;
+        cursor: pointer;
+        margin-bottom: 1rem;
+        background: var(--white);
+      }
+
+      .upload-area:hover {
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .upload-area.dragging {
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-light);
+      }
+
+      .upload-input {
+        display: none;
+      }
+
+      .upload-icon {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+        color: var(--hemo-blue);
+      }
+
+      /* Metrics */
+      .metrics-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .metric-card {
+        background: var(--white);
+        padding: 1.5rem;
+        border-radius: 12px;
+        border-left: 4px solid var(--hemo-blue);
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      .metric-card:hover {
+        box-shadow: var(--shadow-lg);
+        transform: translateY(-2px);
+      }
+
+      .metric-value {
+        font-size: 2rem;
+        font-weight: bold;
+        color: var(--hemo-blue);
+      }
+
+      .metric-label {
+        font-size: 0.875rem;
+        color: var(--gray);
+        margin-top: 0.25rem;
+      }
+
+      .metric-change {
+        font-size: 0.8125rem;
+        margin-top: 0.5rem;
+      }
+
+      #top-antibodies-list {
+        margin: 0;
+      }
+
+      #top-antibodies-list ol {
+        margin: 0;
+        padding-left: 1.25rem;
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .case-study-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .case-study-list.empty {
+        margin-bottom: 0.5rem;
+      }
+
+      .case-study-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 10px;
+        background: var(--hemo-blue-lighter);
+        border: 1px solid var(--border);
+        transition: border-color 0.2s ease, background 0.2s ease;
+      }
+
+      .case-study-item.completed {
+        background: var(--light);
+        border-color: rgba(99, 102, 241, 0.15);
+      }
+
+      .case-study-item.overdue:not(.completed) {
+        border-color: var(--danger);
+      }
+
+      .case-study-main {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        flex: 1;
+      }
+
+      .case-study-label {
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        font-weight: 600;
+      }
+
+      .case-study-description {
+        display: inline-block;
+      }
+
+      .case-study-item.completed .case-study-description {
+        text-decoration: line-through;
+        color: var(--gray);
+      }
+
+      .case-study-item.overdue:not(.completed) .case-study-description {
+        color: var(--danger);
+      }
+
+      .case-study-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        font-size: 0.85rem;
+        color: var(--gray);
+      }
+
+      .case-study-status {
+        font-weight: 600;
+      }
+
+      .case-study-item.completed .case-study-status {
+        color: var(--success);
+      }
+
+      .case-study-item.overdue:not(.completed) .case-study-status,
+      .case-study-item.overdue:not(.completed) .case-study-date {
+        color: var(--danger);
+      }
+
+      .case-study-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-end;
+      }
+
+      .case-study-form .form-group {
+        flex: 1 1 220px;
+        margin-bottom: 0;
+      }
+
+      .case-study-description-group {
+        flex: 2 1 280px;
+      }
+
+      .case-study-form button {
+        white-space: nowrap;
+      }
+
+      .metric-change.positive {
+        color: var(--success);
+      }
+
+      .metric-change.negative {
+        color: var(--danger);
+      }
+
+      /* Status Messages */
+      .alert {
+        padding: 1rem;
+        border-radius: 6px;
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        animation: slideIn 0.3s ease;
+      }
+
+      @keyframes slideIn {
+        from {
+          transform: translateX(-20px);
+          opacity: 0;
+        }
+
+        to {
+          transform: translateX(0);
+          opacity: 1;
+        }
+      }
+
+      .alert-success {
+        background: #dcfce7;
+        color: #166534;
+        border-left: 4px solid var(--success);
+      }
+
+      .alert-warning {
+        background: #fef3c7;
+        color: #92400e;
+        border-left: 4px solid var(--warning);
+      }
+
+      .alert-error {
+        background: #fee2e2;
+        color: #991b1b;
+        border-left: 4px solid var(--danger);
+      }
+
+      .alert-info {
+        background: var(--hemo-blue-lighter);
+        color: var(--hemo-blue);
+        border-left: 4px solid var(--hemo-blue);
+      }
+
+      /* Blood Type Tags */
+      .blood-tag {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin-right: 0.25rem;
+      }
+
+      .blood-tag.o-pos {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .blood-tag.o-neg {
+        background: #fef2f2;
+        color: #7f1d1d;
+      }
+
+      .blood-tag.a-pos {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+
+      .blood-tag.a-neg {
+        background: #e0e7ff;
+        color: #312e81;
+      }
+
+      .blood-tag.b-pos {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .blood-tag.b-neg {
+        background: #f0fdf4;
+        color: #14532d;
+      }
+
+      .blood-tag.ab-pos {
+        background: #f3e8ff;
+        color: #581c87;
+      }
+
+      .blood-tag.ab-neg {
+        background: #faf5ff;
+        color: #4c1d95;
+      }
+
+      /* Status Tags */
+      .status-tag {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.8125rem;
+        font-weight: 500;
+      }
+
+      .status-tag.available {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .status-tag.limited {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      .status-tag.discontinued {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      /* Customer Cards */
+      .customer-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .customer-card {
+        background: var(--white);
+        padding: 1.25rem;
+        padding-top: 2.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        transition: all 0.2s;
+        position: relative;
+        min-height: 120px;
+      }
+
+      .customer-card:hover {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        transform: translateY(-2px);
+        border-color: var(--hemo-blue);
+      }
+
+      .customer-header {
+        margin-bottom: 1rem;
+      }
+
+      .customer-name {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+        margin-bottom: 0.25rem;
+      }
+
+      .customer-code {
+        font-size: 0.875rem;
+        color: var(--gray);
+        font-family: monospace;
+      }
+
+      .customer-info {
+        font-size: 0.875rem;
+        color: var(--gray);
+        margin-bottom: 0.5rem;
+      }
+
+      .customer-contacts {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border);
+      }
+
+      .contact-item {
+        display: flex;
+        gap: 0.5rem;
+        font-size: 0.8125rem;
+        margin-bottom: 0.25rem;
+      }
+
+      .customer-actions {
+        position: absolute;
+        top: 0.75rem;
+        right: 0.75rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .customer-actions button {
+        padding: 0.375rem;
+        background: var(--white);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        cursor: pointer;
+        color: var(--gray);
+        transition: all 0.2s;
+        font-size: 0.875rem;
+      }
+
+      .customer-actions button:hover {
+        color: var(--hemo-blue);
+        border-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      /* Antibody Tables */
+      #antibody-specificity-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      #antibody-specificity-table tbody tr {
+        cursor: pointer;
+      }
+
+      #antibody-specificity-table tbody tr.expanded {
+        background: var(--hemo-blue-lighter);
+      }
+
+      .specificity-summary {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .specificity-summary span {
+        font-size: 0.8125rem;
+        color: var(--gray);
+      }
+
+      .row-actions {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .expand-indicator {
+        margin-right: 0.5rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      .lot-detail-row {
+        background: var(--hemo-blue-lighter);
+      }
+
+      .lot-detail-cell {
+        padding: 0;
+        border-bottom: none;
+      }
+
+      .lot-table-wrapper {
+        padding: 1rem 1.5rem 1.5rem;
+        background: var(--white);
+        border-radius: 0 0 8px 8px;
+        box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.05);
+      }
+
+      .lot-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .lot-table thead th {
+        background: var(--hemo-blue);
+        color: var(--white);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .lot-table tbody tr {
+        cursor: default;
+      }
+
+      .lot-table td,
+      .lot-table th {
+        padding: 0.75rem;
+        font-size: 0.8125rem;
+      }
+
+      .lot-actions {
+        display: flex;
+        gap: 0.25rem;
+      }
+
+      .history-list {
+        margin-top: 0.75rem;
+        padding: 0.75rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 6px;
+        font-size: 0.75rem;
+      }
+
+      .history-list h4 {
+        margin-bottom: 0.5rem;
+        font-size: 0.75rem;
+        color: var(--hemo-blue-dark);
+      }
+
+      .cost-value {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      /* Modals */
+      .modal {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1000;
+        animation: fadeIn 0.2s ease;
+      }
+
+      .modal.active {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .modal-content {
+        background: var(--white);
+        border-radius: 12px;
+        max-width: 700px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+        animation: slideUp 0.3s ease;
+      }
+
+      @keyframes slideUp {
+        from {
+          transform: translateY(20px);
+          opacity: 0;
+        }
+
+        to {
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+
+      .modal-header {
+        padding: 1.5rem;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--hemo-blue-lighter);
+      }
+
+      .modal-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      .modal-body {
+        padding: 1.5rem;
+      }
+
+      .modal-footer {
+        padding: 1rem 1.5rem;
+        border-top: 1px solid var(--border);
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        background: var(--light);
+      }
+
+      .optimization-popover {
+        position: absolute;
+        background: var(--white);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow: var(--shadow-lg);
+        padding: 1rem;
+        width: 350px;
+        z-index: 1100;
+        display: none;
+      }
+
+      .optimization-suggestion {
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 0.75rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .optimization-suggestion:last-child {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+
+      .suggestion-header {
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      .suggestion-details {
+        font-size: 0.875rem;
+        color: var(--gray);
+        margin: 0.25rem 0;
+      }
+
+      .row-flash-success {
+        animation: rowFlashSuccess 1.5s ease forwards;
+      }
+
+      @keyframes rowFlashSuccess {
+        0% {
+          background: rgba(22, 163, 74, 0.2);
+        }
+
+        100% {
+          background: transparent;
+        }
+      }
+
+      .close-btn {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: var(--gray);
+        transition: color 0.2s;
+      }
+
+      .close-btn:hover {
+        color: var(--hemo-blue);
+      }
+
+      /* Setup Wizard Modal */
+      .setup-modal {
+        z-index: 2000;
+      }
+
+      .setup-steps {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 2rem;
+        padding: 1rem;
+        background: var(--light);
+        border-radius: 8px;
+      }
+
+      .setup-step {
+        flex: 1;
+        text-align: center;
+        padding: 0.5rem;
+        position: relative;
+      }
+
+      .setup-step:not(:last-child)::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: -50%;
+        width: 100%;
+        height: 2px;
+        background: var(--border);
+      }
+
+      .setup-step.active .step-number {
+        background: var(--hemo-blue);
+        color: white;
+      }
+
+      .setup-step.completed .step-number {
+        background: var(--success);
+        color: white;
+      }
+
+      .step-number {
+        width: 32px;
+        height: 32px;
+        background: var(--border);
+        color: var(--gray);
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 0.5rem;
+        font-weight: 600;
+      }
+
+      .step-label {
+        font-size: 0.875rem;
+        color: var(--gray);
+      }
+
+      .setup-step.active .step-label {
+        color: var(--dark);
+        font-weight: 500;
+      }
+
+      .setup-content {
+        min-height: 200px;
+      }
+
+      /* Instructions Panel */
+      .instructions-panel {
+        max-height: 400px;
+        overflow-y: auto;
+        background: var(--light);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .instructions-panel h4 {
+        color: var(--hemo-blue);
+        margin-top: 1rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .instructions-panel ul {
+        margin-left: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .instructions-panel li {
+        margin-bottom: 0.25rem;
+      }
+
+      /* Activity Log */
+      .activity-item {
+        display: flex;
+        gap: 1rem;
+        padding: 0.75rem;
+        border-left: 3px solid var(--hemo-blue-lighter);
+        margin-bottom: 0.5rem;
+        background: var(--white);
+        border-radius: 4px;
+        transition: all 0.2s;
+      }
+
+      .activity-item:hover {
+        border-left-color: var(--hemo-blue);
+        background: var(--hemo-blue-lighter);
+      }
+
+      .activity-time {
+        font-size: 0.8125rem;
+        color: var(--gray-light);
+        min-width: 80px;
+      }
+
+      .activity-user {
+        font-weight: 500;
+        color: var(--hemo-blue);
+        min-width: 100px;
+      }
+
+      .activity-action {
+        flex: 1;
+        color: var(--dark);
+      }
+
+      /* Calculation Results */
+      .calculation-results {
+        margin-top: 1.5rem;
+        padding: 1rem;
+        background: var(--hemo-blue-lighter);
+        border-radius: 8px;
+        border: 1px solid var(--hemo-blue);
+      }
+
+      .result-item {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem 0;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .result-item:last-child {
+        border-bottom: none;
+      }
+
+      .result-label {
+        font-weight: 500;
+        color: var(--dark);
+      }
+
+      .result-value {
+        font-weight: 600;
+        color: var(--hemo-blue);
+      }
+
+      /* Sharing Window Display */
+      .sharing-window-display {
+        background: var(--hemo-blue-lighter);
+        border-left: 4px solid var(--hemo-blue);
+        padding: 1rem;
+        margin: 1rem 0;
+        border-radius: 4px;
+      }
+
+      .sharing-window-display h4 {
+        margin-bottom: 0.5rem;
+        color: var(--hemo-blue);
+      }
+
+      .sharing-window-dates {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+        margin-top: 0.5rem;
+      }
+
+      .sharing-date-item {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .sharing-date-label {
+        font-size: 0.75rem;
+        color: var(--gray);
+        margin-bottom: 0.25rem;
+      }
+
+      .sharing-date-value {
+        font-weight: 600;
+        color: var(--dark);
+      }
+
+      /* Calendar */
+      .calendar-container {
+        background: var(--white);
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: var(--shadow);
+      }
+
+      .calendar-header {
+        background: var(--hemo-blue);
+        color: white;
+        padding: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .calendar-nav {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .calendar-nav button {
+        background: none;
+        border: none;
+        color: white;
+        cursor: pointer;
+        font-size: 1.25rem;
+      }
+
+      .calendar-grid {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+      }
+
+      .calendar-weekday {
+        background: var(--hemo-blue-lighter);
+        padding: 0.5rem;
+        text-align: center;
+        font-weight: 600;
+        font-size: 0.875rem;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .calendar-day {
+        min-height: 100px;
+        padding: 0.5rem;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        position: relative;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .calendar-day:hover {
+        background: var(--hemo-blue-lighter);
+      }
+
+      .calendar-day-number {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+
+      .calendar-event {
+        font-size: 0.75rem;
+        padding: 0.125rem 0.25rem;
+        margin-bottom: 0.125rem;
+        border-radius: 3px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .calendar-event.standing-order {
+        background: var(--hemo-blue-lighter);
+        color: var(--hemo-blue);
+      }
+
+      .calendar-event.blood-arrival {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .calendar-event.shipment {
+        background: #dcfce7;
+        color: #166534;
+      }
+      /* Calendar Event Colors by Category */
+      .calendar-event.bulk-event,
+      .calendar-event.fill-event,
+      .calendar-event.wash-rbcs,
+      .calendar-event.coat-rbcs,
+      .calendar-event.setup-event {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+
+      .calendar-event.external-testing,
+      .calendar-event.blood-arrival,
+      .calendar-event.shipment {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .calendar-event.timesheets,
+      .calendar-event.case-study {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      .calendar-event.label-event {
+        background: #f3e8ff;
+        color: #581c87;
+      }
+
+      .calendar-event.conference {
+        background: #e5e7eb;
+        color: #374151;
+      }
+
+      .calendar-event.pto,
+      .calendar-event.holiday {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      /* Contact List in Modal */
+      .contact-list {
+        margin-top: 1rem;
+      }
+
+      .contact-entry {
+        background: var(--light);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 1rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .contact-entry-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+      }
+
+      .contact-remove {
+        background: none;
+        border: none;
+        color: var(--danger);
+        cursor: pointer;
+        font-size: 1.25rem;
+      }
+
+      /* BUP Sections */
+      .bup-section {
+        margin-bottom: 2rem;
+      }
+
+      .bup-header {
+        background: var(--hemo-blue);
+        color: white;
+        padding: 0.75rem 1rem;
+        border-radius: 6px 6px 0 0;
+        font-weight: 600;
+      }
+
+      .bup-content {
+        background: var(--white);
+        border: 1px solid var(--border);
+        border-top: none;
+        padding: 1rem;
+        border-radius: 0 0 6px 6px;
+      }
+
+      /* Loading */
+      .spinner {
+        border: 3px solid var(--border);
+        border-top-color: var(--hemo-blue);
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .loading-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(255, 255, 255, 0.9);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 1rem;
+        z-index: 9999;
+      }
+
+      /* Utilities */
+      .text-center {
+        text-align: center;
+      }
+
+      .text-right {
+        text-align: right;
+      }
+
+      .mb-0 {
+        margin-bottom: 0;
+      }
+
+      .mb-1 {
+        margin-bottom: 0.5rem;
+      }
+
+      .mb-2 {
+        margin-bottom: 1rem;
+      }
+
+      .mb-3 {
+        margin-bottom: 1.5rem;
+      }
+
+      .mt-2 {
+        margin-top: 1rem;
+      }
+
+      .mt-3 {
+        margin-top: 1.5rem;
+      }
+
+      .mt-4 {
+        margin-top: 2rem;
+      }
+
+      .flex {
+        display: flex;
+      }
+
+      .justify-between {
+        justify-content: space-between;
+      }
+
+      .justify-center {
+        justify-content: center;
+      }
+
+      .align-center {
+        align-items: center;
+      }
+
+      .gap-1 {
+        gap: 0.5rem;
+      }
+
+      .gap-2 {
+        gap: 1rem;
+      }
+
+      /* Responsive */
+      @media (max-width: 768px) {
+        .app-container {
+          flex-direction: column;
+        }
+
+        .sidebar {
+          width: 100%;
+          position: static;
+          height: auto;
+        }
+
+        .header-bar {
+          left: 0;
+          position: static;
+        }
+
+        .main-content {
+          margin-left: 0;
+          margin-top: 0;
+        }
+
+        .content-body {
+          padding: 1rem;
+        }
+
+        .metrics-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .customer-grid,
+        .antibody-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+
+  <body data-theme="light">
+    <div class="app-container">
+      <!-- Sidebar Navigation -->
+      <aside class="sidebar">
+        <div class="sidebar-header">
+          <div class="logo">
+            <div class="logo-icon">Hb</div>
+            <div class="logo-text">
+              <div class="logo-main">Hemo bioscience</div>
+              <div class="logo-sub">Blood Optimization Platform</div>
+            </div>
+          </div>
+        </div>
+
+        <nav class="nav-menu">
+          <div class="nav-section">
+            <div class="nav-section-title">Main</div>
+            <button class="nav-item active" onclick="switchPanel('dashboard', event)">
+              <span class="nav-icon">📊</span>
+              <span>Dashboard</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('calendar', event)">
+              <span class="nav-icon">📅</span>
+              <span>Manufacturing Calendar</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Data Manager</div>
+            <button class="nav-item" onclick="switchPanel('customers', event)">
+              <span class="nav-icon">🏢</span>
+              <span>PT Customers</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('samples', event)">
+              <span class="nav-icon">🧪</span>
+              <span>Sample Definitions</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('specs', event)">
+              <span class="nav-icon">📝</span>
+              <span>Historical Specifications</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('quantities', event)">
+              <span class="nav-icon">📊</span>
+              <span>Order Quantities</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('historical-quantities', event)">
+              <span class="nav-icon">📉</span>
+              <span>Historical Quantities</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Analysis</div>
+            <button class="nav-item" onclick="switchPanel('future-specs', event)">
+              <span class="nav-icon">🔮</span>
+              <span>Future Specifications</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('calculator', event)">
+              <span class="nav-icon">🧮</span>
+              <span>Blood Calculator</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('bup', event)">
+              <span class="nav-icon">📑</span>
+              <span>BUP Generator</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('sharing', event)">
+              <span class="nav-icon">🔄</span>
+              <span>Sharing Opportunities</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('reporting', event)">
+              <span class="nav-icon">📈</span>
+              <span>Reporting</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">Inventory</div>
+            <button class="nav-item" onclick="switchPanel('vendors', event)">
+              <span class="nav-icon">🚚</span>
+              <span>Vendors</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('blood-suppliers', event)">
+              <span class="nav-icon">🩸</span>
+              <span>Blood Suppliers</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('bulk-rbcs', event)">
+              <span class="nav-icon">🩸</span>
+              <span>Bulk RBCs</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('bulk-serums', event)">
+              <span class="nav-icon">🧫</span>
+              <span>Bulk Serums</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('antibodies', event)">
+              <span class="nav-icon">🧬</span>
+              <span>Antibodies</span>
+            </button>
+          </div>
+
+          <div class="nav-section">
+            <div class="nav-section-title">System</div>
+            <button class="nav-item" onclick="switchPanel('activity', event)">
+              <span class="nav-icon">📜</span>
+              <span>Activity Log</span>
+            </button>
+            <button class="nav-item" onclick="switchPanel('settings', event)">
+              <span class="nav-icon">⚙️</span>
+              <span>Settings</span>
+            </button>
+          </div>
+        </nav>
+      </aside>
+
+      <!-- Header Bar -->
+      <header class="header-bar">
+        <div class="header-left">
+        <div class="version-badge">v1.0.1</div>
+          <div class="active-users" id="active-users" style="display: none">
+            <span>👤 Active:</span>
+            <span id="active-user-list">-</span>
+          </div>
+        </div>
+
+        <div class="header-right">
+          <div class="storage-status" id="storage-status">
+            <span class="dot"></span>
+            <span id="storage-text">Last saved: Never</span>
+          </div>
+
+          <div class="user-info">
+            <div class="user-avatar" id="user-avatar">?</div>
+            <span id="user-name">Not Set</span>
+          </div>
+
+          <button class="theme-toggle" onclick="toggleTheme()">
+            <div class="theme-toggle-slider">
+              <span id="theme-icon">☀️</span>
+            </div>
+          </button>
+        </div>
+      </header>
+
+      <!-- Main Content Area -->
+      <main class="main-content">
+        <!-- Dashboard Panel -->
+        <div id="dashboard-panel" class="panel active">
+          <div class="content-header">
+            <h1 class="content-title">Dashboard</h1>
+            <p class="content-subtitle">Blood optimization overview and quick stats</p>
+          </div>
+
+          <div class="content-body">
+            <div class="metrics-grid">
+              <div class="metric-card">
+                <div class="metric-value" id="blood-cost-last-year">$0</div>
+                <div class="metric-label">Last Year's Blood Cost</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="blood-cost-ytd">$0</div>
+                <div class="metric-label">YTD Blood Cost (2025)</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="blood-cost-forecast">$0</div>
+                <div class="metric-label">Forecasted Blood Cost (2025)</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="antibody-cost-last-year">$0</div>
+                <div class="metric-label">Last Year's Antibody Cost</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="antibody-cost-ytd">$0</div>
+                <div class="metric-label">YTD Antibody Cost (2025)</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-value" id="antibody-cost-forecast">$0</div>
+                <div class="metric-label">Forecasted Antibody Cost (2025)</div>
+              </div>
+            </div>
+
+            <div class="card" id="top-antibodies-card">
+              <div class="card-header">
+                <h3 class="card-title">Top 3 Most Used Antibodies</h3>
+              </div>
+              <div class="card-body">
+                <div id="top-antibodies-list" class="text-muted">No usage data logged yet.</div>
+              </div>
+            </div>
+
+            <div class="card" id="case-study-tracker-card">
+              <div class="card-header">
+                <h3 class="card-title">Case Study Tracker</h3>
+              </div>
+              <div class="card-body">
+                <div id="case-study-list" class="case-study-list empty">
+                  <p class="text-muted">No case studies tracked yet.</p>
+                </div>
+                <form class="case-study-form" onsubmit="addCaseStudy(event)">
+                  <div class="form-group case-study-description-group">
+                    <label class="form-label" for="case-study-description">Description</label>
+                    <input
+                      id="case-study-description"
+                      type="text"
+                      class="form-input"
+                      placeholder="e.g., Draft June case study"
+                      required
+                    />
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" for="case-study-due-date">Due Date</label>
+                    <input id="case-study-due-date" type="date" class="form-input" required />
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" style="opacity: 0">Add Case</label>
+                    <button type="submit" class="btn btn-primary">Add Case</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Quick Actions</h3>
+              </div>
+              <div class="btn-group">
+                <button
+                  class="btn btn-primary"
+                  onclick="switchPanel('customers'); openCustomerModal();"
+                >
+                  + Add PT Customer
+                </button>
+                <button
+                  class="btn btn-primary"
+                  onclick="switchPanel('antibodies'); openSpecificityModal();"
+                >
+                  + Add Specificity
+                </button>
+                <button class="btn btn-outline" onclick="switchPanel('calculator', event)">
+                  Calculate Blood Needs
+                </button>
+                <button class="btn btn-outline" onclick="switchPanel('bup', event)">
+                  Generate BUP
+                </button>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Standing Orders Schedule</h3>
+              </div>
+              <div id="standing-orders-list">
+                <!-- Will be populated -->
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Antibody Alerts</h3>
+              </div>
+              <div id="antibody-alerts">
+                <div class="alert alert-info">No antibody alerts at this time</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Customers Panel -->
+        <div id="customers-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">PT Customers</h1>
+            <p class="content-subtitle">Manage customers and their contact information</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active PT Customers</h3>
+                <button class="btn btn-primary btn-sm" onclick="openCustomerModal()">
+                  + Add PT Customer
+                </button>
+              </div>
+
+              <div class="customer-grid" id="customer-list">
+                <!-- Customers will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sample Definitions Panel -->
+        <div id="samples-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Sample Definitions</h1>
+            <p class="content-subtitle">Manage sample type definitions and properties</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Sample Type Definitions</h3>
+              </div>
+
+              <div class="table-container">
+                <table id="sample-table">
+                  <thead>
+                    <tr>
+                      <th>Sample Type ID</th>
+                      <th>Name</th>
+                      <th>Volume (mL)</th>
+                      <th>Hematocrit (%)</th>
+                      <th>Requires RBC</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="6" class="text-center" style="color: var(--gray)">
+                        No sample definitions loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="table-pagination" data-pagination="samples">
+                <div class="pagination-group">
+                  <label for="sample-page-size">Show</label>
+                  <select
+                    id="sample-page-size"
+                    class="form-select pagination-size"
+                    aria-label="Show rows"
+                  >
+                    <option value="25" selected>25 rows</option>
+                    <option value="50">50 rows</option>
+                    <option value="75">75 rows</option>
+                    <option value="100">100 rows</option>
+                    <option value="all">All</option>
+                  </select>
+                  <span>Rows</span>
+                </div>
+                <div class="pagination-group">
+                  <button
+                    class="btn btn-outline btn-sm pagination-prev"
+                    aria-label="Previous page"
+                  >
+                    Previous
+                  </button>
+                  <select
+                    class="form-select pagination-page-select"
+                    aria-label="Jump to page"
+                  ></select>
+                  <button
+                    class="btn btn-outline btn-sm pagination-next"
+                    aria-label="Next page"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div class="pagination-info">No entries</div>
+              </div>
+              <div style="display: flex; justify-content: flex-end; margin-top: 1rem">
+                <button class="btn btn-danger" onclick="deleteAllSamples()">
+                  Delete All Sample Definitions
+                </button>
+              </div>
+            </div>
+            <div class="card mt-4 import-section">
+              <div class="card-header">
+                <h3>Import sample_definitions.csv</h3>
+              </div>
+              <div class="card-body">
+                <input id="sample-definitions-import-file" type="file" accept=".csv" />
+                <button class="btn btn-primary" onclick="handleSampleDefinitionsCsvImport()">
+                  Import
+                </button>
+                <div id="sample-definitions-import-feedback" class="text-muted small mt-2"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Historical Specifications Panel -->
+        <div id="specs-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Historical Specifications</h1>
+            <p class="content-subtitle">Import and manage customer specifications</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Customer Specifications</h3>
+              </div>
+
+              <!-- Pagination Controls -->
+              <div style="margin: 1rem 0">
+                <!-- Filter Row -->
+                <div
+                  style="
+                    display: flex;
+                    gap: 1rem;
+                    align-items: center;
+                    margin-bottom: 1rem;
+                    padding: 1rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <select
+                    id="spec-filter-customer"
+                    class="form-select"
+                    style="flex: 1; min-width: 200px"
+                    onchange="handleSpecCustomerChange()"
+                  >
+                    <option value="">All Customers</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-year"
+                    class="form-select"
+                    style="width: 120px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Years</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-event"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Events</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-sample-id"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Sample IDs</option>
+                  </select>
+
+                  <select
+                    id="spec-filter-sample-type"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="filterSpecs()"
+                  >
+                    <option value="">All Sample Types</option>
+                  </select>
+
+                  <button class="btn btn-outline btn-sm" onclick="clearSpecFilters()">
+                    Clear Filters
+                  </button>
+                </div>
+
+                <!-- Delete All Row -->
+                <div
+                  style="
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 0.5rem;
+                    padding: 0.5rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <span id="spec-selected-count" style="color: var(--gray)">
+                    0 specifications selected
+                  </span>
+                  <div class="btn-group">
+                    <button
+                      class="btn btn-warning"
+                      onclick="deleteAllSpecs()"
+                      id="delete-all-specs-btn"
+                    >
+                      Delete Filtered
+                    </button>
+                    <button
+                      class="btn btn-danger"
+                      onclick="deleteAllSpecifications_UNFILTERED()"
+                    >
+                      Delete ALL Specs
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Pagination Row -->
+                <div
+                  style="
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: 0.5rem;
+                    background: var(--white);
+                    border-radius: 6px;
+                  "
+                >
+                  <select
+                    id="spec-page-size"
+                    class="form-select"
+                    style="width: 150px"
+                    onchange="updateSpecPagination()"
+                  >
+                    <option value="25">25 rows</option>
+                    <option value="50">50 rows</option>
+                    <option value="100" selected>100 rows</option>
+                    <option value="all">All rows</option>
+                  </select>
+
+                  <div id="spec-pagination-info" style="color: var(--gray)">
+                    Showing 1-100 of 912 entries
+                  </div>
+
+                  <div id="spec-pagination-controls" style="display: flex; gap: 0.5rem">
+                    <button class="btn btn-outline btn-sm" onclick="specChangePage('prev')">
+                      Previous
+                    </button>
+                    <div
+                      id="spec-page-numbers"
+                      style="display: flex; gap: 0.25rem; align-items: center"
+                    >
+                      <!-- Page numbers will be generated here -->
+                    </div>
+                    <button class="btn btn-outline btn-sm" onclick="specChangePage('next')">
+                      Next
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="spec-table">
+                  <thead>
+                    <tr>
+                      <th>Customer</th>
+                      <th>Event</th>
+                      <th>Year</th>
+                      <th>Sample ID</th>
+                      <th>Sample Type</th>
+                      <th>ABO/Rh</th>
+                      <th>Antibodies</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray)">
+                        No specifications loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="card mt-4 import-section">
+              <div class="card-header">
+                <h3>Import historical specifications CSVs</h3>
+              </div>
+              <div class="card-body">
+                <input id="historical-specifications-import-file" type="file" accept=".csv" multiple />
+                <button class="btn btn-primary" onclick="handleHistoricalSpecificationsCsvImport()">
+                  Import
+                </button>
+                <div id="historical-specifications-import-feedback" class="text-muted small mt-2"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Future Specifications Panel -->
+        <div id="future-specs-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Future Specifications</h1>
+            <p class="content-subtitle">Design and optimize specifications for upcoming events</p>
+          </div>
+
+          <div class="content-body">
+            <!-- Create New Future Spec Card -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Create Future Specification</h3>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label class="form-label">Customer <span class="required">*</span></label>
+                  <select
+                    class="form-select"
+                    id="future-spec-customer"
+                    onchange="handleFutureSpecCustomerChange()"
+                  >
+                    <option value="">Select Customer</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Event <span class="required">*</span></label>
+                  <select
+                    class="form-select"
+                    id="future-spec-event"
+                    onchange="handleFutureSpecEventChange()"
+                  >
+                    <option value="">Select Event</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Year <span class="required">*</span></label>
+                  <select class="form-select" id="future-spec-year" onchange="handleFutureSpecYearChange()">
+                    <option value="">Select Year</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Copy Structure From</label>
+                  <select class="form-select" id="future-spec-copy-from">
+                    <option value="">Manual Entry</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label">Override Forecasted Quantity (Optional)</label>
+                  <input
+                    type="number"
+                    class="form-input"
+                    id="future-spec-quantity"
+                    placeholder="Optional: Override forecasted quantities"
+                  />
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="createFutureSpec()">
+                Create Specification
+              </button>
+            </div>
+
+            <!-- Active Future Specifications -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Future Specifications</h3>
+              </div>
+
+              <div id="future-specs-list">
+                <p class="text-center" style="color: var(--gray)">
+                  No future specifications created yet
+                </p>
+              </div>
+            </div>
+
+            <!-- Optimization Results (hidden initially) -->
+            <div class="card" id="optimization-results" style="display: none">
+              <div class="card-header">
+                <h3 class="card-title">Optimization Results</h3>
+                <button class="btn btn-outline btn-sm" onclick="closeOptimization()">Close</button>
+              </div>
+
+              <div id="optimization-content">
+                <!-- Results will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Blood Calculator Panel -->
+        <div id="calculator-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Blood Calculator</h1>
+            <p class="content-subtitle">Forecast demand and uncover sharing opportunities</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Forecast &amp; Sharing Analysis</h3>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-group">
+                  <label class="form-label">Customer</label>
+                  <select
+                    class="form-select"
+                    id="calc-customer"
+                    onchange="handleCalculatorCustomerChange()"
+                  >
+                    <option value="">Select Customer</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Year</label>
+                  <select
+                    class="form-select"
+                    id="calc-year"
+                    onchange="handleCalculatorYearChange()"
+                  >
+                    <option value="">Select Year</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">PT Event</label>
+                  <select
+                    class="form-select"
+                    id="calc-event"
+                    onchange="handleCalculatorEventChange()"
+                  >
+                    <option value="">Select Event</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Sample ID</label>
+                  <div class="sample-input-wrapper">
+                    <div id="calc-sample-select-wrapper">
+                      <select
+                        class="form-select"
+                        id="calc-sample"
+                        onchange="handleCalculatorSampleChange()"
+                      >
+                        <option value="">Select Sample ID</option>
+                      </select>
+                    </div>
+                    <div
+                      id="calc-sample-input-wrapper"
+                      style="display: none"
+                    >
+                      <input
+                        type="text"
+                        class="form-input"
+                        id="calc-sample-input"
+                        placeholder="Enter Sample ID"
+                        oninput="handleCalculatorSampleInputChange()"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-outline btn-sm"
+                      id="calc-sample-toggle"
+                      onclick="toggleSampleInputMode()"
+                    >
+                      Use Manual Entry
+                    </button>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Forecasted Quantity</label>
+                  <input
+                    type="number"
+                    class="form-input"
+                    id="calc-forecast"
+                    placeholder="Calculated forecast will appear here"
+                  />
+                </div>
+              </div>
+
+              <div class="date-display" id="calc-date-display">
+                <div class="date-display-header">Schedule Dates</div>
+                <div class="date-display-grid">
+                  <div class="date-display-item">
+                    <span class="date-label">Earliest Bleed Date</span>
+                    <span class="date-value" id="calc-bleed-date">—</span>
+                  </div>
+                  <div class="date-display-item">
+                    <span class="date-label">Ship Date</span>
+                    <span class="date-value" id="calc-ship-date">—</span>
+                  </div>
+                  <div class="date-display-item">
+                    <span class="date-label">Expiration Date</span>
+                    <span class="date-value" id="calc-expiration-date">—</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="btn-group" style="margin-top: 1rem">
+                <button
+                  class="btn btn-outline"
+                  onclick="updateForecastCalculator()"
+                  type="button"
+                >
+                  Recalculate Forecast
+                </button>
+                <button
+                  class="btn btn-primary"
+                  onclick="findSharingOpportunities()"
+                  type="button"
+                >
+                  Find Sharing Opportunities
+                </button>
+              </div>
+
+              <div id="sharing-results" class="sharing-results"></div>
+            </div>
+          </div>
+        </div>
+        <!-- BUP Generator Panel -->
+        <div id="bup-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">BUP Generator</h1>
+            <p class="content-subtitle">Create blood utilization plans with optimization</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Select Events for BUP</h3>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Mode</label>
+                <div style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: center">
+                  <label style="display: flex; align-items: center; gap: 0.5rem">
+                    <input
+                      type="radio"
+                      name="bup-mode"
+                      value="confirmed"
+                      checked
+                      onchange="setBUPMode('confirmed')"
+                    />
+                    Confirmed Quantities
+                  </label>
+                  <label style="display: flex; align-items: center; gap: 0.5rem">
+                    <input
+                      type="radio"
+                      name="bup-mode"
+                      value="forecasted"
+                      onchange="setBUPMode('forecasted')"
+                    />
+                    Forecasted Quantities
+                  </label>
+                </div>
+                <div
+                  id="bup-mode-indicator"
+                  class="form-hint"
+                  style="display: none; color: var(--info); font-weight: 600; margin-top: 0.5rem"
+                >
+                  Forecasted Mode Active
+                </div>
+                <div
+                  id="bup-mode-availability"
+                  class="form-hint"
+                  style="display: none; color: var(--gray); margin-top: 0.25rem"
+                >
+                  Forecasted quantities are available for future events only.
+                </div>
+                <div
+                  id="bup-forecast-notice"
+                  class="form-hint"
+                  style="display: none; color: var(--warning); margin-top: 0.25rem"
+                ></div>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Filter and Select Events</label>
+
+                <!-- Filter Controls -->
+                <div
+                  style="
+                    display: grid;
+                    grid-template-columns: 1fr 1fr 1fr;
+                    gap: 1rem;
+                    margin-bottom: 1rem;
+                  "
+                >
+                  <div>
+                    <label class="form-label">Customer</label>
+                    <select
+                      class="form-select"
+                      id="bup-filter-customer"
+                      onchange="updateBUPEventList()"
+                    >
+                      <option value="">All Customers</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="form-label">Year</label>
+                    <select
+                      class="form-select"
+                      id="bup-filter-year"
+                      onchange="updateBUPEventList()"
+                    >
+                      <option value="">All Years</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="form-label">Search</label>
+                    <input
+                      type="text"
+                      class="form-input"
+                      id="bup-filter-search"
+                      placeholder="Search events..."
+                      oninput="updateBUPEventList()"
+                    />
+                  </div>
+                </div>
+
+                <!-- Event Selection List -->
+                <div
+                  style="
+                    border: 1px solid var(--border);
+                    border-radius: 6px;
+                    padding: 1rem;
+                    max-height: 300px;
+                    overflow-y: auto;
+                    background: var(--white);
+                  "
+                >
+                  <div style="margin-bottom: 0.5rem; display: flex; justify-content: space-between">
+                    <label style="font-weight: 600">Available Events</label>
+                    <button class="btn btn-outline btn-sm" onclick="selectAllVisibleEvents()">
+                      Select All Visible
+                    </button>
+                  </div>
+                  <div id="bup-events-list">
+                    <!-- Checkboxes will be populated here -->
+                  </div>
+                </div>
+
+                <div class="form-hint" style="margin-top: 0.5rem">
+                  Selected: <span id="bup-selected-count">0</span> events
+                </div>
+                <!-- Selected Events Pool -->
+                <div id="selected-events-pool" style="margin-top: 1.5rem; display: none">
+                  <h4 style="margin-bottom: 0.5rem">Selected Events Pool</h4>
+                  <div
+                    style="
+                      border: 2px solid var(--hemo-blue);
+                      border-radius: 6px;
+                      padding: 1rem;
+                      background: var(--hemo-blue-lighter);
+                      min-height: 100px;
+                    "
+                  >
+                    <div
+                      id="selected-events-list"
+                      style="display: flex; flex-wrap: wrap; gap: 0.5rem"
+                    >
+                      <!-- Selected event tags will appear here -->
+                    </div>
+                    <div
+                      id="empty-pool-message"
+                      style="color: var(--gray); text-align: center; padding: 2rem"
+                    >
+                      No events selected yet. Use the filters above to find and add events.
+                    </div>
+                  </div>
+                  <button
+                    class="btn btn-danger btn-sm"
+                    style="margin-top: 0.5rem"
+                    onclick="clearSelectedPool()"
+                  >
+                    Clear All Selected
+                  </button>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Include Standing Orders</label>
+                <div style="display: flex; flex-direction: column; gap: 0.5rem">
+                  <label
+                    ><input type="checkbox" id="include-hqc" checked /> HQC (Every 28 days)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-mirrscitech" checked /> Mirrscitech/Korea
+                    (Every 28 days)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-c3" checked /> C3 Control (Every 28 days - O
+                    unit available)</label
+                  >
+                  <label
+                    ><input type="checkbox" id="include-mqc" checked /> MQC/MQC-CAT (Every 35
+                    days)</label
+                  >
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="generateBUP()">Generate BUP Report</button>
+            </div>
+
+            <div class="card" id="bup-report" style="display: none">
+              <div class="card-header">
+                <h3 class="card-title">Blood Utilization Plan</h3>
+                <div class="btn-group">
+                  <button class="btn btn-outline btn-sm" onclick="toggleBUPView()">
+                    Toggle View
+                  </button>
+                  <button class="btn btn-outline btn-sm" onclick="exportBUP()">
+                    Export Report
+                  </button>
+                </div>
+              </div>
+
+              <div id="bup-summary" class="alert alert-info" style="margin: 1rem">
+                <!-- Summary will appear here -->
+              </div>
+
+              <div id="bup-content">
+                <!-- BUP will be generated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quantities Panel -->
+        <div id="quantities-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Order Quantities</h1>
+            <p class="content-subtitle">Manage confirmed and forecasted quantities</p>
+          </div>
+
+          <div class="content-body">
+            <!-- Filter Quantities Card -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Filter Quantities</h3>
+              </div>
+
+              <div
+                style="
+                  display: grid;
+                  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                  gap: 1rem;
+                  padding: 1rem;
+                "
+              >
+                <div>
+                  <label class="form-label">Customer</label>
+                  <select
+                    class="form-select"
+                    id="qty-filter-customer"
+                    onchange="handleQuantityCustomerChange()"
+                  >
+                    <option value="">All Customers</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Year</label>
+                  <select class="form-select" id="qty-filter-year" onchange="filterQuantities()">
+                    <option value="">All Years</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Event</label>
+                  <select class="form-select" id="qty-filter-event" onchange="filterQuantities()">
+                    <option value="">All Events</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Sample ID</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="qty-filter-sample"
+                    placeholder="Filter by sample ID..."
+                    oninput="filterQuantities()"
+                  />
+                </div>
+
+                <div>
+                  <label class="form-label">PO Number</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="qty-filter-po"
+                    placeholder="Filter by PO..."
+                    oninput="filterQuantities()"
+                  />
+                </div>
+
+                <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+                  <button class="btn btn-outline btn-sm" onclick="clearQuantityFilters()">
+                    Clear Filters
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteFilteredQuantities()">
+                    Delete Filtered
+                  </button>
+                </div>
+              </div>
+
+              <div style="padding: 0 1rem 1rem; color: var(--gray)">
+                <span id="qty-filter-count">Showing all quantities</span>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Confirmed Orders</h3>
+                <div class="btn-group">
+                  <button class="btn btn-primary btn-sm" onclick="openQuantityModal()">
+                    + Add Quantity
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteAllQuantities()">
+                    Delete All Quantities
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="quantities-table">
+                  <thead>
+                    <tr>
+                      <th>Customer</th>
+                      <th>Event</th>
+                      <th>Year</th>
+                      <th>Sample ID</th>
+                      <th>Quantity</th>
+                      <th>PO Number</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray)">
+                        No quantities loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="table-pagination" data-pagination="orderQuantities">
+                <div class="pagination-group">
+                  <label for="order-page-size">Show</label>
+                  <select
+                    id="order-page-size"
+                    class="form-select pagination-size"
+                    aria-label="Show rows"
+                  >
+                    <option value="25" selected>25 rows</option>
+                    <option value="50">50 rows</option>
+                    <option value="75">75 rows</option>
+                    <option value="100">100 rows</option>
+                    <option value="all">All</option>
+                  </select>
+                  <span>Rows</span>
+                </div>
+                <div class="pagination-group">
+                  <button
+                    class="btn btn-outline btn-sm pagination-prev"
+                    aria-label="Previous page"
+                  >
+                    Previous
+                  </button>
+                  <select
+                    class="form-select pagination-page-select"
+                    aria-label="Jump to page"
+                  ></select>
+                  <button
+                    class="btn btn-outline btn-sm pagination-next"
+                    aria-label="Next page"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div class="pagination-info">No entries</div>
+              </div>
+            </div>
+            <div class="card mt-4 import-section">
+              <div class="card-header">
+                <h3>Import order_quantities_confirmed.csv</h3>
+              </div>
+              <div class="card-body">
+                <input id="order-quantities-import-file" type="file" accept=".csv" />
+                <button class="btn btn-primary" onclick="handleOrderQuantitiesCsvImport()">
+                  Import
+                </button>
+                <div id="order-quantities-import-feedback" class="text-muted small mt-2"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div id="historical-quantities-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Historical Quantities</h1>
+            <p class="content-subtitle">Review archived order quantities</p>
+          </div>
+
+          <div class="content-body">
+            <!-- Filter Historical Quantities Card -->
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Filter Historical Quantities</h3>
+              </div>
+
+              <div
+                style="
+                  display: grid;
+                  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                  gap: 1rem;
+                  padding: 1rem;
+                "
+              >
+                <div>
+                  <label class="form-label">Customer</label>
+                  <select
+                    class="form-select"
+                    id="hqty-filter-customer"
+                    onchange="handleHistoricalQuantityCustomerChange()"
+                  >
+                    <option value="">All Customers</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Year</label>
+                  <select class="form-select" id="hqty-filter-year" onchange="filterHistoricalQuantities()">
+                    <option value="">All Years</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Event</label>
+                  <select class="form-select" id="hqty-filter-event" onchange="filterHistoricalQuantities()">
+                    <option value="">All Events</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label class="form-label">Sample ID</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="hqty-filter-sample"
+                    placeholder="Filter by sample ID..."
+                    oninput="filterHistoricalQuantities()"
+                  />
+                </div>
+
+                <div>
+                  <label class="form-label">PO Number</label>
+                  <input
+                    type="text"
+                    class="form-input"
+                    id="hqty-filter-po"
+                    placeholder="Filter by PO..."
+                    oninput="filterHistoricalQuantities()"
+                  />
+                </div>
+
+                <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+                  <button class="btn btn-outline btn-sm" onclick="clearHistoricalQuantityFilters()">
+                    Clear Filters
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteFilteredHistoricalQuantities()">
+                    Delete Filtered
+                  </button>
+                </div>
+              </div>
+
+              <div style="padding: 0 1rem 1rem; color: var(--gray)">
+                <span id="hqty-filter-count">Showing all historical quantities</span>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Historical Orders</h3>
+                <div class="btn-group">
+                  <button class="btn btn-primary btn-sm" onclick="openHistoricalQuantityModal()">
+                    + Add Historical Quantity
+                  </button>
+                  <button class="btn btn-danger btn-sm" onclick="deleteAllHistoricalQuantities()">
+                    Delete All Historical Quantities
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="historical-quantities-table">
+                  <thead>
+                    <tr>
+                      <th>Customer</th>
+                      <th>Event</th>
+                      <th>Year</th>
+                      <th>Sample ID</th>
+                      <th>Quantity</th>
+                      <th>PO Number</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray)">
+                        No historical quantities loaded
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="table-pagination" data-pagination="historicalQuantities">
+                <div class="pagination-group">
+                  <label for="historical-page-size">Show</label>
+                  <select
+                    id="historical-page-size"
+                    class="form-select pagination-size"
+                    aria-label="Show rows"
+                  >
+                    <option value="25" selected>25 rows</option>
+                    <option value="50">50 rows</option>
+                    <option value="75">75 rows</option>
+                    <option value="100">100 rows</option>
+                    <option value="all">All</option>
+                  </select>
+                  <span>Rows</span>
+                </div>
+                <div class="pagination-group">
+                  <button
+                    class="btn btn-outline btn-sm pagination-prev"
+                    aria-label="Previous page"
+                  >
+                    Previous
+                  </button>
+                  <select
+                    class="form-select pagination-page-select"
+                    aria-label="Jump to page"
+                  ></select>
+                  <button
+                    class="btn btn-outline btn-sm pagination-next"
+                    aria-label="Next page"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div class="pagination-info">No entries</div>
+              </div>
+            </div>
+            <div class="card mt-4 import-section">
+              <div class="card-header">
+                <h3>Import order_quantities_historical.csv</h3>
+              </div>
+              <div class="card-body">
+                <input id="historical-quantities-import-file" type="file" accept=".csv" />
+                <button class="btn btn-primary" onclick="handleHistoricalQuantitiesCsvImport()">
+                  Import
+                </button>
+                <div id="historical-quantities-import-feedback" class="text-muted small mt-2"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sharing Opportunities Panel -->
+        <div id="sharing-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Sharing Opportunities</h1>
+            <p class="content-subtitle">Analyze blood sharing opportunities between events</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Sharing Analysis</h3>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Analysis Date Range</label>
+                <div class="form-grid">
+                  <input type="date" class="form-input" id="sharing-start-date" />
+                  <input type="date" class="form-input" id="sharing-end-date" />
+                </div>
+              </div>
+
+              <button class="btn btn-primary" onclick="analyzeSharingOpportunities()">
+                Analyze Sharing Opportunities
+              </button>
+
+              <div id="sharing-analysis-results" style="margin-top: 2rem">
+                <!-- Results will appear here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Reporting Panel -->
+        <div id="reporting-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Reporting</h1>
+            <p class="content-subtitle">Generate and view analytical reports.</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Report Generator</h3>
+              </div>
+              <div class="form-grid" style="padding: 1.5rem;">
+                <div class="form-group">
+                  <label for="report-type-select" class="form-label">Report Type</label>
+                  <select id="report-type-select" class="form-select"></select>
+                </div>
+                <div class="form-group" id="report-year-filter">
+                  <label for="report-year-select" class="form-label">Select Year</label>
+                  <select id="report-year-select" class="form-select"></select>
+                </div>
+                <div class="form-group" id="report-date-range-filter" style="display: none;">
+                  <label class="form-label">Select Date Range</label>
+                  <div class="flex gap-2">
+                    <input type="date" id="report-start-date" class="form-input" />
+                    <input type="date" id="report-end-date" class="form-input" />
+                  </div>
+                </div>
+                <div class="form-group" style="align-self: end;">
+                  <button id="generate-report-btn" class="btn btn-primary" type="button">Generate Report</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="card mt-3" id="report-output-card" style="display: none;">
+              <div class="card-header">
+                <h3 class="card-title" id="report-output-title">Report Results</h3>
+              </div>
+              <div id="report-output-content" style="padding: 1.5rem;">
+                <div
+                  id="report-summary-cards"
+                  class="metrics-grid"
+                  style="grid-template-columns: repeat(3, 1fr); margin-bottom: 2rem;"
+                ></div>
+
+                <div
+                  id="report-chart-container"
+                  class="card"
+                  style="padding: 1.5rem; margin-bottom: 2rem;"
+                >
+                  <div class="flex justify-between align-center mb-2">
+                    <h4 id="chart-title">Annual Spend Comparison</h4>
+                    <div class="btn-group" id="chart-toggle-buttons">
+                      <button
+                        class="btn btn-outline btn-sm active"
+                        data-view="annual"
+                        onclick="renderSpendChart('annual')"
+                      >
+                        Annual
+                      </button>
+                      <button
+                        class="btn btn-outline btn-sm"
+                        data-view="quarterly"
+                        onclick="renderSpendChart('quarterly')"
+                      >
+                        Quarterly
+                      </button>
+                      <button
+                        class="btn btn-outline btn-sm"
+                        data-view="monthly"
+                        onclick="renderSpendChart('monthly')"
+                      >
+                        Monthly
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    id="spend-chart"
+                    style="
+                      height: 300px;
+                      display: flex;
+                      align-items: flex-end;
+                      gap: 0.5rem;
+                      border-bottom: 1px solid var(--border);
+                      padding-bottom: 1rem;
+                    "
+                  ></div>
+                </div>
+
+                <div id="report-table-container">
+                  <h4>Detailed Breakdown</h4>
+                  <div class="table-container mt-2">
+                    <table id="report-details-table">
+                      <thead>
+                        <tr>
+                          <th>Category</th>
+                          <th>Item / Supplier</th>
+                          <th>Date</th>
+                          <th>Cost</th>
+                        </tr>
+                      </thead>
+                      <tbody></tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Manufacturing Calendar Panel -->
+        <div id="calendar-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Manufacturing Calendar</h1>
+            <p class="content-subtitle">Track blood arrivals, shipments, and standing orders</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="calendar-container">
+                <div class="calendar-header">
+                  <h3 id="calendar-month-year">January 2025</h3>
+                  <div class="calendar-nav">
+                    <button onclick="previousMonth()">◀</button>
+                    <button onclick="goToToday()">Current Month</button>
+                    <button onclick="nextMonth()">▶</button>
+                  </div>
+                </div>
+                <div class="calendar-grid" id="calendar-grid">
+                  <!-- Calendar will be generated here -->
+                </div>
+              </div>
+            </div>
+            <div class="card mt-4 import-section">
+              <div class="card-header">
+                <h3>Import schedule.csv</h3>
+                <p class="text-muted">Upload the production schedule for the Manufacturing Calendar.</p>
+              </div>
+              <div class="card-body">
+                <input id="schedule-import-file" type="file" accept=".csv" />
+                <button class="btn btn-primary" onclick="handleScheduleCsvImport()">Import</button>
+                <div id="schedule-import-feedback" class="text-muted small mt-2"></div>
+              </div>
+            </div>
+          </div>
+          <!-- closes .content-body -->
+        </div>
+        <!-- closes #calendar-panel -->
+
+        <!-- Blood Suppliers Panel -->
+        <div id="blood-suppliers-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Blood Suppliers</h1>
+            <p class="content-subtitle">Manage RBC suppliers and their pricing rules</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Registered Blood Suppliers</h3>
+                <button class="btn btn-primary btn-sm" onclick="openBloodSupplierModal()">+ Add Supplier</button>
+              </div>
+
+              <div id="blood-supplier-list" class="customer-grid">
+                <!-- Blood suppliers will be displayed here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bulk RBCs Panel -->
+        <div id="bulk-rbcs-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Bulk RBCs</h1>
+            <p class="content-subtitle">Track individual pRBC units and their remaining volumes.</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active RBC Units</h3>
+                <button class="btn btn-primary btn-sm" onclick="openBulkRBCModal()">+ Add RBC Unit</button>
+              </div>
+
+              <div id="bulk-rbc-list" class="customer-grid">
+                <!-- RBC units will be rendered here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bulk Serums Panel -->
+        <div id="bulk-serums-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Bulk Serums</h1>
+            <p class="content-subtitle">Log reagent-grade serums and track remaining volumes.</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Serum Lots</h3>
+                <button class="btn btn-primary btn-sm" onclick="openBulkSerumModal()">+ Add Serum Lot</button>
+              </div>
+
+              <div id="bulk-serum-list" class="customer-grid">
+                <!-- Serum lots will be rendered here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Antibodies Panel -->
+        <div id="antibodies-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Antibodies</h1>
+            <p class="content-subtitle">Track inventory, costs, and usage of antibodies</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Antibody Inventory</h3>
+                <div class="btn-group">
+                  <button class="btn btn-primary btn-sm" onclick="openSpecificityModal()">
+                    + Add Specificity
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-container">
+                <table id="antibody-specificity-table">
+                  <thead>
+                    <tr>
+                      <th>Specificity</th>
+                      <th>Manufacturer(s)</th>
+                      <th>Lots in Stock</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Vendors Panel -->
+        <div id="vendors-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Vendors</h1>
+            <p class="content-subtitle">Manage suppliers for non-blood materials</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">Active Vendors</h3>
+                <button class="btn btn-primary btn-sm" onclick="openVendorModal()">+ Add Vendor</button>
+              </div>
+
+              <div id="vendor-list" class="customer-grid">
+                <!-- Vendors will be displayed here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Activity Log Panel -->
+
+        <!-- Activity Log Panel -->
+        <div id="activity-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Activity Log</h1>
+            <p class="content-subtitle">Track all changes and user activity</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <div class="card-header" style="display: flex; gap: 0.5rem; align-items: center">
+                <div class="btn-group">
+                  <button
+                    id="btn-tab-activity"
+                    class="btn btn-primary btn-sm"
+                    onclick="showActivitySection('all')"
+                  >
+                    All Activity
+                  </button>
+                  <button
+                    id="btn-tab-decisions"
+                    class="btn btn-outline btn-sm"
+                    onclick="showActivitySection('decisions')"
+                  >
+                    Decisions
+                  </button>
+                </div>
+                <button
+                  class="btn btn-success btn-sm"
+                  style="margin-left: auto"
+                  onclick="logDecision('Test','Manual test entry', null); showActivitySection('decisions');"
+                >
+                  + Add Test Decision
+                </button>
+              </div>
+
+              <div id="activity-log">
+                <!-- Activity items will be populated here -->
+              </div>
+
+              <div id="decisions-log" style="display: none">
+                <!-- Decision entries will be populated here -->
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Settings Panel -->
+        <div id="settings-panel" class="panel">
+          <div class="content-header">
+            <h1 class="content-title">Settings</h1>
+            <p class="content-subtitle">Configure platform settings and preferences</p>
+          </div>
+
+          <div class="content-body">
+            <div class="card">
+              <h3 class="card-title mb-3">Backup &amp; Data Management</h3>
+              <p class="mb-3">
+                Export a backup of your current application data or import a previously saved
+                snapshot.
+              </p>
+              <div class="btn-group">
+                <button class="btn btn-primary" onclick="exportDataToJSON()">
+                  Export All Data to File
+                </button>
+                <button class="btn btn-outline" onclick="importDataFromJSON()">
+                  Import Data from File
+                </button>
+              </div>
+            </div>
+
+            <div class="card">
+              <h3 class="card-title mb-3">Annual Data Migration</h3>
+              <div class="alert alert-info">
+                Use this tool at the end of a calendar year to move all 'Future Specifications' for
+                that year into the permanent 'Historical Specifications' database. This action is
+                irreversible.
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="migration-year-select">Select Year to Migrate</label>
+                <select id="migration-year-select" class="form-select" disabled>
+                  <option>Populating years...</option>
+                </select>
+                <button
+                  id="migrate-specs-btn"
+                  class="btn btn-warning"
+                  onclick="initiateSpecMigration()"
+                  disabled
+                >
+                  Migrate Specifications
+                </button>
+              </div>
+              <hr />
+              <div class="form-group">
+                <label class="form-label" for="migration-qty-year-select">
+                  Select Year to Migrate (Order Quantities)
+                </label>
+                <select id="migration-qty-year-select" class="form-select" disabled>
+                  <option value="">No order quantities available</option>
+                </select>
+                <button
+                  id="migrate-qty-btn"
+                  class="btn btn-warning"
+                  onclick="initiateQuantityMigration()"
+                  disabled
+                >
+                  Migrate Order Quantities
+                </button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <!-- Setup Wizard Modal -->
+    <div id="setup-wizard-modal" class="modal setup-modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title">Welcome to Blood Optimization Platform</h3>
+        </div>
+        <div class="modal-body">
+          <div class="setup-steps">
+            <div class="setup-step active" id="step-1">
+              <div class="step-number">1</div>
+              <div class="step-label">User Setup</div>
+            </div>
+            <div class="setup-step" id="step-2">
+              <div class="step-number">2</div>
+              <div class="step-label">Instructions</div>
+            </div>
+            <div class="setup-step" id="step-3">
+              <div class="step-number">3</div>
+              <div class="step-label">Get Started</div>
+            </div>
+          </div>
+
+          <div class="setup-content" id="setup-content">
+            <!-- Content will be populated by JavaScript -->
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn btn-outline"
+            id="setup-back"
+            onclick="previousSetupStep()"
+            style="display: none"
+          >
+            Back
+          </button>
+          <button class="btn btn-primary" id="setup-next" onclick="nextSetupStep()">Next</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Customer Modal -->
+    <div id="customer-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="customer-modal-title">Add PT Customer</h3>
+          <button class="close-btn" onclick="closeCustomerModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Customer Name <span class="required">*</span></label>
+              <input
+                type="text"
+                class="form-input"
+                id="customer-name"
+                placeholder="e.g., Wisconsin State Laboratory of Hygiene"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Customer Code <span class="required">*</span></label>
+              <input type="text" class="form-input" id="customer-code" placeholder="e.g., WSLH" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Country/Region <span class="required">*</span></label>
+              <select class="form-select" id="customer-region">
+                <option value="">Select Region</option>
+                <option value="United States">United States</option>
+                <option value="Canada">Canada</option>
+                <option value="Mexico">Mexico</option>
+                <option value="United Kingdom">United Kingdom</option>
+                <option value="Germany">Germany</option>
+                <option value="France">France</option>
+                <option value="Australia">Australia</option>
+                <option value="Japan">Japan</option>
+                <option value="South Korea">South Korea</option>
+                <option value="Other">Other</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Notes</label>
+              <textarea
+                class="form-textarea"
+                id="customer-notes"
+                placeholder="Special requirements, formerly known as, etc."
+              ></textarea>
+            </div>
+          </div>
+
+          <h4 class="mb-2">Contacts</h4>
+          <div class="contact-list" id="contact-list">
+            <!-- Contacts will be added here -->
+          </div>
+          <button class="btn btn-outline btn-sm" onclick="addContactField()">+ Add Contact</button>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeCustomerModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveCustomer()">Save Customer</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Vendor Modal -->
+    <div id="vendor-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="vendor-modal-title">Add Vendor</h3>
+          <button class="close-btn" onclick="closeVendorModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label">Vendor Name <span class="required">*</span></label>
+            <input
+              type="text"
+              class="form-input"
+              id="vendor-name"
+              placeholder="e.g., Global Lab Supplies"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label class="form-label">Category</label>
+            <select class="form-select" id="vendor-category">
+              <option value="Antibodies">Antibodies</option>
+              <option value="Reagents">Reagents</option>
+              <option value="Chemicals">Chemicals</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Notes</label>
+            <textarea
+              class="form-textarea"
+              id="vendor-notes"
+              placeholder="Special ordering instructions, contract terms, etc."
+            ></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeVendorModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveVendor()">Save Vendor</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Log Purchase Modal -->
+    <div id="log-purchase-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="log-purchase-modal-title">Log Purchase</h3>
+          <button class="close-btn" onclick="closeLogPurchaseModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label" for="purchase-description">Description <span class="required">*</span></label>
+            <input
+              type="text"
+              class="form-input"
+              id="purchase-description"
+              placeholder="e.g., 5L Buffer Solution"
+            />
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="purchase-date">Date</label>
+            <input type="date" class="form-input" id="purchase-date" />
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="purchase-cost">Cost ($) <span class="required">*</span></label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              class="form-input"
+              id="purchase-cost"
+              placeholder="e.g., 245.50"
+            />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeLogPurchaseModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="savePurchase()">Save Purchase</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- View Purchases Modal -->
+    <div id="view-purchases-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="view-purchases-modal-title">Purchase History</h3>
+          <button class="close-btn" onclick="closeViewPurchasesModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="table-container">
+            <table class="data-table" id="purchase-history-table">
+              <thead>
+                <tr>
+                  <th>Description</th>
+                  <th>Date</th>
+                  <th>Cost</th>
+                  <th style="width: 120px;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colspan="4" style="text-align: center; color: var(--gray);">No purchases logged yet.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeViewPurchasesModal()">Close</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Blood Supplier Modal -->
+    <div id="blood-supplier-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="blood-supplier-modal-title">Add Blood Supplier</h3>
+          <button class="close-btn" onclick="closeBloodSupplierModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <h4 class="mb-2">Supplier Information</h4>
+          <div class="form-group">
+            <label class="form-label" for="supplier-name">Supplier Name <span class="required">*</span></label>
+            <input type="text" class="form-input" id="supplier-name" placeholder="e.g., National Blood Bank" />
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="supplier-notes">Notes</label>
+            <textarea
+              class="form-textarea"
+              id="supplier-notes"
+              placeholder="Contract highlights, logistics partners, etc."
+            ></textarea>
+          </div>
+
+          <hr />
+
+          <h4 class="mb-2">Pricing Rules</h4>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label" for="supplier-base-price">Base Unit Price ($)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="supplier-base-price"
+                step="0.01"
+                placeholder="e.g., 450"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="supplier-antigen-fee">Per-Antigen Fee ($)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="supplier-antigen-fee"
+                step="0.01"
+                placeholder="e.g., 35"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="supplier-rare-fee">Rare Unit Fee ($)</label>
+              <input
+                type="number"
+                class="form-input"
+                id="supplier-rare-fee"
+                step="0.01"
+                placeholder="e.g., 150"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeBloodSupplierModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveBloodSupplier()">Save Supplier</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bulk RBC Modal -->
+    <div id="bulk-rbc-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="bulk-rbc-modal-title">Add RBC Unit</h3>
+          <button class="close-btn" onclick="closeBulkRBCModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div id="bulk-rbc-add-fields">
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="rbc-unit-id">Unit ID <span class="required">*</span></label>
+                <input type="text" class="form-input" id="rbc-unit-id" placeholder="e.g., W012325012345A" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="rbc-blood-type">Blood Type</label>
+                <input type="text" class="form-input" id="rbc-blood-type" placeholder="e.g., O Pos" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="rbc-initial-volume">Initial Volume (mL) <span class="required">*</span></label>
+                <input type="number" class="form-input" id="rbc-initial-volume" value="180" min="0" step="0.1" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="rbc-bleed-date">Bleed Date</label>
+                <input type="date" class="form-input" id="rbc-bleed-date" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="rbc-expiration-date">Expiration Date</label>
+                <input type="date" class="form-input" id="rbc-expiration-date" />
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Antigens</label>
+              <div id="rbc-antigen-list"></div>
+              <button type="button" class="btn btn-outline btn-sm" onclick="addRBCAntigenRow()">+ Add Antigen</button>
+            </div>
+          </div>
+          <div id="bulk-rbc-log-fields" style="display: none;">
+            <p>Logging usage for Unit ID: <strong id="log-usage-unit-id"></strong></p>
+            <div class="form-group">
+              <label class="form-label" for="rbc-usage-volume">Volume to Use (mL) <span class="required">*</span></label>
+              <input type="number" class="form-input" id="rbc-usage-volume" min="0" step="0.1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="rbc-usage-notes">Used For (Notes)</label>
+              <input type="text" class="form-input" id="rbc-usage-notes" placeholder="Usage notes or destination" />
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeBulkRBCModal()">Cancel</button>
+          <button class="btn btn-primary" id="rbc-modal-save-btn" onclick="saveBulkRBC()">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bulk Serum Modal -->
+    <div id="bulk-serum-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="bulk-serum-modal-title">Add Serum Lot</h3>
+          <button class="close-btn" onclick="closeBulkSerumModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div id="bulk-serum-add-fields">
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="serum-unit-id">Serum ID <span class="required">*</span></label>
+                <input type="text" class="form-input" id="serum-unit-id" placeholder="e.g., S-2025-001" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="serum-description">Description</label>
+                <input type="text" class="form-input" id="serum-description" placeholder="e.g., Anti-D Serum" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="serum-initial-volume">Initial Volume (mL) <span class="required">*</span></label>
+                <input type="number" class="form-input" id="serum-initial-volume" min="0" step="0.1" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="serum-receive-date">Received Date</label>
+                <input type="date" class="form-input" id="serum-receive-date" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="serum-expiration-date">Expiration Date</label>
+                <input type="date" class="form-input" id="serum-expiration-date" />
+              </div>
+            </div>
+          </div>
+          <div id="bulk-serum-log-fields" style="display: none;">
+            <p>Logging usage for Serum ID: <strong id="log-usage-serum-id"></strong></p>
+            <div class="form-group">
+              <label class="form-label" for="serum-usage-volume">Volume to Use (mL) <span class="required">*</span></label>
+              <input type="number" class="form-input" id="serum-usage-volume" min="0" step="0.1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="serum-usage-notes">Used For (Notes)</label>
+              <input type="text" class="form-input" id="serum-usage-notes" placeholder="Usage notes or destination" />
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeBulkSerumModal()">Cancel</button>
+          <button class="btn btn-primary" id="serum-modal-save-btn" onclick="saveBulkSerum()">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Specificity Modal -->
+    <div id="specificity-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="specificity-modal-title">Add Specificity</h3>
+          <button class="close-btn" onclick="closeSpecificityModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label" for="specificity-name">Specificity Name <span class="required">*</span></label>
+            <input type="text" class="form-input" id="specificity-name" placeholder="e.g., Anti-K" />
+          </div>
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label" for="specificity-type">Type</label>
+              <select class="form-select" id="specificity-type">
+                <option value="Monoclonal">Monoclonal</option>
+                <option value="Polyclonal">Polyclonal</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="specificity-class">Class</label>
+              <select class="form-select" id="specificity-class">
+                <option value="IgG">IgG</option>
+                <option value="IgM">IgM</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeSpecificityModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveSpecificity()">Save Specificity</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Inventory Lot Modal -->
+    <div id="inventory-lot-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="inventory-lot-modal-title">Add Inventory Lot</h3>
+          <button class="close-btn" onclick="closeLotModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div id="lot-form-fields">
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="lot-manufacturer">Manufacturer</label>
+                <input type="text" class="form-input" id="lot-manufacturer" placeholder="e.g., Immucor" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-number">Lot Number <span class="required">*</span></label>
+                <input type="text" class="form-input" id="lot-number" placeholder="e.g., LK-20394" />
+              </div>
+            </div>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="lot-clone">Clone</label>
+                <input type="text" class="form-input" id="lot-clone" placeholder="e.g., K1-2B6" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-type">Type</label>
+                <select class="form-select" id="lot-type">
+                  <option value="Monoclonal">Monoclonal</option>
+                  <option value="Polyclonal">Polyclonal</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-class">Class</label>
+                <select class="form-select" id="lot-class">
+                  <option value="IgG">IgG</option>
+                  <option value="IgM">IgM</option>
+                </select>
+              </div>
+            </div>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="lot-purchase-price">Purchase Price ($)</label>
+                <input type="number" class="form-input" id="lot-purchase-price" step="0.01" min="0" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-purchase-quantity">Purchase Quantity (mL)</label>
+                <input type="number" class="form-input" id="lot-purchase-quantity" step="0.1" min="0" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-current-quantity">Current Quantity (mL)</label>
+                <input type="number" class="form-input" id="lot-current-quantity" step="0.1" min="0" />
+              </div>
+            </div>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="lot-qualification-date">Qualification Date</label>
+                <input type="date" class="form-input" id="lot-qualification-date" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-requalification-date">Requalification Date</label>
+                <input type="date" class="form-input" id="lot-requalification-date" readonly />
+                <div class="form-hint">Auto-calculated (+1 year)</div>
+              </div>
+            </div>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label" for="lot-optimal-dilution-serum">Optimal Dilution (Serum)</label>
+                <input type="text" class="form-input" id="lot-optimal-dilution-serum" placeholder="e.g., 1:100" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lot-optimal-dilution-dat">Optimal Dilution (DAT)</label>
+                <input type="text" class="form-input" id="lot-optimal-dilution-dat" placeholder="e.g., 1:8" />
+              </div>
+            </div>
+          </div>
+
+          <div id="lot-usage-fields" style="display: none;">
+            <p>
+              Logging usage for <strong id="usage-specificity-name"></strong> • Lot
+              <strong id="usage-lot-number"></strong>
+            </p>
+            <div class="form-group">
+              <label class="form-label" for="lot-usage-volume">Volume to Use (mL) <span class="required">*</span></label>
+              <input type="number" class="form-input" id="lot-usage-volume" min="0" step="0.1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="lot-usage-notes">Usage Notes</label>
+              <input type="text" class="form-input" id="lot-usage-notes" placeholder="Enter usage details" />
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeLotModal()">Cancel</button>
+          <button class="btn btn-primary" id="lot-modal-save-btn">Save Lot</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Quantity Edit Modal -->
+    <div id="quantity-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="quantity-modal-title">Edit Quantity</h3>
+          <button class="close-btn" onclick="closeQuantityModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Customer <span class="required">*</span></label>
+              <input type="text" class="form-input" id="qty-modal-customer" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Event <span class="required">*</span></label>
+              <input type="text" class="form-input" id="qty-modal-event" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Year <span class="required">*</span></label>
+              <input type="number" class="form-input" id="qty-modal-year" min="2020" max="2030" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Sample ID</label>
+              <input
+                type="text"
+                class="form-input"
+                id="qty-modal-sample"
+                placeholder="Leave blank for all samples"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Quantity <span class="required">*</span></label>
+              <input type="number" class="form-input" id="qty-modal-quantity" min="1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">PO Number</label>
+              <input type="text" class="form-input" id="qty-modal-po" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Status</label>
+              <select class="form-select" id="qty-modal-status">
+                <option value="Confirmed">Confirmed</option>
+                <option value="Pending">Pending</option>
+                <option value="Forecast">Forecast</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeQuantityModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveQuantity()">Save</button>
+        </div>
+      </div>
+    </div>
+    <!-- Historical Quantity Modal -->
+    <div id="historical-quantity-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="historical-quantity-modal-title">Edit Historical Quantity</h3>
+          <button class="close-btn" onclick="closeHistoricalQuantityModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label">Customer <span class="required">*</span></label>
+              <input type="text" class="form-input" id="hqty-modal-customer" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Event <span class="required">*</span></label>
+              <input type="text" class="form-input" id="hqty-modal-event" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Year <span class="required">*</span></label>
+              <input type="number" class="form-input" id="hqty-modal-year" min="2020" max="2030" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Sample ID</label>
+              <input
+                type="text"
+                class="form-input"
+                id="hqty-modal-sample"
+                placeholder="Leave blank for all samples"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Quantity <span class="required">*</span></label>
+              <input type="number" class="form-input" id="hqty-modal-quantity" min="1" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">PO Number</label>
+              <input type="text" class="form-input" id="hqty-modal-po" />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Status</label>
+              <select class="form-select" id="hqty-modal-status">
+                <option value="Confirmed">Confirmed</option>
+                <option value="Pending">Pending</option>
+                <option value="Forecast">Forecast</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeHistoricalQuantityModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveHistoricalQuantity()">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Calendar Add Event Modal -->
+    <div id="calendar-add-event-modal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title" id="calendar-add-event-modal-title">Add Event</h3>
+          <button class="close-btn" onclick="closeCalendarAddEventModal()">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label required" id="modal-main-date-label">Date</label>
+              <input type="date" class="form-input" id="modal-calendar-date" readonly />
+            </div>
+            <div class="form-group" id="modal-arrival-date-group" style="display: none;">
+              <label class="form-label required">Arrival Date</label>
+              <input type="date" class="form-input" id="modal-arrival-date" />
+            </div>
+            <div class="form-group">
+              <label class="form-label required">Entry Type</label>
+              <select
+                class="form-select"
+                id="modal-calendar-type"
+                onchange="handleTypeChange('modal'); toggleShipmentFields()"
+              >
+                <!-- Will be populated by JavaScript -->
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Notes</label>
+              <textarea
+                class="form-textarea"
+                id="modal-calendar-notes"
+                placeholder="Add optional notes..."
+              ></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn btn-danger"
+            id="modal-delete-event-btn"
+            onclick="deleteCalendarEvent()"
+            style="margin-right: auto; display: none;"
+          >
+            Delete Event
+          </button>
+          <button class="btn btn-outline" onclick="closeCalendarAddEventModal()">Cancel</button>
+          <button class="btn btn-primary" id="calendar-add-event-submit" onclick="addCalendarEvent()">
+            Add Event
+          </button>
+        </div>
+      </div>
+    </div>
+    <!-- Future Spec Edit Modal -->
+    <div id="future-spec-edit-modal" class="modal">
+      <div class="modal-content" style="max-width: 1600px; width: 95%;">
+        <div class="modal-header" style="align-items: flex-start; gap: 1rem;">
+          <div>
+            <h3 class="modal-title" id="future-spec-edit-title">Future Specification</h3>
+            <div class="modal-metadata" style="margin-top: 0.5rem; font-size: 0.875rem; color: var(--gray);">
+              <span>Status: <strong id="future-spec-edit-status">-</strong></span>
+              <span style="margin-left: 1rem;">Version: <strong id="future-spec-edit-version">-</strong></span>
+            </div>
+          </div>
+          <button class="close-btn" onclick="closeFutureSpecModal()">×</button>
+        </div>
+        <div class="modal-body" style="max-height: 70vh; overflow-y: auto;">
+          <div class="table-container">
+            <table id="future-spec-edit-table">
+              <thead>
+                <tr>
+                  <th>Sample ID</th>
+                  <th>Sample Type</th>
+                  <th>ABO</th>
+                  <th>Rh</th>
+                  <th style="min-width: 250px;">Antigens</th>
+                  <th style="min-width: 220px;">Antibodies</th>
+                  <th>DAT Status</th>
+                  <th>Optimization</th>
+                  <th style="min-width: 100px;">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline" onclick="closeFutureSpecModal()">Cancel</button>
+          <button class="btn btn-outline" id="future-spec-add-sample" onclick="addFutureSpecSampleRow()">
+            Add Sample
+          </button>
+          <button class="btn btn-primary" onclick="saveFutureSpecEdits()">Save Changes</button>
+        </div>
+      </div>
+    </div>
+    <script>
+// ===============================
+// Application State Management
+// ===============================
+
+const APP_STATE = {
+  version: "1.0.1",
+  customers: [],
+  sampleDefinitions: [],
+  customerSpecs: [],
+  confirmedQuantities: [],
+  historicalQuantities: [],
+  schedule: [],
+  vendors: [],
+  bloodSuppliers: [],
+  antibodies: [],
+  bloodUnits: [],
+  bulkRBCs: [],
+  bulkSerums: [],
+  manufacturingCalendar: [],
+  activityLog: [],
+  decisions: [],
+  caseStudies: [],
+
+  // ADD THIS NEW STRUCTURE:
+  futureSpecs: {
+    entries: [],
+    versions: {},
+    metadata: {},
+  },
+
+  futureAllocations: [],
+  optimizationDecisions: [],
+
+  activeUsers: [],
+  editingCustomerId: null,
+  editingSpecificityId: null,
+  lotModalState: {
+    specificityId: null,
+    lotId: null,
+    mode: "add",
+  },
+  calculatorState: {
+    sampleMode: "dropdown",
+    scheduleEntry: null,
+  },
+  editingQuantityId: null,
+  editingHistoricalQuantityId: null,
+  currentUser: null,
+  writeAccess: false,
+  setupComplete: false,
+  instructionsAcknowledged: false,
+  lastSavedAt: null,
+  theme: localStorage.getItem("theme") || "light",
+  currentSetupStep: 1,
+  currentMonth: new Date().getMonth(),
+  currentYear: new Date().getFullYear(),
+  specPagination: {
+    currentPage: 1,
+    pageSize: 100,
+    filteredSpecs: [],
+    filterCustomer: "",
+    filterEvent: "",
+    filterYear: "",
+    filterSampleId: "",
+    filterSampleType: "",
+  },
+  tablePagination: {
+    samples: { currentPage: 1, pageSize: 25 },
+    orderQuantities: { currentPage: 1, pageSize: 25 },
+    historicalQuantities: { currentPage: 1, pageSize: 25 },
+  },
+  quantityFilters: {
+    customer: "",
+    event: "",
+    year: "",
+    sampleId: "",
+    poNumber: "",
+    filteredQuantities: [],
+  },
+  historicalQuantityFilters: {
+    customer: "",
+    event: "",
+    year: "",
+    sampleId: "",
+    poNumber: "",
+    filteredQuantities: [],
+  },
+  bupAnalysis: {
+    selectedEvents: [],
+    calculations: [],
+    sharingOpportunities: [],
+    optimizedPlan: null,
+  },
+  bupGenerator: {
+    mode: "confirmed",
+    forecastFallbacks: [],
+  },
+  bupSelectedPool: new Set(), // Stores selected event keys
+  _initedPanels: {},
+};
+
+let editingSupplierId = null;
+let editingVendorId = null;
+
+let antibodyMigrationChecked = false;
+
+let editingCalendarEntryId = null;
+
+// Constants
+const RBC_UNIT_ML = 180.0;
+const RETENTION_SAMPLES = 5;
+const DEFAULT_UNIT_VOLUME = 180;
+const MAX_BLOOD_AGE = 77; // days
+const STANDARD_BUFFER = 10; // days
+const EXTERNAL_TESTING_BUFFER = 17; // days (future feature)
+
+// Calendar Configuration
+const CALENDAR_CATEGORIES = {
+  Manufacturing: [
+    { value: "bulk-event", label: "Bulk Event" },
+    { value: "fill-event", label: "Fill Event" },
+    { value: "wash-rbcs", label: "Wash RBCs" },
+    { value: "coat-rbcs", label: "Coat RBCs" },
+    { value: "setup-event", label: "Set Up for Event" },
+  ],
+  Shipping: [
+    { value: "manual-bleed-date", label: "Bleed Date (Manual)" },
+    { value: "external-testing", label: "External Testing Ship" },
+    // Only keep the dual-date shipment option to avoid legacy single-date entries
+    { value: "blood-shipment", label: "Blood Shipment" },
+  ],
+  Administrative: [
+    { value: "timesheets", label: "Timesheets Due" },
+    { value: "case-study", label: "Case Study Due" },
+  ],
+  Quality: [{ value: "label-event", label: "Label Event" }],
+  Professional: [{ value: "conference", label: "Conference" }],
+  "Time Off": [
+    { value: "pto", label: "Employee PTO" },
+    { value: "holiday", label: "Holiday/Hb Closed" },
+  ],
+  Recurring: [{ value: "standing-order", label: "Standing Order" }],
+};
+
+const RECURRENCE_ENABLED_CATEGORY = "Recurring";
+
+// Overage Tiers
+const OVERAGE_TIERS = [
+  { maxQuantity: 200, overage: 1.15 },
+  { maxQuantity: 1000, overage: 1.1 },
+  { maxQuantity: 2000, overage: 1.08 },
+  { maxQuantity: Infinity, overage: 1.06 },
+];
+
+const DAT_OVERAGE_MIN = 1.25;
+const DAT_OVERAGE_MAX = 1.3;
+const ELU_OVERAGE_MIN = 1.25;
+const ELU_OVERAGE_MAX = 1.3;
+
+// Standing Orders Configuration
+const STANDING_ORDERS = [
+  {
+    product: "C3 Control Cells",
+    units: [
+      { type: "O", count: 2, vendor: "Tennessee" },
+      { type: "FFS", count: 4, vendor: "Tennessee" },
+    ],
+    frequency: 28,
+    bonus: { type: "O", volume: 180, rh: "Any" },
+  },
+  {
+    product: "Hemo-QC",
+    units: [
+      { type: "AsubB Pos", count: 3, vendor: "Memorial" },
+      { type: "O Pos R1r Fya Neg", count: 3, vendor: "Memorial" },
+      { type: "A₁ Neg rr", count: 3, vendor: "Memorial" },
+    ],
+    frequency: 28,
+  },
+  {
+    product: "MQC/MQC-CAT",
+    units: [
+      { type: "A₁B Pos", count: 1, vendor: "Kansas City" },
+      { type: "O Neg rr K Pos", count: 1, vendor: "Kansas City" },
+    ],
+    frequency: 35,
+  },
+  {
+    product: "Korea FFMU/Mirrscitech",
+    units: [
+      { type: "A₁ Pos R1R1", count: 1, vendor: "Memorial" },
+      { type: "B Pos R2R2", count: 1, vendor: "Memorial" },
+      { type: "O Neg rr", count: 1, vendor: "Tennessee" },
+    ],
+    frequency: 28,
+  },
+];
+
+// Antigen Cost Configuration
+const ANTIGEN_COSTS = {
+  standard: 35, // Common antigens (Fya, Fyb, K, etc.)
+  rare: 75, // Rare antigens
+  panel: 150, // Full phenotyping panels
+};
+
+const BLOOD_UNIT_COSTS = {
+  standard: 450, // Regular ABO/Rh matched
+  antigenMatched: 525, // With specific antigens
+  rare: 650, // Rare blood types
+  emergency: 850, // Rush orders
+};
+
+// Common antigens tracked for optimization
+const TRACKED_ANTIGENS = [
+  "C",
+  "c",
+  "E",
+  "e",
+  "K",
+  "Fya",
+  "Fyb",
+  "Jka",
+  "Jkb",
+  "S",
+  "s",
+  "M",
+  "N",
+];
+
+// ===============================
+// Database Management
+// ===============================
+
+let dbInstance = null;
+
+function initDB() {
+  if (dbInstance) {
+    return Promise.resolve(dbInstance);
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open("HemoBioscienceDB", 1);
+
+    request.onupgradeneeded = function (event) {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains("appDataStore")) {
+        db.createObjectStore("appDataStore");
+      }
+    };
+
+    request.onsuccess = function () {
+      dbInstance = request.result;
+      resolve(dbInstance);
+    };
+
+    request.onerror = function () {
+      reject(request.error);
+    };
+  });
+}
+
+async function saveStateToDB(stateObject) {
+  const db = await initDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction("appDataStore", "readwrite");
+    const store = transaction.objectStore("appDataStore");
+    const request = store.put(stateObject, "currentState");
+
+    request.onsuccess = function () {
+      resolve();
+    };
+
+    request.onerror = function () {
+      reject(request.error);
+    };
+  });
+}
+
+async function loadStateFromDB() {
+  const db = await initDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction("appDataStore", "readonly");
+    const store = transaction.objectStore("appDataStore");
+    const request = store.get("currentState");
+
+    request.onsuccess = function (event) {
+      resolve(event.target.result || null);
+    };
+
+    request.onerror = function () {
+      reject(request.error);
+    };
+  });
+}
+
+// Helper function to migrate old antigen/antibody format to new format
+function migrateFutureSpecsFormat() {
+  if (!APP_STATE.futureSpecs || !APP_STATE.futureSpecs.entries) return;
+
+  APP_STATE.futureSpecs.entries.forEach((spec) => {
+    // Migrate antigens from string to array format
+    if (typeof spec.antigens === "string") {
+      const oldAntigens = spec.antigens;
+      spec.antigens = [];
+      if (oldAntigens && oldAntigens.trim()) {
+        const parts = oldAntigens.split(",").map((s) => s.trim());
+        parts.forEach((part) => {
+          const match = part.match(/^([A-Za-z]+)([\+\-])$/);
+          if (match) {
+            spec.antigens.push({
+              antigen: match[1],
+              status: match[2] === "+" ? "Positive" : "Negative",
+            });
+          }
+        });
+      }
+    }
+
+    // Migrate antibodies to array format
+    if (!Array.isArray(spec.antibodies)) {
+      spec.antibodies = [];
+      if (spec.antibody_1) spec.antibodies.push(spec.antibody_1);
+      if (spec.antibody_2) spec.antibodies.push(spec.antibody_2);
+      delete spec.antibody_1;
+      delete spec.antibody_2;
+    }
+
+    // Migrate DAT format
+    if (spec.is_dat_positive === "TRUE") {
+      spec.dat_status = "Positive";
+    } else {
+      spec.dat_status = "Negative";
+    }
+    delete spec.is_dat_positive;
+  });
+}
+
+// Define proper antigen order for immunohematology
+const ANTIGEN_ORDER = [
+  "C",
+  "E",
+  "c",
+  "e",
+  "K",
+  "k",
+  "Fya",
+  "Fyb",
+  "Jka",
+  "Jkb",
+  "S",
+  "s",
+];
+
+// Available antibodies list
+const AVAILABLE_ANTIBODIES = [
+  "Anti-D",
+  "Anti-C",
+  "Anti-E",
+  "Anti-c",
+  "Anti-e",
+  "Anti-K",
+  "Anti-k",
+  "Anti-Fya",
+  "Anti-Fyb",
+  "Anti-Jka",
+  "Anti-Jkb",
+  "Anti-S",
+  "Anti-s",
+  "WAA",
+  "Daratumumab",
+];
+
+const optimizationSuggestionStore = {};
+let currentOptimizationPopover = null;
+let optimizationPopoverListener = null;
+
+// Helper functions
+function formatAntigensDisplay(antigens) {
+  if (!antigens || !Array.isArray(antigens)) return "";
+  const sorted = antigens.sort((a, b) => {
+    const indexA = ANTIGEN_ORDER.indexOf(a.antigen);
+    const indexB = ANTIGEN_ORDER.indexOf(b.antigen);
+    return indexA - indexB;
+  });
+  return sorted
+    .map((a) => `${a.antigen}${a.status === "Positive" ? "+" : "-"}`)
+    .join(", ");
+}
+
+function generateElementId() {
+  return "elem_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9);
+}
+
+function createId(prefix) {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function calculateRequalificationDate(qualificationDate) {
+  if (!qualificationDate) return "";
+  const date = new Date(qualificationDate);
+  if (Number.isNaN(date.getTime())) return "";
+  date.setFullYear(date.getFullYear() + 1);
+  return date.toISOString().split("T")[0];
+}
+
+function getLotLowStockThreshold(lot) {
+  const parsed = Number(lot.lowStockThreshold);
+  if (!Number.isNaN(parsed) && parsed > 0) {
+    return parsed;
+  }
+  const baseQuantity = Number(lot.purchaseQuantity) || 0;
+  if (baseQuantity <= 0) return 0;
+  return Math.max(5, Math.round(baseQuantity * 0.2));
+}
+
+function normalizeLot(lot = {}, specificity = {}) {
+  const normalized = {
+    inventoryId: lot.inventoryId || createId("lot"),
+    manufacturer: lot.manufacturer || specificity.manufacturer || "Unknown",
+    lotNumber: lot.lotNumber || lot.lot || lot.lot_id || "N/A",
+    clone: lot.clone || specificity.clone || "N/A",
+    type: lot.type || specificity.type || "Monoclonal",
+    class: lot.class || specificity.class || "IgG",
+    purchasePrice: Number(lot.purchasePrice) || 0,
+    purchaseQuantity:
+      Number(
+        lot.purchaseQuantity || lot.initialQuantity || lot.originalQuantity,
+      ) || 0,
+    currentQuantity:
+      Number(
+        lot.currentQuantity !== undefined
+          ? lot.currentQuantity
+          : lot.remainingQuantity !== undefined
+            ? lot.remainingQuantity
+            : lot.purchaseQuantity,
+      ) || 0,
+    qualificationDate: lot.qualificationDate || lot.validatedOn || "",
+    requalificationDate:
+      lot.requalificationDate || lot.requalificationDue || lot.requalDue || "",
+    optimalDilutionSerum:
+      lot.optimalDilutionSerum ||
+      lot.serumDilution ||
+      (lot.dilution ? `1:${lot.dilution}` : "N/A") ||
+      "N/A",
+    optimalDilutionDAT: lot.optimalDilutionDAT || lot.datDilution || "N/A",
+    history: Array.isArray(lot.history)
+      ? lot.history.slice()
+      : Array.isArray(lot.usageHistory)
+        ? lot.usageHistory.slice()
+        : [],
+    status: lot.status || specificity.status || "Available",
+    lowStockThreshold:
+      lot.lowStockThreshold || specificity.lowStockThreshold || null,
+  };
+
+  if (!normalized.requalificationDate && normalized.qualificationDate) {
+    normalized.requalificationDate = calculateRequalificationDate(
+      normalized.qualificationDate,
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeSpecificityEntry(entry = {}) {
+  const normalizedInventory = Array.isArray(entry.inventory)
+    ? entry.inventory.map((lot) => normalizeLot(lot, entry))
+    : [];
+
+  return {
+    id: entry.id || createId("ab"),
+    specificity: entry.specificity || entry.name || "Unnamed Specificity",
+    type: entry.type || "Monoclonal",
+    class: entry.class || "IgG",
+    inventory: normalizedInventory,
+  };
+}
+
+function convertLegacyAntibody(legacyEntry = {}) {
+  const specificity =
+    legacyEntry.name || legacyEntry.specificity || "Unnamed Specificity";
+  const specificityId = legacyEntry.id || createId("ab");
+  const legacyLot = { ...legacyEntry };
+  delete legacyLot.id;
+  delete legacyLot.name;
+  delete legacyLot.specificity;
+
+  const lot = normalizeLot(
+    {
+      ...legacyLot,
+      class: legacyEntry.type || legacyEntry.class || legacyEntry.isotype,
+      type: legacyEntry.productType || legacyEntry.antibodyType,
+    },
+    legacyEntry,
+  );
+
+  if (!lot.history.length && Array.isArray(legacyEntry.history)) {
+    lot.history = legacyEntry.history.slice();
+  }
+
+  return normalizeSpecificityEntry({
+    id: specificityId,
+    specificity,
+    type: legacyEntry.productType || legacyEntry.typeCategory || "Monoclonal",
+    class: lot.class || "IgG",
+    inventory: [lot],
+  });
+}
+
+function migrateAntibodiesToLotStructure(force = false) {
+  if (antibodyMigrationChecked && !force) {
+    return;
+  }
+
+  if (!Array.isArray(APP_STATE.antibodies)) {
+    APP_STATE.antibodies = [];
+    antibodyMigrationChecked = true;
+    return;
+  }
+
+  APP_STATE.antibodies = APP_STATE.antibodies.map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return normalizeSpecificityEntry({ specificity: "Unnamed Specificity" });
+    }
+
+    if (!entry.inventory) {
+      return convertLegacyAntibody(entry);
+    }
+
+    return normalizeSpecificityEntry(entry);
+  });
+
+  antibodyMigrationChecked = true;
+}
+
+// ===============================
+
+// ===============================
+// Initialization
+// ===============================
+
+document.addEventListener("DOMContentLoaded", async function () {
+  // Apply saved theme
+  document.body.setAttribute("data-theme", APP_STATE.theme);
+  updateThemeIcon();
+
+  // Initialize IndexedDB and load any existing state
+  let storedState = null;
+  try {
+    await initDB();
+    storedState = await loadStateFromDB();
+  } catch (error) {
+    console.error("Failed to initialize IndexedDB:", error);
+  }
+
+  if (storedState && typeof storedState === "object") {
+    Object.assign(APP_STATE, storedState);
+  }
+
+  const storageStatus = document.getElementById("storage-status");
+  if (storageStatus) {
+    storageStatus.classList.add("connected");
+  }
+
+  const storageText = document.getElementById("storage-text");
+  if (storageText) {
+    if (APP_STATE.lastSavedAt) {
+      const savedDate = new Date(APP_STATE.lastSavedAt);
+      storageText.textContent = `Last saved ${savedDate.toLocaleString()}`;
+    } else {
+      storageText.textContent = "Last saved: Never";
+    }
+  }
+
+  const localUser = localStorage.getItem("current_user");
+  if (localUser) {
+    APP_STATE.currentUser = localUser;
+  } else if (APP_STATE.currentUser) {
+    localStorage.setItem("current_user", APP_STATE.currentUser);
+  }
+
+  const storedSetupComplete = !!APP_STATE.setupComplete;
+  const storedInstructionsAcknowledged = !!APP_STATE.instructionsAcknowledged;
+  const localSetupComplete = localStorage.getItem("setup_complete") === "true";
+  const localInstructionsAcknowledged =
+    localStorage.getItem("instructions_acknowledged") === "true";
+
+  APP_STATE.setupComplete = storedSetupComplete || localSetupComplete;
+  APP_STATE.instructionsAcknowledged =
+    storedInstructionsAcknowledged || localInstructionsAcknowledged;
+  APP_STATE.writeAccess = APP_STATE.instructionsAcknowledged;
+
+  if (APP_STATE.setupComplete) {
+    localStorage.setItem("setup_complete", "true");
+  }
+  if (APP_STATE.instructionsAcknowledged) {
+    localStorage.setItem("instructions_acknowledged", "true");
+  }
+
+  updateUserDisplay();
+
+  // === Antibodies v0.5.0 one-time migration (idempotent) ===
+  (function migrateAntibodiesV050() {
+    try {
+      let changed = false;
+
+      const add365Days = (iso) => {
+        if (!iso) return "";
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return "";
+        d.setUTCFullYear(d.getUTCFullYear() + 1);
+        return d.toISOString().slice(0, 10);
+      };
+
+      const toNum = (v, def = 0) => {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : def;
+      };
+
+      const parseDilution = (txt) => {
+        if (!txt) return null;
+        const s = String(txt).trim();
+        const m = s.match(/^1\s*[:/]\s*(\d+)$/i);
+        if (m) return toNum(m[1], null);
+        const n = toNum(s, null);
+        return n && n > 0 ? n : null;
+      };
+
+      window.__parseDilution = window.__parseDilution || parseDilution;
+
+      if (!Array.isArray(window.APP_STATE?.antibodies)) return;
+
+      window.APP_STATE.antibodies = window.APP_STATE.antibodies.map((item) => {
+        if (item && Array.isArray(item.inventory)) return item;
+
+        if (item && !Array.isArray(item.inventory)) {
+          changed = true;
+          const id =
+            item.id ||
+            self.crypto?.randomUUID?.() ||
+            `ab_${Math.random().toString(36).slice(2)}`;
+          const inventoryId =
+            self.crypto?.randomUUID?.() ||
+            `lot_${Math.random().toString(36).slice(2)}`;
+
+          const purchasePrice = toNum(item.purchasePrice, 0);
+          const purchaseQuantity = toNum(item.purchaseQuantity, 0);
+          const currentQuantity = toNum(item.currentQuantity, purchaseQuantity);
+
+          const qualificationDate = item.qualificationDate || "";
+          const requalificationDate =
+            item.requalificationDate || add365Days(qualificationDate);
+
+          return {
+            id,
+            specificity: item.specificity || item.name || "Unspecified",
+            inventory: [
+              {
+                inventoryId,
+                manufacturer: item.manufacturer || "",
+                lotNumber: item.lotNumber || "",
+                clone: item.clone || item.cloneName || "",
+                type: item.type || "Monoclonal",
+                class: item.class || "IgG",
+                purchasePrice,
+                purchaseQuantity,
+                currentQuantity,
+                qualificationDate,
+                requalificationDate,
+                optimalDilutionSerum: item.optimalDilutionSerum || "N/A",
+                optimalDilutionDAT: item.optimalDilutionDAT || "N/A",
+                history: Array.isArray(item.history) ? item.history : [],
+              },
+            ],
+          };
+        }
+        return item;
+      });
+
+      if (changed && typeof window.updateAntibodyView === "function") {
+        console.info("[Antibodies v0.5.0] migration applied");
+        window.updateAntibodyView();
+      }
+    } catch (err) {
+      console.error("Antibodies v0.5.0 migration error:", err);
+    }
+  })();
+
+  (function ensureVendorPurchasesArray() {
+    if (!Array.isArray(APP_STATE.vendors)) {
+      APP_STATE.vendors = [];
+      return;
+    }
+
+    let updated = false;
+    APP_STATE.vendors.forEach((vendor) => {
+      if (vendor && !Array.isArray(vendor.purchases)) {
+        vendor.purchases = [];
+        updated = true;
+      }
+    });
+
+    if (updated) {
+      console.info("[Vendors] purchases array migration applied");
+    }
+  })();
+
+  const needsAntibodyMigration =
+    Array.isArray(APP_STATE.antibodies) &&
+    APP_STATE.antibodies.some((entry) => entry && !entry.inventory);
+  if (needsAntibodyMigration) {
+    migrateAntibodiesToLotStructure(true);
+  } else {
+    migrateAntibodiesToLotStructure();
+  }
+
+  populateMigrationYearOptions();
+  populateQuantityMigrationOptions();
+
+  updateDashboard();
+  updateCustomerList();
+  populateCustomerDropdowns();
+  updateAntibodyView();
+  updateActivityLog();
+  displayStandingOrders();
+  initializeCalendar();
+  // Initialize calendar with current month/year
+  APP_STATE.currentMonth = new Date().getMonth();
+  APP_STATE.currentYear = new Date().getFullYear();
+  renderCalendar();
+  setupPaginationControls();
+  updateAllTables();
+  updateForecastModeAvailability();
+
+  if (
+    !document.getElementById("report-type-select")?.dataset.reportingInitialized
+  ) {
+    initializeReportingPanel();
+  }
+
+  updateVendorList();
+  updateBloodSupplierList();
+  updateBulkRBCList();
+  updateBulkSerumList();
+
+  const lotQualInput = document.getElementById("lot-qualification-date");
+  const lotRequalInput = document.getElementById("lot-requalification-date");
+  if (lotQualInput && lotRequalInput) {
+    lotQualInput.addEventListener("change", function (e) {
+      const newDate = e.target.value;
+      if (!newDate) {
+        lotRequalInput.value = "";
+        return;
+      }
+
+      const calculated = calculateRequalificationDate(newDate);
+      lotRequalInput.value = calculated || "";
+    });
+  }
+
+  if (
+    !APP_STATE.setupComplete ||
+    !APP_STATE.currentUser ||
+    !APP_STATE.instructionsAcknowledged
+  ) {
+    showSetupWizard();
+  }
+
+  // Initialize drag and drop
+  initializeDragAndDrop();
+
+  // Persist state every 30 seconds
+  setInterval(persistState, 30000);
+});
+
+// ===============================
+// Setup Wizard
+// ===============================
+
+function showSetupWizard() {
+  const modal = document.getElementById("setup-wizard-modal");
+  modal.classList.add("active");
+  showSetupStep(1);
+}
+
+function showSetupStep(step) {
+  console.log("showSetupStep called with step:", step);
+  APP_STATE.currentSetupStep = step;
+  console.log("currentSetupStep set to:", APP_STATE.currentSetupStep);
+
+  // Rest of the function...
+
+  // Update step indicators
+  for (let i = 1; i <= 3; i++) {
+    const stepEl = document.getElementById(`step-${i}`);
+    stepEl.classList.remove("active", "completed");
+    if (i < step) stepEl.classList.add("completed");
+    if (i === step) stepEl.classList.add("active");
+  }
+
+  // Update content
+  const content = document.getElementById("setup-content");
+  const backBtn = document.getElementById("setup-back");
+  const nextBtn = document.getElementById("setup-next");
+
+  switch (step) {
+    case 1:
+      content.innerHTML = `
+                                                            <h3>Welcome! Let's set up your profile</h3>
+                                                            <p>This platform requires your name so activity can be tracked accurately.</p>
+                                                            <div class="form-group">
+                                                                <label class="form-label">Your Name</label>
+                                                                <input type="text" class="form-input" id="setup-user-name"
+                                                                       placeholder="Enter your full name"
+                                                                       value="${
+                                                                         APP_STATE.currentUser ||
+                                                                         ""
+                                                                       }">
+                                                                <small>This will be used to track changes and activity</small>
+                                                            </div>
+                                                            <div class="alert alert-warning">
+                                                                ⚠️ Editing features remain read-only until setup is complete
+                                                            </div>
+                                                        `;
+      backBtn.style.display = "none";
+      nextBtn.textContent = "Next";
+      nextBtn.disabled = false;
+      break;
+
+    case 2:
+      content.innerHTML = `
+                                                            <h3>Platform Instructions</h3>
+                                                            <div class="instructions-panel">
+                                                                <h4>Important Guidelines:</h4>
+                                                                <ul>
+                                                                    <li>All changes are tracked with your user name</li>
+                                                                    <li>Data auto-saves every 30 seconds</li>
+                                                                    <li>Use Chrome or Edge browser for best compatibility</li>
+                                                                    <li>Your data is saved locally in this browser</li>
+                                                                </ul>
+
+                                                                <h4>Blood Unit Management:</h4>
+                                                                <ul>
+                                                                    <li>Standard unit size: 180 mL per pRBC unit</li>
+                                                                    <li>Maximum blood age: 77 days from event expiration</li>
+                                                                    <li>Standard manufacturing buffer: 10 days</li>
+                                                                    <li>Extended buffer for external testing: 17 days</li>
+                                                                </ul>
+
+                                                                <h4>Blood Calculation Methodology:</h4>
+                                                                <p><strong>Base Formula:</strong><br>
+                                                                pRBC needed = (Quantity + 5 retention) × Volume × Overage × (Hematocrit% / 100)</p>
+
+                                                                <h4>Standard Overage Range (by quantity):</h4>
+                                                                <ul>
+                                                                    <li>&lt;200 samples: 15-20% overage (multiply by 1.15-1.20)</li>
+                                                                    <li>200-1000 samples: 10-15% overage (multiply by 1.10-1.15)</li>
+                                                                    <li>1001-2000 samples: 7-10% overage (multiply by 1.07-1.10)</li>
+                                                                    <li>&gt;2000 samples: 5-7% overage (multiply by 1.05-1.07)</li>
+                                                                </ul>
+
+                                                                <h4>Special Overage (overrides standard):</h4>
+                                                                <ul>
+                                                                    <li>DAT Positive (IgG or C3): 25-30% overage (multiply by 1.25-1.30)</li>
+                                                                    <li>Eluate (ELU) samples: 25-30% overage (multiply by 1.25-1.30)</li>
+                                                                </ul>
+
+                                                                <p><em>Note: System calculates multiple scenarios to identify optimization opportunities</em></p>
+                                                            </div>
+                                                            <div class="form-group">
+                                                                <label class="checkbox-label">
+                                                                    <input type="checkbox" id="acknowledge-instructions">
+                                                                    I have read and understand these instructions
+                                                                </label>
+                                                            </div>
+                                                        `;
+      backBtn.style.display = "inline-flex";
+      nextBtn.textContent = "Next";
+      nextBtn.disabled = false;
+      break;
+
+    case 3:
+      content.innerHTML = `
+                                                            <h3>Setup Complete!</h3>
+                                                            <p>You're ready to start using the Blood Optimization Platform.</p>
+                                                            <div class="alert alert-success">
+                                                                ✅ User profile configured<br>
+                                                                ✅ Instructions acknowledged<br>
+                                                                ✅ Write access enabled
+                                                            </div>
+                                                            <p>You can now:</p>
+                                                            <ul>
+                                                                <li>Import your CSV data files</li>
+                                                                <li>Add customers and antibodies</li>
+                                                                <li>Calculate blood requirements</li>
+                                                                <li>Track inventory and generate reports</li>
+                                                            </ul>
+                                                        `;
+      backBtn.style.display = "inline-flex";
+      nextBtn.textContent = "Get Started";
+      nextBtn.disabled = false;
+      break;
+  }
+}
+
+function nextSetupStep() {
+  console.log(
+    "nextSetupStep called, current step:",
+    APP_STATE.currentSetupStep,
+  );
+
+  if (APP_STATE.currentSetupStep === 1) {
+    const name = document.getElementById("setup-user-name").value.trim();
+    if (!name) {
+      showAlert("error", "Please enter your name");
+      return;
+    }
+    APP_STATE.currentUser = name;
+    localStorage.setItem("current_user", name);
+    updateUserDisplay();
+    console.log("Step 1 validated, name set to:", name);
+  } else if (APP_STATE.currentSetupStep === 2) {
+    const acknowledged = document.getElementById(
+      "acknowledge-instructions",
+    ).checked;
+    if (!acknowledged) {
+      showAlert("error", "Please acknowledge the instructions");
+      return;
+    }
+    APP_STATE.instructionsAcknowledged = true;
+    APP_STATE.writeAccess = true;
+    localStorage.setItem("instructions_acknowledged", "true");
+    console.log("Step 2 validated");
+  } else if (APP_STATE.currentSetupStep === 3) {
+    // Complete setup
+    APP_STATE.setupComplete = true;
+    localStorage.setItem("setup_complete", "true");
+    document.getElementById("setup-wizard-modal").classList.remove("active");
+
+    logActivity("Platform setup completed");
+    showAlert(
+      "success",
+      "Setup complete! Welcome to Blood Optimization Platform.",
+    );
+    console.log("Step 3 - setup complete");
+    persistState();
+    return;
+  }
+
+  console.log(
+    "About to call showSetupStep with step:",
+    APP_STATE.currentSetupStep + 1,
+  );
+  showSetupStep(APP_STATE.currentSetupStep + 1);
+}
+
+function previousSetupStep() {
+  if (APP_STATE.currentSetupStep > 1) {
+    showSetupStep(APP_STATE.currentSetupStep - 1);
+  }
+}
+
+async function persistState() {
+  if (!APP_STATE.writeAccess) return;
+
+  const previousTimestamp = APP_STATE.lastSavedAt;
+
+  try {
+    const timestamp = new Date().toISOString();
+    APP_STATE.lastSavedAt = timestamp;
+    await saveStateToDB(APP_STATE);
+
+    const status = document.getElementById("storage-status");
+    if (status) {
+      status.classList.add("connected");
+    }
+
+    const storageText = document.getElementById("storage-text");
+    if (storageText) {
+      const savedDate = new Date(APP_STATE.lastSavedAt);
+      storageText.textContent = `Last saved ${savedDate.toLocaleString()}`;
+    }
+  } catch (error) {
+    APP_STATE.lastSavedAt = previousTimestamp;
+    console.error("Failed to persist state:", error);
+  }
+}
+
+// ===============================
+// Data Migration Utilities
+// ===============================
+
+function migrateDataFormats(data) {
+  console.log("Starting data format migration...");
+
+  // Helper function to convert antigen string to new format
+  const convertAntigens = (antigenString) => {
+    if (typeof antigenString !== "string" || !antigenString.trim()) {
+      return []; // Return empty array if not a string or is empty
+    }
+
+    const result = [];
+    // Handle formats like "A1-pos K-neg", "K-neg Jka-pos", etc.
+    const antigenPairs = antigenString.split(/\s+/);
+
+    for (const pair of antigenPairs) {
+      if (pair.includes("-")) {
+        const [antigen, status] = pair.split("-");
+        if (antigen && status) {
+          const formattedStatus =
+            status.toLowerCase() === "pos" ? "Positive" : "Negative";
+          result.push({ antigen: antigen.trim(), status: formattedStatus });
+        }
+      }
+    }
+
+    return result;
+  };
+
+  // Helper function to convert legacy antibody fields to new format
+  const convertAntibodies = (antibody1, antibody2) => {
+    const result = [];
+    if (typeof antibody1 === "string" && antibody1.trim()) {
+      result.push(antibody1.trim());
+    }
+    if (typeof antibody2 === "string" && antibody2.trim()) {
+      result.push(antibody2.trim());
+    }
+    return result;
+  };
+
+  // Helper function to convert DAT status
+  const convertDatStatus = (isDatPositive) => {
+    if (typeof isDatPositive === "string") {
+      return isDatPositive.toUpperCase() === "TRUE" ? "Positive" : "Negative";
+    }
+    return "Negative"; // Default
+  };
+
+  // Process customerSpecs
+  if (data.customerSpecs && Array.isArray(data.customerSpecs)) {
+    for (const spec of data.customerSpecs) {
+      // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+      if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+        spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+        delete spec.antibody_1;
+        delete spec.antibody_2;
+      }
+
+      // Migrate antigens from string to array format
+      if (typeof spec.antigens === "string") {
+        spec.antigens = convertAntigens(spec.antigens);
+      }
+
+      // Migrate DAT status
+      if (spec.is_dat_positive !== undefined) {
+        spec.dat_status = convertDatStatus(spec.is_dat_positive);
+        delete spec.is_dat_positive;
+      }
+    }
+    console.log(
+      `Migrated ${data.customerSpecs.length} customer specifications`,
+    );
+  }
+
+  // Process futureSpecs.entries
+  if (
+    data.futureSpecs &&
+    data.futureSpecs.entries &&
+    Array.isArray(data.futureSpecs.entries)
+  ) {
+    for (const spec of data.futureSpecs.entries) {
+      // Migrate antibodies from antibody_1/antibody_2 to antibodies array
+      if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+        spec.antibodies = convertAntibodies(spec.antibody_1, spec.antibody_2);
+        delete spec.antibody_1;
+        delete spec.antibody_2;
+      }
+
+      // Migrate antigens from string to array format
+      if (typeof spec.antigens === "string") {
+        spec.antigens = convertAntigens(spec.antigens);
+      }
+
+      // Migrate DAT status
+      if (spec.is_dat_positive !== undefined) {
+        spec.dat_status = convertDatStatus(spec.is_dat_positive);
+        delete spec.is_dat_positive;
+      }
+    }
+    console.log(
+      `Migrated ${data.futureSpecs.entries.length} future specifications`,
+    );
+  }
+
+  // Process futureSpecs.versions (historical data)
+  if (data.futureSpecs && data.futureSpecs.versions) {
+    Object.keys(data.futureSpecs.versions).forEach((versionKey) => {
+      const versionData = data.futureSpecs.versions[versionKey];
+      if (versionData.samples && Array.isArray(versionData.samples)) {
+        for (const spec of versionData.samples) {
+          // Apply same migrations to historical versions
+          if (spec.antibody_1 !== undefined || spec.antibody_2 !== undefined) {
+            spec.antibodies = convertAntibodies(
+              spec.antibody_1,
+              spec.antibody_2,
+            );
+            delete spec.antibody_1;
+            delete spec.antibody_2;
+          }
+
+          if (typeof spec.antigens === "string") {
+            spec.antigens = convertAntigens(spec.antigens);
+          }
+
+          if (spec.is_dat_positive !== undefined) {
+            spec.dat_status = convertDatStatus(spec.is_dat_positive);
+            delete spec.is_dat_positive;
+          }
+        }
+      }
+    });
+    console.log(
+      `Migrated ${Object.keys(data.futureSpecs.versions).length} future spec versions`,
+    );
+  }
+
+  console.log("Data format migration completed");
+  data.vendors = data.vendors || [];
+  data.historicalQuantities = data.historicalQuantities || [];
+  return data;
+}
+
+// ===============================
+// Data Migration Utilities
+// ===============================
+
+function updateActiveUsers(lastUser) {
+  if (!lastUser) return;
+
+  // Add current user if not in list
+  if (
+    APP_STATE.currentUser &&
+    !APP_STATE.activeUsers.includes(APP_STATE.currentUser)
+  ) {
+    APP_STATE.activeUsers.push(APP_STATE.currentUser);
+  }
+
+  // Update display
+  if (APP_STATE.activeUsers.length > 0) {
+    document.getElementById("active-users").style.display = "flex";
+    document.getElementById("active-user-list").textContent =
+      APP_STATE.activeUsers.join(", ");
+  }
+}
+
+// ===============================
+// Theme Management
+// ===============================
+
+function toggleTheme() {
+  const currentTheme = document.body.getAttribute("data-theme");
+  const newTheme = currentTheme === "light" ? "dark" : "light";
+  document.body.setAttribute("data-theme", newTheme);
+  APP_STATE.theme = newTheme;
+  localStorage.setItem("theme", newTheme);
+  updateThemeIcon();
+}
+
+function updateThemeIcon() {
+  const icon = document.getElementById("theme-icon");
+  icon.textContent = APP_STATE.theme === "light" ? "☀️" : "🌙";
+}
+
+// ===============================
+// User Management
+// ===============================
+
+function updateUserDisplay() {
+  if (APP_STATE.currentUser) {
+    const initials = APP_STATE.currentUser
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase();
+    document.getElementById("user-avatar").textContent = initials;
+    document.getElementById("user-name").textContent = APP_STATE.currentUser;
+  }
+}
+
+// ===============================
+// Activity Logging
+// ===============================
+
+function logActivity(action, details = null) {
+  if (!APP_STATE.writeAccess) return;
+
+  const activity = {
+    timestamp: new Date().toISOString(),
+    user: APP_STATE.currentUser || "Unknown",
+    action: action,
+    details: details,
+  };
+
+  APP_STATE.activityLog.unshift(activity);
+
+  // Keep only last 100 activities
+  if (APP_STATE.activityLog.length > 100) {
+    APP_STATE.activityLog = APP_STATE.activityLog.slice(0, 100);
+  }
+
+  updateActivityLog();
+  persistState();
+}
+
+function updateActivityLog() {
+  const logDiv = document.getElementById("activity-log");
+
+  if (APP_STATE.activityLog.length === 0) {
+    logDiv.innerHTML =
+      '<p class="text-center" style="color: var(--gray);">No activity recorded</p>';
+    return;
+  }
+
+  logDiv.innerHTML = APP_STATE.activityLog
+    .slice(0, 20)
+    .map(
+      (activity) => `
+              <div class="activity-item">
+                <div class="activity-time">${new Date(
+                  activity.timestamp,
+                ).toLocaleTimeString()}</div>
+                <div class="activity-user">${activity.user}</div>
+                <div class="activity-action">${activity.action}${
+                  activity.details ? ` - ${activity.details}` : ""
+                }</div>
+              </div>
+            `,
+    )
+    .join("");
+}
+
+/* ===============================
+      Decision Logging (new)  
+      =============================== */
+function logDecision(type, summary, context = null) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    user: APP_STATE.currentUser || "Unknown",
+    type,
+    summary,
+    context,
+  };
+
+  APP_STATE.decisions = APP_STATE.decisions || [];
+  APP_STATE.decisions.unshift(entry);
+
+  if (APP_STATE.decisions.length > 200) {
+    APP_STATE.decisions.length = 200;
+  }
+
+  updateDecisionsLog();
+  persistState();
+}
+
+function updateDecisionsLog() {
+  const div = document.getElementById("decisions-log");
+  if (!div) return;
+
+  if (!APP_STATE.decisions || APP_STATE.decisions.length === 0) {
+    div.innerHTML =
+      '<p class="text-center" style="color: var(--gray);">No decisions recorded</p>';
+    return;
+  }
+
+  div.innerHTML = APP_STATE.decisions
+    .slice(0, 50)
+    .map((d) => {
+      const t = new Date(d.timestamp).toLocaleString();
+      const ctx = d.context
+        ? '<div class="activity-action" style="color:var(--gray);">' +
+          escapeHtml(JSON.stringify(d.context)) +
+          "</div>"
+        : "";
+      return (
+        '<div class="activity-item">' +
+        '<div class="activity-time">' +
+        t +
+        "</div>" +
+        '<div class="activity-user">' +
+        d.user +
+        "</div>" +
+        '<div class="activity-action"><strong>' +
+        escapeHtml(d.type) +
+        "</strong> — " +
+        escapeHtml(d.summary) +
+        "</div>" +
+        ctx +
+        "</div>"
+      );
+    })
+    .join("");
+}
+
+function showActivitySection(section) {
+  const btnAll = document.getElementById("btn-tab-activity");
+  const btnDec = document.getElementById("btn-tab-decisions");
+  const allDiv = document.getElementById("activity-log");
+  const decDiv = document.getElementById("decisions-log");
+
+  const showDecisions = section === "decisions";
+
+  if (btnAll && btnDec) {
+    btnAll.classList.toggle("btn-primary", !showDecisions);
+    btnAll.classList.toggle("btn-outline", showDecisions);
+    btnDec.classList.toggle("btn-primary", showDecisions);
+    btnDec.classList.toggle("btn-outline", !showDecisions);
+  }
+
+  if (allDiv) allDiv.style.display = showDecisions ? "none" : "";
+  if (decDiv) decDiv.style.display = showDecisions ? "" : "none";
+
+  if (showDecisions) {
+    updateDecisionsLog();
+  } else {
+    updateActivityLog();
+  }
+}
+
+function escapeHtml(s) {
+  if (typeof s !== "string") return s;
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+// ===============================
+// Navigation
+// ===============================
+
+function switchPanel(panelName, evt) {
+  if (
+    !APP_STATE.writeAccess &&
+    ["customers", "calculator", "bup"].includes(panelName)
+  ) {
+    showAlert("warning", "Please complete setup to access this feature");
+    return;
+  }
+
+  // clear active state
+  document
+    .querySelectorAll(".nav-item")
+    .forEach((i) => i.classList.remove("active"));
+
+  // correct target + fixed selector quote
+  const clicked =
+    evt?.currentTarget ||
+    evt?.target?.closest(".nav-item") ||
+    document.querySelector(`.nav-item[onclick*="switchPanel('${panelName}')"]`);
+
+  clicked?.classList.add("active");
+
+  // switch panels
+  document
+    .querySelectorAll(".panel")
+    .forEach((p) => p.classList.remove("active"));
+  const panelElement = document.getElementById(`${panelName}-panel`);
+  if (panelElement) {
+    panelElement.classList.add("active");
+  }
+  if (panelName === "calendar") {
+    renderCalendar();
+  }
+  if (panelName === "activity") {
+    // default to All Activity on open; refresh Decisions as well
+    showActivitySection("all");
+    updateDecisionsLog();
+  }
+
+  if (panelName === "quantities") {
+    if (!APP_STATE._initedPanels.quantities) {
+      populateQuantityFilters();
+      APP_STATE._initedPanels.quantities = true;
+    }
+    updateQuantitiesTable();
+  }
+
+  if (panelName === "historical-quantities") {
+    if (!APP_STATE._initedPanels.historicalQuantities) {
+      updateHistoricalQuantityYearEventOptions();
+      APP_STATE._initedPanels.historicalQuantities = true;
+    }
+    updateHistoricalQuantitiesTable();
+  }
+
+  if (panelName === "bup") {
+    populateBUPEvents();
+  } else if (panelName === "future-specs") {
+    runFutureSpecOptimization();
+    updateFutureSpecsList();
+  } else if (panelName === "activity") {
+    // default to All Activity on open; refresh Decisions as well
+    showActivitySection("all");
+    updateDecisionsLog();
+  }
+}
+
+function showPlaceholder(feature) {
+  showAlert("info", `${feature} - Coming in future version`);
+}
+
+// ===============================
+// Customer Management
+// ===============================
+
+let contactCounter = 0;
+
+let editingRBCId = null;
+let isLoggingUsage = false;
+let editingSerumId = null;
+let isLoggingSerumUsage = false;
+
+function updateCustomerList() {
+  const listDiv = document.getElementById("customer-list");
+
+  if (APP_STATE.customers.length === 0) {
+    listDiv.innerHTML = `
+                                                        <div class="text-center" style="grid-column: 1/-1; color: var(--gray);">
+                                                            No customers yet. Click "Add PT Customer" to get started.
+                                                        </div>
+                                                    `;
+    return;
+  }
+
+  listDiv.innerHTML = APP_STATE.customers
+    .map(
+      (customer) => `
+                                                    <div class="customer-card">
+                                                        <div class="customer-actions">
+                                                            <button onclick="editCustomer('${
+                                                              customer.id
+                                                            }')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>✏️</button>
+                                                            <button onclick="deleteCustomer('${
+                                                              customer.id
+                                                            }')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>🗑️</button>
+                                                        </div>
+                                                        <div class="customer-header">
+                                                            <div>
+                                                                <div class="customer-name">${
+                                                                  customer.name
+                                                                }</div>
+                                                                <div class="customer-code">Code: ${
+                                                                  customer.code
+                                                                }</div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="customer-info">📍 ${
+                                                          customer.region
+                                                        }</div>
+                                                        ${
+                                                          customer.notes
+                                                            ? `<div class="customer-info" style="font-style: italic;">📝 ${customer.notes}</div>`
+                                                            : ""
+                                                        }
+                                                        ${
+                                                          customer.contacts &&
+                                                          customer.contacts
+                                                            .length > 0
+                                                            ? `
+                                                            <div class="customer-contacts">
+                                                                ${customer.contacts
+                                                                  .slice(0, 2)
+                                                                  .map(
+                                                                    (
+                                                                      contact,
+                                                                    ) => `
+                                                                    <div class="contact-item">
+                                                                        <span>👤 ${contact.name} (${contact.role})</span>
+                                                                    </div>
+                                                                `,
+                                                                  )
+                                                                  .join("")}
+                                                                ${
+                                                                  customer
+                                                                    .contacts
+                                                                    .length > 2
+                                                                    ? `<div class="contact-item" style="color: var(--gray);">+${
+                                                                        customer
+                                                                          .contacts
+                                                                          .length -
+                                                                        2
+                                                                      } more contacts</div>`
+                                                                    : ""
+                                                                }
+                                                            </div>
+                                                        `
+                                                            : ""
+                                                        }
+                                                    </div>
+                                                `,
+    )
+    .join("");
+}
+
+function updateCustomerDependentUI() {
+  updateCustomerList();
+  populateCustomerDropdowns();
+}
+
+function openCustomerModal(customerId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to add PT customers");
+    return;
+  }
+
+  const modal = document.getElementById("customer-modal");
+  const title = document.getElementById("customer-modal-title");
+
+  // Reset contact list
+  document.getElementById("contact-list").innerHTML = "";
+  contactCounter = 0;
+
+  if (customerId) {
+    const customer = APP_STATE.customers.find((c) => c.id === customerId);
+    title.textContent = "Edit PT Customer";
+    document.getElementById("customer-name").value = customer.name;
+    document.getElementById("customer-code").value = customer.code;
+    document.getElementById("customer-region").value = customer.region;
+    document.getElementById("customer-notes").value = customer.notes || "";
+
+    // Load contacts
+    if (customer.contacts) {
+      customer.contacts.forEach((contact) => {
+        addContactField(contact);
+      });
+    }
+
+    APP_STATE.editingCustomerId = customerId;
+  } else {
+    title.textContent = "Add PT Customer";
+    document.getElementById("customer-name").value = "";
+    document.getElementById("customer-code").value = "";
+    document.getElementById("customer-region").value = "";
+    document.getElementById("customer-notes").value = "";
+    APP_STATE.editingCustomerId = null;
+
+    // Add one empty contact field
+    addContactField();
+  }
+
+  modal.classList.add("active");
+}
+
+function addContactField(contact = null) {
+  const contactList = document.getElementById("contact-list");
+  const contactId = `contact_${contactCounter++}`;
+
+  const contactDiv = document.createElement("div");
+  contactDiv.className = "contact-entry";
+  contactDiv.id = contactId;
+  contactDiv.innerHTML = `
+                                                    <div class="contact-entry-header">
+                                                        <h5>Contact ${contactCounter}</h5>
+                                                        <button class="contact-remove" onclick="removeContact('${contactId}')">×</button>
+                                                    </div>
+                                                    <div class="form-grid">
+                                                        <div class="form-group">
+                                                            <label class="form-label">Name</label>
+                                                            <input type="text" class="form-input contact-name" placeholder="Jane Smith" value="${
+                                                              contact
+                                                                ? contact.name
+                                                                : ""
+                                                            }">
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Role</label>
+                                                            <select class="form-select contact-role">
+                                                                <option value="Primary" ${
+                                                                  contact &&
+                                                                  contact.role ===
+                                                                    "Primary"
+                                                                    ? "selected"
+                                                                    : ""
+                                                                }>Primary Contact</option>
+                                                                <option value="Secondary" ${
+                                                                  contact &&
+                                                                  contact.role ===
+                                                                    "Secondary"
+                                                                    ? "selected"
+                                                                    : ""
+                                                                }>Secondary Contact</option>
+                                                                <option value="Technical" ${
+                                                                  contact &&
+                                                                  contact.role ===
+                                                                    "Technical"
+                                                                    ? "selected"
+                                                                    : ""
+                                                                }>Technical Contact</option>
+                                                                <option value="Billing" ${
+                                                                  contact &&
+                                                                  contact.role ===
+                                                                    "Billing"
+                                                                    ? "selected"
+                                                                    : ""
+                                                                }>Billing Contact</option>
+                                                            </select>
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Email</label>
+                                                            <input type="email" class="form-input contact-email" placeholder="jane@example.com" value="${
+                                                              contact
+                                                                ? contact.email
+                                                                : ""
+                                                            }">
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label class="form-label">Phone</label>
+                                                            <input type="tel" class="form-input contact-phone" placeholder="+1 (555) 123-4567" value="${
+                                                              contact
+                                                                ? contact.phone
+                                                                : ""
+                                                            }">
+                                                        </div>
+                                                    </div>
+                                                `;
+
+  contactList.appendChild(contactDiv);
+}
+
+function removeContact(contactId) {
+  document.getElementById(contactId).remove();
+}
+
+function closeCustomerModal() {
+  document.getElementById("customer-modal").classList.remove("active");
+  APP_STATE.editingCustomerId = null;
+}
+
+function saveCustomer() {
+  const name = document.getElementById("customer-name").value.trim();
+  const code = document.getElementById("customer-code").value.trim();
+  const region = document.getElementById("customer-region").value;
+  const notes = document.getElementById("customer-notes").value.trim();
+
+  if (!name || !code || !region) {
+    showAlert("error", "Name, code, and region are required");
+    return;
+  }
+
+  // Collect contacts
+  const contacts = [];
+  document.querySelectorAll(".contact-entry").forEach((entry) => {
+    const contact = {
+      name: entry.querySelector(".contact-name").value.trim(),
+      role: entry.querySelector(".contact-role").value,
+      email: entry.querySelector(".contact-email").value.trim(),
+      phone: entry.querySelector(".contact-phone").value.trim(),
+    };
+
+    if (contact.name || contact.email) {
+      contacts.push(contact);
+    }
+  });
+
+  if (APP_STATE.editingCustomerId) {
+    // Edit existing
+    const customer = APP_STATE.customers.find(
+      (c) => c.id === APP_STATE.editingCustomerId,
+    );
+    customer.name = name;
+    customer.code = code;
+    customer.region = region;
+    customer.notes = notes;
+    customer.contacts = contacts;
+    logActivity("Updated customer", name);
+    showAlert("success", "Customer updated successfully");
+    closeCustomerModal();
+  } else {
+    // Add new
+    const newCustomer = {
+      id: "cust_" + Date.now(),
+      name,
+      code,
+      region,
+      notes,
+      contacts,
+      createdAt: new Date().toISOString(),
+      createdBy: APP_STATE.currentUser,
+    };
+    APP_STATE.customers.push(newCustomer);
+    logActivity("Added customer", name);
+    showAlert("success", "Customer added successfully");
+    closeCustomerModal();
+  }
+
+  updateCustomerDependentUI();
+  updateDashboard();
+  persistState();
+}
+
+function editCustomer(customerId) {
+  openCustomerModal(customerId);
+}
+
+function deleteCustomer(customerId) {
+  if (!APP_STATE.writeAccess) return;
+
+  const customer = APP_STATE.customers.find((c) => c.id === customerId);
+  if (
+    confirm(
+      `Are you sure you want to delete ${customer.name}? This cannot be undone.`,
+    )
+  ) {
+    APP_STATE.customers = APP_STATE.customers.filter(
+      (c) => c.id !== customerId,
+    );
+    updateCustomerDependentUI();
+    updateDashboard();
+    logActivity("Deleted customer", customer.name);
+    persistState();
+    showAlert("success", "Customer deleted");
+  }
+}
+
+// ===============================
+// Blood Supplier Management
+// ===============================
+
+function updateBloodSupplierList() {
+  const listDiv = document.getElementById("blood-supplier-list");
+  if (!listDiv) return;
+
+  if (!APP_STATE.bloodSuppliers || APP_STATE.bloodSuppliers.length === 0) {
+    listDiv.innerHTML = `
+                                                    <div class="text-center" style="grid-column: 1 / -1; color: var(--gray);">
+                                                        No blood suppliers yet. Click "+ Add Supplier" to add one.
+                                                    </div>
+                                                `;
+    return;
+  }
+
+  listDiv.innerHTML = APP_STATE.bloodSuppliers
+    .map((supplier) => {
+      const pricing = supplier.pricing || {};
+      const baseUnit = Number(pricing.baseUnit || 0);
+      const perAntigen = Number(pricing.perAntigen || 0);
+      const rareFee = Number(pricing.rareFee || 0);
+      const pricingSummary = `Base: $${baseUnit.toFixed(2)}, Antigen: $${perAntigen.toFixed(2)}, Rare: $${rareFee.toFixed(2)}`;
+
+      return `
+                                                    <div class="customer-card">
+                                                        <div class="customer-actions">
+                                                            <button onclick="openBloodSupplierModal('${supplier.id}')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>✏️</button>
+                                                            <button onclick="deleteBloodSupplier('${supplier.id}')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>🗑️</button>
+                                                        </div>
+                                                        <div class="customer-header">
+                                                            <div>
+                                                                <div class="customer-name">${supplier.name}</div>
+                                                                <div class="customer-code">${pricingSummary}</div>
+                                                            </div>
+                                                        </div>
+                                                        ${
+                                                          supplier.notes
+                                                            ? `<div class="customer-info" style="font-style: italic;">📝 ${supplier.notes}</div>`
+                                                            : ""
+                                                        }
+                                                    </div>
+                                                `;
+    })
+    .join("");
+}
+
+function openBloodSupplierModal(supplierId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage blood suppliers");
+    return;
+  }
+
+  const modal = document.getElementById("blood-supplier-modal");
+  const title = document.getElementById("blood-supplier-modal-title");
+
+  if (supplierId) {
+    const supplier = APP_STATE.bloodSuppliers.find((s) => s.id === supplierId);
+    if (!supplier) return;
+
+    title.textContent = "Edit Blood Supplier";
+    document.getElementById("supplier-name").value = supplier.name || "";
+    document.getElementById("supplier-notes").value = supplier.notes || "";
+    document.getElementById("supplier-base-price").value =
+      supplier.pricing?.baseUnit != null ? supplier.pricing.baseUnit : "";
+    document.getElementById("supplier-antigen-fee").value =
+      supplier.pricing?.perAntigen != null ? supplier.pricing.perAntigen : "";
+    document.getElementById("supplier-rare-fee").value =
+      supplier.pricing?.rareFee != null ? supplier.pricing.rareFee : "";
+    editingSupplierId = supplierId;
+  } else {
+    title.textContent = "Add Blood Supplier";
+    document.getElementById("supplier-name").value = "";
+    document.getElementById("supplier-notes").value = "";
+    document.getElementById("supplier-base-price").value = "";
+    document.getElementById("supplier-antigen-fee").value = "";
+    document.getElementById("supplier-rare-fee").value = "";
+    editingSupplierId = null;
+  }
+
+  modal.classList.add("active");
+}
+
+function closeBloodSupplierModal() {
+  const modal = document.getElementById("blood-supplier-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  document.getElementById("supplier-name").value = "";
+  document.getElementById("supplier-notes").value = "";
+  document.getElementById("supplier-base-price").value = "";
+  document.getElementById("supplier-antigen-fee").value = "";
+  document.getElementById("supplier-rare-fee").value = "";
+  editingSupplierId = null;
+}
+
+function saveBloodSupplier() {
+  if (!APP_STATE.writeAccess) return;
+
+  const name = document.getElementById("supplier-name").value.trim();
+  const notes = document.getElementById("supplier-notes").value.trim();
+  const baseUnitInput = document.getElementById("supplier-base-price").value;
+  const antigenInput = document.getElementById("supplier-antigen-fee").value;
+  const rareInput = document.getElementById("supplier-rare-fee").value;
+
+  if (!name) {
+    showAlert("error", "Supplier name is required");
+    return;
+  }
+
+  const pricing = {
+    baseUnit: parseFloat(baseUnitInput) || 0,
+    perAntigen: parseFloat(antigenInput) || 0,
+    rareFee: parseFloat(rareInput) || 0,
+  };
+
+  if (editingSupplierId) {
+    const supplier = APP_STATE.bloodSuppliers.find(
+      (s) => s.id === editingSupplierId,
+    );
+    if (!supplier) return;
+
+    supplier.name = name;
+    supplier.notes = notes;
+    supplier.pricing = pricing;
+    supplier.updatedAt = new Date().toISOString();
+    supplier.updatedBy = APP_STATE.currentUser;
+    logActivity("Updated blood supplier", name);
+    showAlert("success", "Blood supplier updated successfully");
+  } else {
+    const newSupplier = {
+      id: "bsup_" + Date.now(),
+      name,
+      notes,
+      pricing,
+      createdAt: new Date().toISOString(),
+      createdBy: APP_STATE.currentUser,
+    };
+
+    APP_STATE.bloodSuppliers.push(newSupplier);
+    logActivity("Added blood supplier", name);
+    showAlert("success", "Blood supplier added successfully");
+  }
+
+  updateBloodSupplierList();
+  updateDashboard();
+  persistState();
+  closeBloodSupplierModal();
+}
+
+function deleteBloodSupplier(supplierId) {
+  if (!APP_STATE.writeAccess) return;
+
+  const supplier = APP_STATE.bloodSuppliers.find((s) => s.id === supplierId);
+  if (!supplier) return;
+
+  if (
+    confirm(
+      `Are you sure you want to delete ${supplier.name}? This cannot be undone.`,
+    )
+  ) {
+    APP_STATE.bloodSuppliers = APP_STATE.bloodSuppliers.filter(
+      (s) => s.id !== supplierId,
+    );
+    updateBloodSupplierList();
+    updateDashboard();
+    persistState();
+    logActivity("Deleted blood supplier", supplier.name);
+    showAlert("success", "Blood supplier deleted");
+  }
+}
+
+// ===============================
+// Bulk RBC Inventory
+// ===============================
+
+function updateBulkRBCList() {
+  const listDiv = document.getElementById("bulk-rbc-list");
+  if (!listDiv) return;
+
+  const units = APP_STATE.bulkRBCs || [];
+
+  if (units.length === 0) {
+    listDiv.innerHTML = `
+                                                    <div class="text-center" style="grid-column: 1 / -1; color: var(--gray);">
+                                                        No RBC units logged yet. Click "+ Add RBC Unit" to begin.
+                                                    </div>
+                                                `;
+    return;
+  }
+
+  listDiv.innerHTML = units
+    .map((unit) => {
+      const antigens =
+        unit.antigens && unit.antigens.length > 0
+          ? unit.antigens
+              .map((a) => `${a.antigen}${a.status ? ` (${a.status})` : ""}`)
+              .join(", ")
+          : "None recorded";
+
+      const currentVolume =
+        unit.currentVolume != null
+          ? `${Number(unit.currentVolume).toFixed(1)} mL`
+          : "0 mL";
+
+      const expiration = unit.expirationDate
+        ? new Date(unit.expirationDate).toLocaleDateString()
+        : "N/A";
+      const bleedDate = unit.bleedDate
+        ? new Date(unit.bleedDate).toLocaleDateString()
+        : "N/A";
+
+      const lastEntry =
+        unit.history && unit.history.length > 0 ? unit.history[0] : null;
+      let lastUsage = "No usage logged yet";
+      if (lastEntry) {
+        const ts = lastEntry.timestamp ? new Date(lastEntry.timestamp) : null;
+        const formatted =
+          ts && !isNaN(ts) ? ts.toLocaleString() : "Unknown time";
+        lastUsage = `Last used ${formatted}${lastEntry.notes ? ` – ${lastEntry.notes}` : ""}`;
+      }
+
+      const disabledAttr = !APP_STATE.writeAccess ? "disabled" : "";
+
+      return `
+                                                    <div class="customer-card">
+                                                        <div class="customer-header" style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem;">
+                                                            <div>
+                                                                <div class="customer-name">${unit.unitId || "Unnamed Unit"}</div>
+                                                                <div class="customer-code">Blood Type: ${unit.bloodType || "Unknown"}</div>
+                                                            </div>
+                                                            <button type="button" class="btn btn-outline btn-sm" onclick="openBulkRBCModal('${unit.id}', true)" ${disabledAttr}>Log Usage</button>
+                                                        </div>
+                                                        <div class="customer-info">💉 Current Volume: ${currentVolume}</div>
+                                                        <div class="customer-info">🧪 Antigens: ${antigens}</div>
+                                                        <div class="customer-info">🗓️ Bleed Date: ${bleedDate}</div>
+                                                        <div class="customer-info">⏳ Expires: ${expiration}</div>
+                                                        <div class="customer-info" style="font-style: italic;">${lastUsage}</div>
+                                                    </div>
+                                                `;
+    })
+    .join("");
+}
+
+function openBulkRBCModal(unitId = null, logging = false) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage bulk RBCs");
+    return;
+  }
+
+  const modal = document.getElementById("bulk-rbc-modal");
+  if (!modal) return;
+
+  const title = document.getElementById("bulk-rbc-modal-title");
+  const addFields = document.getElementById("bulk-rbc-add-fields");
+  const logFields = document.getElementById("bulk-rbc-log-fields");
+
+  editingRBCId = unitId;
+  isLoggingUsage = logging;
+
+  if (logging) {
+    const unit = APP_STATE.bulkRBCs.find((u) => u.id === unitId);
+    if (!unit) {
+      showAlert("error", "Unable to find the selected RBC unit.");
+      return;
+    }
+
+    title.textContent = "Log Usage";
+    if (addFields) addFields.style.display = "none";
+    if (logFields) logFields.style.display = "block";
+    const unitLabel = document.getElementById("log-usage-unit-id");
+    if (unitLabel) unitLabel.textContent = unit.unitId || unit.id;
+    const usageInput = document.getElementById("rbc-usage-volume");
+    const notesInput = document.getElementById("rbc-usage-notes");
+    if (usageInput) usageInput.value = "";
+    if (notesInput) notesInput.value = "";
+  } else {
+    title.textContent = "Add RBC Unit";
+    if (addFields) addFields.style.display = "block";
+    if (logFields) logFields.style.display = "none";
+    const unitInput = document.getElementById("rbc-unit-id");
+    const bloodTypeInput = document.getElementById("rbc-blood-type");
+    const volumeInput = document.getElementById("rbc-initial-volume");
+    const bleedInput = document.getElementById("rbc-bleed-date");
+    const expiryInput = document.getElementById("rbc-expiration-date");
+    if (unitInput) unitInput.value = "";
+    if (bloodTypeInput) bloodTypeInput.value = "";
+    if (volumeInput) volumeInput.value = "180";
+    if (bleedInput) bleedInput.value = "";
+    if (expiryInput) expiryInput.value = "";
+    const antigenList = document.getElementById("rbc-antigen-list");
+    if (antigenList) {
+      antigenList.innerHTML = "";
+      addRBCAntigenRow();
+    }
+  }
+
+  modal.classList.add("active");
+}
+
+function closeBulkRBCModal() {
+  const modal = document.getElementById("bulk-rbc-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  const addFields = document.getElementById("bulk-rbc-add-fields");
+  const logFields = document.getElementById("bulk-rbc-log-fields");
+  if (addFields) addFields.style.display = "block";
+  if (logFields) logFields.style.display = "none";
+  const usageInput = document.getElementById("rbc-usage-volume");
+  const notesInput = document.getElementById("rbc-usage-notes");
+  if (usageInput) usageInput.value = "";
+  if (notesInput) notesInput.value = "";
+  editingRBCId = null;
+  isLoggingUsage = false;
+}
+
+function saveBulkRBC() {
+  if (!APP_STATE.writeAccess) return;
+
+  if (isLoggingUsage && editingRBCId) {
+    const unit = APP_STATE.bulkRBCs.find((u) => u.id === editingRBCId);
+    if (!unit) {
+      showAlert("error", "Unable to find the selected RBC unit.");
+      return;
+    }
+
+    const usageValue = parseFloat(
+      document.getElementById("rbc-usage-volume").value,
+    );
+    if (!usageValue || usageValue <= 0) {
+      showAlert("error", "Enter a valid usage volume.");
+      return;
+    }
+
+    const currentVolume = Number(unit.currentVolume || 0);
+    if (usageValue > currentVolume) {
+      showAlert("warning", "Usage exceeds the remaining volume for this unit.");
+      return;
+    }
+
+    const notes = document.getElementById("rbc-usage-notes").value.trim();
+    const newVolume = Math.max(0, currentVolume - usageValue);
+    unit.currentVolume = Math.round(newVolume * 100) / 100;
+    if (!Array.isArray(unit.history)) unit.history = [];
+    unit.history.unshift({
+      id: "rbc_usage_" + Date.now(),
+      timestamp: new Date().toISOString(),
+      volumeUsed: usageValue,
+      notes,
+      remainingVolume: unit.currentVolume,
+      user: APP_STATE.currentUser || "Unknown",
+    });
+
+    logActivity(
+      "Logged RBC usage",
+      `${usageValue} mL from ${unit.unitId || unit.id}`,
+    );
+    showAlert("success", "Usage logged successfully.");
+  } else {
+    const unitIdInput = document.getElementById("rbc-unit-id").value.trim();
+    const bloodType = document.getElementById("rbc-blood-type").value.trim();
+    const initialVolumeInput = parseFloat(
+      document.getElementById("rbc-initial-volume").value,
+    );
+    const bleedDate = document.getElementById("rbc-bleed-date").value;
+    const expirationDate = document.getElementById("rbc-expiration-date").value;
+
+    if (!unitIdInput) {
+      showAlert("error", "Unit ID is required.");
+      return;
+    }
+    if (!initialVolumeInput || initialVolumeInput <= 0) {
+      showAlert("error", "Enter a valid initial volume.");
+      return;
+    }
+
+    const antigenList = [];
+    const antigenContainer = document.getElementById("rbc-antigen-list");
+    if (antigenContainer) {
+      antigenContainer.querySelectorAll(".antigen-row").forEach((row) => {
+        const selects = row.querySelectorAll("select");
+        if (selects.length >= 2) {
+          const antigen = selects[0].value;
+          const status = selects[1].value;
+          if (antigen) {
+            antigenList.push({ antigen, status });
+          }
+        }
+      });
+    }
+
+    const normalizedVolume = Math.round(initialVolumeInput * 100) / 100;
+    const newUnit = {
+      id: "rbc_" + Date.now(),
+      unitId: unitIdInput,
+      bloodType,
+      initialVolume: normalizedVolume,
+      currentVolume: normalizedVolume,
+      bleedDate,
+      expirationDate,
+      antigens: antigenList,
+      history: [],
+      createdAt: new Date().toISOString(),
+      createdBy: APP_STATE.currentUser || "Unknown",
+    };
+
+    APP_STATE.bulkRBCs.push(newUnit);
+    logActivity("Added RBC unit", unitIdInput);
+    showAlert("success", "RBC unit added successfully.");
+  }
+
+  updateBulkRBCList();
+  persistState();
+  closeBulkRBCModal();
+}
+
+function addRBCAntigenRow(antigen = "", status = "Positive") {
+  const container = document.getElementById("rbc-antigen-list");
+  if (!container) return;
+
+  const rowId =
+    "rbc-antigen-" + Date.now() + "-" + Math.floor(Math.random() * 1000);
+  const row = document.createElement("div");
+  row.className = "antigen-row";
+  row.id = rowId;
+  row.style.display = "flex";
+  row.style.gap = "0.5rem";
+  row.style.marginBottom = "0.5rem";
+
+  const antigenOptions = ['<option value="">Select</option>'];
+  if (typeof ANTIGEN_ORDER !== "undefined" && Array.isArray(ANTIGEN_ORDER)) {
+    ANTIGEN_ORDER.forEach((a) => {
+      antigenOptions.push(
+        `<option value="${a}" ${a === antigen ? "selected" : ""}>${a}</option>`,
+      );
+    });
+  }
+
+  row.innerHTML = `
+          <select class="form-select" style="min-width: 120px;">${antigenOptions.join("")}</select>
+          <select class="form-select" style="min-width: 120px;">
+            <option value="Positive" ${status === "Positive" ? "selected" : ""}>Positive</option>
+            <option value="Negative" ${status === "Negative" ? "selected" : ""}>Negative</option>
+          </select>
+          <button type="button" class="btn btn-danger btn-sm" onclick="removeRBCAntigenRow('${rowId}')">×</button>
+        `;
+
+  container.appendChild(row);
+}
+
+function removeRBCAntigenRow(rowId) {
+  const row = document.getElementById(rowId);
+  if (row && row.parentElement) {
+    row.parentElement.removeChild(row);
+  }
+}
+
+// ===============================
+// Bulk Serum Inventory
+// ===============================
+
+function updateBulkSerumList() {
+  const listDiv = document.getElementById("bulk-serum-list");
+  if (!listDiv) return;
+
+  const serums = APP_STATE.bulkSerums || [];
+
+  if (serums.length === 0) {
+    listDiv.innerHTML = `
+                                                    <div class="text-center" style="grid-column: 1 / -1; color: var(--gray);">
+                                                        No serums logged yet. Click "+ Add Serum Lot" to begin.
+                                                    </div>
+                                                `;
+    return;
+  }
+
+  listDiv.innerHTML = serums
+    .map((serum) => {
+      const currentVolume =
+        serum.currentVolume != null
+          ? `${Number(serum.currentVolume).toFixed(1)} mL`
+          : "0 mL";
+      const received = serum.receiveDate
+        ? new Date(serum.receiveDate).toLocaleDateString()
+        : "N/A";
+      const expiration = serum.expirationDate
+        ? new Date(serum.expirationDate).toLocaleDateString()
+        : "N/A";
+      const lastEntry =
+        serum.history && serum.history.length > 0 ? serum.history[0] : null;
+      let lastUsage = "No usage logged yet";
+      if (lastEntry) {
+        const ts = lastEntry.timestamp ? new Date(lastEntry.timestamp) : null;
+        const formatted =
+          ts && !isNaN(ts) ? ts.toLocaleString() : "Unknown time";
+        lastUsage = `Last used ${formatted}${lastEntry.notes ? ` – ${lastEntry.notes}` : ""}`;
+      }
+      const disabledAttr = !APP_STATE.writeAccess ? "disabled" : "";
+
+      return `
+                                                    <div class="customer-card">
+                                                        <div class="customer-header" style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem;">
+                                                            <div>
+                                                                <div class="customer-name">${serum.serumId || "Unnamed Serum"}</div>
+                                                                <div class="customer-code">${serum.description || "No description provided"}</div>
+                                                            </div>
+                                                            <button type="button" class="btn btn-outline btn-sm" onclick="openBulkSerumModal('${serum.id}', true)" ${disabledAttr}>Log Usage</button>
+                                                        </div>
+                                                        <div class="customer-info">💉 Current Volume: ${currentVolume}</div>
+                                                        <div class="customer-info">📦 Received: ${received}</div>
+                                                        <div class="customer-info">⏳ Expires: ${expiration}</div>
+                                                        <div class="customer-info" style="font-style: italic;">${lastUsage}</div>
+                                                    </div>
+                                                `;
+    })
+    .join("");
+}
+
+function openBulkSerumModal(unitId = null, logging = false) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage bulk serums");
+    return;
+  }
+
+  const modal = document.getElementById("bulk-serum-modal");
+  if (!modal) return;
+
+  const title = document.getElementById("bulk-serum-modal-title");
+  const addFields = document.getElementById("bulk-serum-add-fields");
+  const logFields = document.getElementById("bulk-serum-log-fields");
+
+  editingSerumId = unitId;
+  isLoggingSerumUsage = logging;
+
+  if (logging) {
+    const serum = APP_STATE.bulkSerums.find((s) => s.id === unitId);
+    if (!serum) {
+      showAlert("error", "Unable to find the selected serum lot.");
+      return;
+    }
+
+    title.textContent = "Log Serum Usage";
+    if (addFields) addFields.style.display = "none";
+    if (logFields) logFields.style.display = "block";
+    const unitLabel = document.getElementById("log-usage-serum-id");
+    if (unitLabel) unitLabel.textContent = serum.serumId || serum.id;
+    const usageInput = document.getElementById("serum-usage-volume");
+    const notesInput = document.getElementById("serum-usage-notes");
+    if (usageInput) usageInput.value = "";
+    if (notesInput) notesInput.value = "";
+  } else {
+    title.textContent = "Add Serum Lot";
+    if (addFields) addFields.style.display = "block";
+    if (logFields) logFields.style.display = "none";
+    const idInput = document.getElementById("serum-unit-id");
+    const descInput = document.getElementById("serum-description");
+    const volumeInput = document.getElementById("serum-initial-volume");
+    const receiveInput = document.getElementById("serum-receive-date");
+    const expireInput = document.getElementById("serum-expiration-date");
+    if (idInput) idInput.value = "";
+    if (descInput) descInput.value = "";
+    if (volumeInput) volumeInput.value = "";
+    if (receiveInput) receiveInput.value = "";
+    if (expireInput) expireInput.value = "";
+  }
+
+  modal.classList.add("active");
+}
+
+function closeBulkSerumModal() {
+  const modal = document.getElementById("bulk-serum-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  const addFields = document.getElementById("bulk-serum-add-fields");
+  const logFields = document.getElementById("bulk-serum-log-fields");
+  if (addFields) addFields.style.display = "block";
+  if (logFields) logFields.style.display = "none";
+  const usageInput = document.getElementById("serum-usage-volume");
+  const notesInput = document.getElementById("serum-usage-notes");
+  if (usageInput) usageInput.value = "";
+  if (notesInput) notesInput.value = "";
+  editingSerumId = null;
+  isLoggingSerumUsage = false;
+}
+
+function saveBulkSerum() {
+  if (!APP_STATE.writeAccess) return;
+
+  if (isLoggingSerumUsage && editingSerumId) {
+    const serum = APP_STATE.bulkSerums.find((s) => s.id === editingSerumId);
+    if (!serum) {
+      showAlert("error", "Unable to find the selected serum lot.");
+      return;
+    }
+
+    const usageValue = parseFloat(
+      document.getElementById("serum-usage-volume").value,
+    );
+    if (!usageValue || usageValue <= 0) {
+      showAlert("error", "Enter a valid usage volume.");
+      return;
+    }
+
+    const currentVolume = Number(serum.currentVolume || 0);
+    if (usageValue > currentVolume) {
+      showAlert(
+        "warning",
+        "Usage exceeds the remaining volume for this serum lot.",
+      );
+      return;
+    }
+
+    const notes = document.getElementById("serum-usage-notes").value.trim();
+    const newVolume = Math.max(0, currentVolume - usageValue);
+    serum.currentVolume = Math.round(newVolume * 100) / 100;
+    if (!Array.isArray(serum.history)) serum.history = [];
+    serum.history.unshift({
+      id: "serum_usage_" + Date.now(),
+      timestamp: new Date().toISOString(),
+      volumeUsed: usageValue,
+      notes,
+      remainingVolume: serum.currentVolume,
+      user: APP_STATE.currentUser || "Unknown",
+    });
+
+    logActivity(
+      "Logged serum usage",
+      `${usageValue} mL from ${serum.serumId || serum.id}`,
+    );
+    showAlert("success", "Serum usage logged successfully.");
+  } else {
+    const serumId = document.getElementById("serum-unit-id").value.trim();
+    const description = document
+      .getElementById("serum-description")
+      .value.trim();
+    const initialVolumeInput = parseFloat(
+      document.getElementById("serum-initial-volume").value,
+    );
+    const receiveDate = document.getElementById("serum-receive-date").value;
+    const expirationDate = document.getElementById(
+      "serum-expiration-date",
+    ).value;
+
+    if (!serumId) {
+      showAlert("error", "Serum ID is required.");
+      return;
+    }
+    if (!initialVolumeInput || initialVolumeInput <= 0) {
+      showAlert("error", "Enter a valid initial volume.");
+      return;
+    }
+
+    const normalizedVolume = Math.round(initialVolumeInput * 100) / 100;
+    const newSerum = {
+      id: "serum_" + Date.now(),
+      serumId,
+      description,
+      initialVolume: normalizedVolume,
+      currentVolume: normalizedVolume,
+      receiveDate,
+      expirationDate,
+      history: [],
+      createdAt: new Date().toISOString(),
+      createdBy: APP_STATE.currentUser || "Unknown",
+    };
+
+    APP_STATE.bulkSerums.push(newSerum);
+    logActivity("Added serum lot", serumId);
+    showAlert("success", "Serum lot added successfully.");
+  }
+
+  updateBulkSerumList();
+  persistState();
+  closeBulkSerumModal();
+}
+
+// ===============================
+// Vendor Management
+// ===============================
+
+function updateVendorList() {
+  const listDiv = document.getElementById("vendor-list");
+  if (!listDiv) return;
+
+  if (!APP_STATE.vendors || APP_STATE.vendors.length === 0) {
+    listDiv.innerHTML = `
+                                                    <div class="text-center" style="grid-column: 1 / -1; color: var(--gray);">
+                                                        No vendors yet. Click "+ Add Vendor" to add one.
+                                                    </div>
+                                                `;
+    return;
+  }
+
+  listDiv.innerHTML = APP_STATE.vendors
+    .map(
+      (vendor) => `
+                                                    <div class="customer-card">
+                                                        <div class="customer-actions">
+                                                            <button onclick="openVendorModal('${vendor.id}')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>✏️</button>
+                                                            <button onclick="deleteVendor('${vendor.id}')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>🗑️</button>
+                                                        </div>
+                                                        <div class="customer-header">
+                                                            <div>
+                                                                <div class="customer-name">${vendor.name}</div>
+                                                                <div class="customer-code">Category: ${
+                                                                  vendor.category ||
+                                                                  "Other"
+                                                                }</div>
+                                                            </div>
+                                                        </div>
+                                                        ${
+                                                          vendor.notes
+                                                            ? `<div class="customer-info" style="font-style: italic;">📝 ${vendor.notes}</div>`
+                                                            : ""
+                                                        }
+                                                        <div class="customer-info" style="margin-top: 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                                                            <button class="btn btn-primary btn-sm" onclick="openLogPurchaseModal('${vendor.id}')" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>Log Purchase</button>
+                                                            <button class="btn btn-outline btn-sm" onclick="openViewPurchasesModal('${vendor.id}')">View Purchases</button>
+                                                        </div>
+                                                    </div>
+                                                `,
+    )
+    .join("");
+}
+
+function openVendorModal(vendorId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage vendors");
+    return;
+  }
+
+  const modal = document.getElementById("vendor-modal");
+  const title = document.getElementById("vendor-modal-title");
+
+  if (vendorId) {
+    const vendor = APP_STATE.vendors.find((v) => v.id === vendorId);
+    if (!vendor) return;
+    title.textContent = "Edit Vendor";
+    document.getElementById("vendor-name").value = vendor.name || "";
+    document.getElementById("vendor-category").value =
+      vendor.category || "Other";
+    document.getElementById("vendor-notes").value = vendor.notes || "";
+    editingVendorId = vendorId;
+  } else {
+    title.textContent = "Add Vendor";
+    document.getElementById("vendor-name").value = "";
+    document.getElementById("vendor-category").value = "Antibodies";
+    document.getElementById("vendor-notes").value = "";
+    editingVendorId = null;
+  }
+
+  modal.classList.add("active");
+}
+
+function closeVendorModal() {
+  const modal = document.getElementById("vendor-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+  editingVendorId = null;
+
+  const nameInput = document.getElementById("vendor-name");
+  const categorySelect = document.getElementById("vendor-category");
+  const notesInput = document.getElementById("vendor-notes");
+  if (nameInput) nameInput.value = "";
+  if (categorySelect) categorySelect.value = "Antibodies";
+  if (notesInput) notesInput.value = "";
+}
+
+function saveVendor() {
+  if (!APP_STATE.writeAccess) return;
+
+  const name = document.getElementById("vendor-name").value.trim();
+  const category = document.getElementById("vendor-category").value;
+  const notes = document.getElementById("vendor-notes").value.trim();
+
+  if (!name) {
+    showAlert("error", "Vendor name is required");
+    return;
+  }
+
+  if (editingVendorId) {
+    const vendor = APP_STATE.vendors.find((v) => v.id === editingVendorId);
+    if (!vendor) return;
+
+    vendor.name = name;
+    vendor.category = category;
+    vendor.notes = notes;
+    vendor.updatedAt = new Date().toISOString();
+    vendor.updatedBy = APP_STATE.currentUser;
+    logActivity("Updated vendor", name);
+    showAlert("success", "Vendor updated successfully");
+  } else {
+    const newVendor = {
+      id: "vend_" + Date.now(),
+      name,
+      category,
+      notes,
+      purchases: [],
+      createdAt: new Date().toISOString(),
+      createdBy: APP_STATE.currentUser,
+    };
+    APP_STATE.vendors.push(newVendor);
+    logActivity("Added vendor", name);
+    showAlert("success", "Vendor added successfully");
+  }
+
+  updateVendorList();
+  persistState();
+  closeVendorModal();
+}
+
+function deleteVendor(vendorId) {
+  if (!APP_STATE.writeAccess) return;
+
+  const vendor = APP_STATE.vendors.find((v) => v.id === vendorId);
+  if (!vendor) return;
+
+  if (
+    confirm(
+      `Are you sure you want to delete ${vendor.name}? This cannot be undone.`,
+    )
+  ) {
+    APP_STATE.vendors = APP_STATE.vendors.filter((v) => v.id !== vendorId);
+    updateVendorList();
+    persistState();
+    logActivity("Deleted vendor", vendor.name);
+    showAlert("success", "Vendor deleted");
+  }
+}
+
+function openLogPurchaseModal(vendorId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage vendor purchases");
+    return;
+  }
+
+  const vendor = APP_STATE.vendors.find((v) => v.id === vendorId);
+  if (!vendor) {
+    showAlert("error", "Vendor not found");
+    return;
+  }
+
+  const title = document.getElementById("log-purchase-modal-title");
+  if (title) {
+    title.textContent = `Log Purchase for ${vendor.name}`;
+  }
+
+  const descriptionInput = document.getElementById("purchase-description");
+  const dateInput = document.getElementById("purchase-date");
+  const costInput = document.getElementById("purchase-cost");
+  if (descriptionInput) descriptionInput.value = "";
+  if (dateInput) dateInput.value = "";
+  if (costInput) costInput.value = "";
+
+  editingVendorId = vendorId;
+
+  const modal = document.getElementById("log-purchase-modal");
+  if (modal) {
+    modal.classList.add("active");
+  }
+}
+
+function closeLogPurchaseModal() {
+  const modal = document.getElementById("log-purchase-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  const descriptionInput = document.getElementById("purchase-description");
+  const dateInput = document.getElementById("purchase-date");
+  const costInput = document.getElementById("purchase-cost");
+  if (descriptionInput) descriptionInput.value = "";
+  if (dateInput) dateInput.value = "";
+  if (costInput) costInput.value = "";
+
+  editingVendorId = null;
+}
+
+function savePurchase() {
+  if (!APP_STATE.writeAccess) return;
+
+  const descriptionInput = document.getElementById("purchase-description");
+  const dateInput = document.getElementById("purchase-date");
+  const costInput = document.getElementById("purchase-cost");
+
+  const description = descriptionInput ? descriptionInput.value.trim() : "";
+  const purchaseDate = dateInput ? dateInput.value : "";
+  const costRaw = costInput ? costInput.value.trim() : "";
+
+  if (!description) {
+    showAlert("error", "Purchase description is required");
+    return;
+  }
+
+  if (!costRaw) {
+    showAlert("error", "Purchase cost is required");
+    return;
+  }
+
+  const costValue = Number(costRaw);
+  if (!Number.isFinite(costValue)) {
+    showAlert("error", "Purchase cost must be a valid number");
+    return;
+  }
+
+  const vendor = APP_STATE.vendors.find((v) => v.id === editingVendorId);
+  if (!vendor) {
+    showAlert("error", "Unable to find vendor for purchase");
+    return;
+  }
+
+  if (!Array.isArray(vendor.purchases)) {
+    vendor.purchases = [];
+  }
+
+  const purchase = {
+    purchaseId: "purch_" + Date.now(),
+    description,
+    date: purchaseDate,
+    cost: costValue,
+    createdAt: new Date().toISOString(),
+    createdBy: APP_STATE.currentUser,
+  };
+
+  vendor.purchases.push(purchase);
+
+  persistState();
+  logActivity("Logged vendor purchase", `${vendor.name} - ${description}`);
+  showAlert("success", "Purchase saved successfully");
+
+  closeLogPurchaseModal();
+}
+
+function openViewPurchasesModal(vendorId) {
+  const vendor = APP_STATE.vendors.find((v) => v.id === vendorId);
+  if (!vendor) {
+    showAlert("error", "Vendor not found");
+    return;
+  }
+
+  if (!Array.isArray(vendor.purchases)) {
+    vendor.purchases = [];
+  }
+
+  const title = document.getElementById("view-purchases-modal-title");
+  if (title) {
+    title.textContent = `Purchase History for ${vendor.name}`;
+  }
+
+  const table = document.getElementById("purchase-history-table");
+  if (table) {
+    let tbody = table.querySelector("tbody");
+    if (!tbody) {
+      tbody = document.createElement("tbody");
+      table.appendChild(tbody);
+    }
+
+    const formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    });
+
+    if (vendor.purchases.length === 0) {
+      tbody.innerHTML = `
+              <tr>
+                <td colspan="4" style="text-align: center; color: var(--gray);">No purchases logged yet.</td>
+              </tr>
+            `;
+    } else {
+      tbody.innerHTML = vendor.purchases
+        .map((purchase) => {
+          const numericCost = Number(purchase.cost);
+          const formattedCost = Number.isFinite(numericCost)
+            ? formatter.format(numericCost)
+            : String(purchase.cost || "");
+          const purchaseDate = purchase.date ? purchase.date : "—";
+          const deleteDisabled = !APP_STATE.writeAccess ? "disabled" : "";
+          return `
+                  <tr>
+                    <td>${purchase.description}</td>
+                    <td>${purchaseDate}</td>
+                    <td>${formattedCost}</td>
+                    <td style="text-align: right;">
+                      <button class="btn btn-outline btn-sm" onclick="deletePurchase('${vendor.id}', '${purchase.purchaseId}')" ${deleteDisabled}>Delete</button>
+                    </td>
+                  </tr>
+                `;
+        })
+        .join("");
+    }
+  }
+
+  const modal = document.getElementById("view-purchases-modal");
+  if (modal) {
+    modal.classList.add("active");
+  }
+}
+
+function closeViewPurchasesModal() {
+  const modal = document.getElementById("view-purchases-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+}
+
+function deletePurchase(vendorId, purchaseId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage vendor purchases");
+    return;
+  }
+
+  const vendor = APP_STATE.vendors.find((v) => v.id === vendorId);
+  if (!vendor || !Array.isArray(vendor.purchases)) {
+    showAlert("error", "Unable to locate purchase record");
+    return;
+  }
+
+  const purchaseIndex = vendor.purchases.findIndex(
+    (p) => p.purchaseId === purchaseId,
+  );
+  if (purchaseIndex === -1) {
+    showAlert("error", "Purchase not found");
+    return;
+  }
+
+  const [removed] = vendor.purchases.splice(purchaseIndex, 1);
+  const detail =
+    removed && removed.description
+      ? `${vendor.name} - ${removed.description}`
+      : vendor.name;
+
+  persistState();
+  logActivity("Deleted vendor purchase", detail);
+  showAlert("success", "Purchase deleted");
+
+  openViewPurchasesModal(vendorId);
+}
+
+// ===============================
+// Antibody Management
+// ===============================
+
+// ===============================
+// Dashboard Functions
+// ===============================
+
+function updateDashboard() {
+  calculateAndDisplayCosts();
+  calculateAndDisplayTopAntibodies();
+  renderCaseStudies();
+}
+
+function formatCurrency(value) {
+  if (!formatCurrency.formatter) {
+    formatCurrency.formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return formatCurrency.formatter.format(0);
+  }
+  return formatCurrency.formatter.format(numeric);
+}
+
+function extractNumericValue(value) {
+  if (value === null || value === undefined || value === "") {
+    return 0;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === "string") {
+    const direct = Number(value);
+    if (Number.isFinite(direct)) {
+      return direct;
+    }
+
+    const cleaned = Number(value.replace(/[^0-9.-]+/g, ""));
+    return Number.isFinite(cleaned) ? cleaned : 0;
+  }
+
+  if (typeof value === "object") {
+    const candidateKeys = [
+      "netSavings",
+      "amount",
+      "value",
+      "estimated",
+      "total",
+      "estimatedSavings",
+    ];
+    for (const key of candidateKeys) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        const nested = extractNumericValue(value[key]);
+        if (Number.isFinite(nested)) {
+          return nested;
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+function setMetricText(elementId, value) {
+  const el = document.getElementById(elementId);
+  if (!el) return;
+  el.textContent = formatCurrency(value);
+}
+
+function getYearFromDate(value) {
+  if (value == null || value === "") return null;
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 4 && /^\d{4}$/.test(trimmed)) {
+      return Number(trimmed);
+    }
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.getFullYear();
+}
+
+function calculateAndDisplayCosts() {
+  const metricsAvailable = document.getElementById("blood-cost-last-year");
+  if (!metricsAvailable) return;
+
+  const fallbackUnitPrice = 500;
+  const supplier = (APP_STATE.bloodSuppliers || []).find(
+    (entry) =>
+      entry && entry.pricing && Number.isFinite(Number(entry.pricing.baseUnit)),
+  );
+  const candidatePrice = supplier ? Number(supplier.pricing.baseUnit) : NaN;
+  const unitPrice =
+    Number.isFinite(candidatePrice) && candidatePrice > 0
+      ? candidatePrice
+      : fallbackUnitPrice;
+
+  const parseQuantity = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  };
+
+  const countUnitsForYear = (collection, year) =>
+    (Array.isArray(collection) ? collection : []).reduce((total, record) => {
+      if (Number(record?.year) === year) {
+        return total + parseQuantity(record.quantity);
+      }
+      return total;
+    }, 0);
+
+  const lastYearUnits = countUnitsForYear(APP_STATE.historicalQuantities, 2024);
+  const ytdUnits = countUnitsForYear(APP_STATE.confirmedQuantities, 2025);
+
+  const lastYearCost = lastYearUnits * unitPrice;
+  const ytdCost = ytdUnits * unitPrice;
+
+  const today = new Date();
+  let monthsElapsed = 12;
+  if (today.getFullYear() === 2025) {
+    monthsElapsed = Math.max(1, today.getMonth() + 1);
+  }
+  const forecastCost = monthsElapsed ? ytdCost * (12 / monthsElapsed) : ytdCost;
+
+  setMetricText("blood-cost-last-year", lastYearCost);
+  setMetricText("blood-cost-ytd", ytdCost);
+  setMetricText("blood-cost-forecast", forecastCost);
+
+  const lots = (APP_STATE.antibodies || []).reduce((acc, specificity) => {
+    if (specificity && Array.isArray(specificity.inventory)) {
+      acc.push(...specificity.inventory);
+    }
+    return acc;
+  }, []);
+
+  const sumLotCostsForYear = (year) =>
+    lots.reduce((sum, lot) => {
+      const lotYear = getYearFromDate(lot?.qualificationDate);
+      if (lotYear !== year) return sum;
+      const price = Number(lot?.purchasePrice);
+      return Number.isFinite(price) ? sum + price : sum;
+    }, 0);
+
+  const antibodyLastYear = sumLotCostsForYear(2024);
+  const antibodyYtd = sumLotCostsForYear(2025);
+
+  setMetricText("antibody-cost-last-year", antibodyLastYear);
+  setMetricText("antibody-cost-ytd", antibodyYtd);
+  setMetricText("antibody-cost-forecast", antibodyYtd);
+}
+
+function calculateAndDisplayTopAntibodies() {
+  const container = document.getElementById("top-antibodies-list");
+  if (!container) return;
+
+  const usageMap = new Map();
+
+  (APP_STATE.antibodies || []).forEach((specificity) => {
+    const lots = Array.isArray(specificity?.inventory)
+      ? specificity.inventory
+      : [];
+    const usageCount = lots.reduce((count, lot) => {
+      const history = Array.isArray(lot?.history) ? lot.history : [];
+      return count + history.length;
+    }, 0);
+
+    if (usageCount > 0) {
+      const name = specificity?.specificity || "Unnamed Specificity";
+      usageMap.set(name, (usageMap.get(name) || 0) + usageCount);
+    }
+  });
+
+  if (usageMap.size === 0) {
+    container.innerHTML = '<p class="text-muted">No usage data logged yet.</p>';
+    return;
+  }
+
+  const topEntries = Array.from(usageMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3);
+
+  const listItems = topEntries
+    .map(
+      ([name, count]) =>
+        `<li><strong>${escapeHtml(name)}</strong> — ${count} usage${count === 1 ? "" : "s"}</li>`,
+    )
+    .join("");
+
+  container.innerHTML = `<ol>${listItems}</ol>`;
+}
+
+function renderCaseStudies() {
+  const listEl = document.getElementById("case-study-list");
+  if (!listEl) return;
+
+  const studies = Array.isArray(APP_STATE.caseStudies)
+    ? [...APP_STATE.caseStudies]
+    : [];
+
+  if (studies.length === 0) {
+    listEl.classList.add("empty");
+    listEl.innerHTML = '<p class="text-muted">No case studies tracked yet.</p>';
+    return;
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  studies.sort((a, b) => {
+    const aTime = Date.parse(a?.dueDate);
+    const bTime = Date.parse(b?.dueDate);
+    if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
+    if (Number.isNaN(aTime)) return 1;
+    if (Number.isNaN(bTime)) return -1;
+    return aTime - bTime;
+  });
+
+  const items = studies
+    .map((study) => {
+      const dueDate = study?.dueDate ? new Date(study.dueDate) : null;
+      const dueValid = dueDate && !Number.isNaN(dueDate.getTime());
+      const dueLabel = dueValid ? dueDate.toLocaleDateString() : "No due date";
+      const isOverdue = dueValid && !study.completed && dueDate < today;
+
+      const classes = ["case-study-item"];
+      if (study.completed) classes.push("completed");
+      if (isOverdue) classes.push("overdue");
+
+      return `
+            <div class="${classes.join(" ")}">
+              <div class="case-study-main">
+                <label class="case-study-label">
+                  <input type="checkbox" class="case-study-checkbox" ${
+                    study.completed ? "checked" : ""
+                  } onchange="toggleCaseStudy('${study.id}')" />
+                  <span class="case-study-description">${escapeHtml(
+                    study.description || "Case Study",
+                  )}</span>
+                </label>
+                <div class="case-study-meta">
+                  <span class="case-study-date">Due ${escapeHtml(dueLabel)}</span>
+                  <span class="case-study-status">${
+                    study.completed
+                      ? "Completed"
+                      : isOverdue
+                        ? "Overdue"
+                        : "In progress"
+                  }</span>
+                </div>
+              </div>
+              <button class="btn btn-outline btn-sm" onclick="deleteCaseStudy('${
+                study.id
+              }')">Delete</button>
+            </div>`;
+    })
+    .join("");
+
+  listEl.classList.remove("empty");
+  listEl.innerHTML = items;
+}
+
+function addCaseStudy(event) {
+  if (event) event.preventDefault();
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage case studies");
+    return false;
+  }
+
+  const descriptionInput = document.getElementById("case-study-description");
+  const dueDateInput = document.getElementById("case-study-due-date");
+  if (!descriptionInput || !dueDateInput) return false;
+
+  const description = descriptionInput.value.trim();
+  const dueDate = dueDateInput.value;
+
+  if (!description || !dueDate) {
+    showAlert(
+      "error",
+      "Description and due date are required for a case study",
+    );
+    return false;
+  }
+
+  APP_STATE.caseStudies = Array.isArray(APP_STATE.caseStudies)
+    ? APP_STATE.caseStudies
+    : [];
+
+  APP_STATE.caseStudies.push({
+    id: createId("case"),
+    description,
+    dueDate,
+    completed: false,
+    createdAt: new Date().toISOString(),
+  });
+
+  descriptionInput.value = "";
+  dueDateInput.value = "";
+
+  renderCaseStudies();
+  persistState();
+  showAlert("success", "Case study added");
+  return false;
+}
+
+function toggleCaseStudy(caseId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage case studies");
+    renderCaseStudies();
+    return;
+  }
+
+  const study = (APP_STATE.caseStudies || []).find(
+    (item) => item.id === caseId,
+  );
+  if (!study) return;
+
+  study.completed = !study.completed;
+  study.completedAt = study.completed ? new Date().toISOString() : null;
+
+  renderCaseStudies();
+  persistState();
+}
+
+function deleteCaseStudy(caseId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage case studies");
+    return;
+  }
+
+  APP_STATE.caseStudies = (APP_STATE.caseStudies || []).filter(
+    (item) => item.id !== caseId,
+  );
+
+  renderCaseStudies();
+  persistState();
+  showAlert("success", "Case study removed");
+}
+
+function displayStandingOrders() {
+  const container = document.getElementById("standing-orders-list");
+  let html =
+    '<div class="table-container"><table><thead><tr>' +
+    "<th>Product</th><th>Frequency</th><th>Blood Types</th><th>Vendor</th>" +
+    "</tr></thead><tbody>";
+
+  STANDING_ORDERS.forEach((order) => {
+    const types = order.units
+      .map((u) =>
+        u.type === "FFS" ? `${u.count}x FFS` : `${u.count}x ${u.type}`,
+      )
+      .join(", ");
+    const vendors = [
+      ...new Set(order.units.map((u) => u.vendor).filter((v) => v)),
+    ].join(", ");
+
+    html += `
+                                                        <tr>
+                                                            <td>${order.product}</td>
+                                                            <td>Every ${order.frequency} days</td>
+                                                            <td>${types}</td>
+                                                            <td>${vendors}</td>
+                                                        </tr>
+                                                    `;
+
+    if (order.bonus) {
+      html += `
+                                                            <tr style="background: var(--hemo-blue-lighter);">
+                                                                <td>${order.product} Bonus</td>
+                                                                <td>-</td>
+                                                                <td>${order.bonus.type} (${order.bonus.volume}p)</td>
+                                                                <td>Available for sharing</td>
+                                                            </tr>
+                                                        `;
+    }
+  });
+
+  html += "</tbody></table></div>";
+  container.innerHTML = html;
+}
+
+// ===============================
+// Customer Dropdown Utilities
+// ===============================
+
+function populateCustomerDropdowns() {
+  const dropdownConfigs = [
+    {
+      id: "future-spec-customer",
+      defaultOption: '<option value="">Select Customer</option>',
+    },
+    {
+      id: "calc-customer",
+      defaultOption: '<option value="">Select Customer</option>',
+    },
+    {
+      id: "bup-filter-customer",
+      defaultOption: '<option value="">All Customers</option>',
+    },
+    {
+      id: "qty-filter-customer",
+      defaultOption: '<option value="">All Customers</option>',
+    },
+    {
+      id: "hqty-filter-customer",
+      defaultOption: '<option value="">All Customers</option>',
+    },
+    {
+      id: "spec-filter-customer",
+      defaultOption: '<option value="">All Customers</option>',
+    },
+  ];
+
+  const customerList = Array.isArray(APP_STATE.customers)
+    ? APP_STATE.customers
+    : [];
+  const customerMap = new Map();
+  customerList.forEach((customer) => {
+    if (customer && customer.code) {
+      customerMap.set(customer.code, customer);
+    }
+  });
+
+  const sortedCustomers = Array.from(customerMap.values()).sort((a, b) => {
+    const nameA = (a.name || a.code || "").toLowerCase();
+    const nameB = (b.name || b.code || "").toLowerCase();
+    if (nameA < nameB) return -1;
+    if (nameA > nameB) return 1;
+    return 0;
+  });
+
+  const optionsHtml = sortedCustomers
+    .map((customer) => {
+      return `<option value="${customer.code}">${customer.code}</option>`;
+    })
+    .join("");
+
+  dropdownConfigs.forEach(({ id, defaultOption }) => {
+    const select = document.getElementById(id);
+    if (!select) return;
+    const previousValue = select.value;
+    select.innerHTML = defaultOption + optionsHtml;
+    if (previousValue && customerMap.has(previousValue)) {
+      select.value = previousValue;
+    } else {
+      select.value = "";
+    }
+  });
+
+  const futureCustomer = document.getElementById("future-spec-customer")?.value || "";
+  populateFutureSpecYearOptions(futureCustomer);
+  const futureYear = document.getElementById("future-spec-year")?.value || "";
+  populateFutureSpecEventOptions(futureCustomer, futureYear);
+  updateFutureCopyOptions();
+}
+
+// ===============================
+// Blood Calculator Functions
+// ===============================
+
+function getScheduleEntriesForCustomer(customer) {
+  const schedule = Array.isArray(APP_STATE.schedule) ? APP_STATE.schedule : [];
+  if (!customer) {
+    return schedule.slice();
+  }
+  return schedule.filter((entry) => entry && entry.customer === customer);
+}
+
+function parseDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function deriveScheduleYear(entry) {
+  if (!entry) return null;
+  if (Number.isFinite(entry.year)) return entry.year;
+  const numericYear = Number(entry.year);
+  if (Number.isFinite(numericYear)) return numericYear;
+  const ship = parseDate(entry.shipDate);
+  if (ship) return ship.getFullYear();
+  const expiration = parseDate(entry.expirationDate);
+  if (expiration) return expiration.getFullYear();
+  return null;
+}
+
+function populateCalculatorYearOptions(customer) {
+  const yearSelect = document.getElementById("calc-year");
+  if (!yearSelect) return;
+  const previousValue = yearSelect.value;
+  const years = new Set();
+  getScheduleEntriesForCustomer(customer).forEach((entry) => {
+    const year = deriveScheduleYear(entry);
+    if (Number.isFinite(year)) {
+      years.add(year);
+    }
+  });
+  const specs = Array.isArray(APP_STATE.customerSpecs) ? APP_STATE.customerSpecs : [];
+  specs.forEach((spec) => {
+    if (!spec || (customer && spec.customer !== customer)) return;
+    const numericYear = Number(spec.year);
+    if (Number.isFinite(numericYear)) {
+      years.add(numericYear);
+    }
+  });
+  const yearOptions = Array.from(years).sort((a, b) => b - a);
+  const defaultOption = '<option value="">Select Year</option>';
+  yearSelect.innerHTML = defaultOption + yearOptions
+    .map((year) => `<option value="${year}">${year}</option>`)
+    .join("");
+  if (previousValue && yearOptions.includes(Number(previousValue))) {
+    yearSelect.value = previousValue;
+  } else {
+    yearSelect.value = "";
+  }
+}
+
+function populateCalculatorEventOptions(customer, year) {
+  const eventSelect = document.getElementById("calc-event");
+  if (!eventSelect) return;
+  const previousValue = eventSelect.value;
+  const events = new Set();
+  const numericYear = Number(year);
+  getScheduleEntriesForCustomer(customer).forEach((entry) => {
+    if (!entry || !entry.event) return;
+    const entryYear = deriveScheduleYear(entry);
+    if (year && Number.isFinite(numericYear) && Number.isFinite(entryYear) && entryYear !== numericYear) {
+      return;
+    }
+    events.add(entry.event);
+  });
+  const specs = Array.isArray(APP_STATE.customerSpecs) ? APP_STATE.customerSpecs : [];
+  specs.forEach((spec) => {
+    if (!spec || !spec.event) return;
+    if (customer && spec.customer !== customer) return;
+    if (year && spec.year && String(spec.year) !== String(year)) return;
+    events.add(spec.event);
+  });
+  const eventOptions = Array.from(events).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const defaultOption = '<option value="">Select Event</option>';
+  eventSelect.innerHTML = defaultOption + eventOptions
+    .map((event) => `<option value="${event}">${event}</option>`)
+    .join("");
+  if (previousValue && eventOptions.includes(previousValue)) {
+    eventSelect.value = previousValue;
+  } else {
+    eventSelect.value = "";
+  }
+}
+
+function populateCalculatorSampleOptions(customer, year, event) {
+  const sampleSelect = document.getElementById("calc-sample");
+  if (!sampleSelect) return;
+  const previousValue = sampleSelect.value;
+  const sampleIds = new Set();
+  const specs = Array.isArray(APP_STATE.customerSpecs) ? APP_STATE.customerSpecs : [];
+  specs.forEach((spec) => {
+    if (!spec || !spec.sample_id) return;
+    if (customer && spec.customer !== customer) return;
+    if (year && spec.year && String(spec.year) !== String(year)) return;
+    if (event && spec.event && spec.event !== event) return;
+    sampleIds.add(spec.sample_id);
+  });
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  futureEntries.forEach((spec) => {
+    if (!spec || !spec.sample_id) return;
+    if (customer && spec.customer !== customer) return;
+    if (year && spec.year && String(spec.year) !== String(year)) return;
+    if (event && spec.event && spec.event !== event) return;
+    sampleIds.add(spec.sample_id);
+  });
+  const options = Array.from(sampleIds).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const defaultOption = '<option value="">Select Sample ID</option>';
+  sampleSelect.innerHTML = defaultOption + options
+    .map((id) => `<option value="${id}">${id}</option>`)
+    .join("");
+  if (previousValue && options.includes(previousValue)) {
+    sampleSelect.value = previousValue;
+  } else {
+    sampleSelect.value = "";
+  }
+}
+
+function handleCalculatorCustomerChange() {
+  const customerSelect = document.getElementById("calc-customer");
+  if (!customerSelect) return;
+  const customer = customerSelect.value || "";
+  const yearSelect = document.getElementById("calc-year");
+  const eventSelect = document.getElementById("calc-event");
+  const sampleSelect = document.getElementById("calc-sample");
+  const sampleInput = document.getElementById("calc-sample-input");
+  if (yearSelect) yearSelect.value = "";
+  if (eventSelect) eventSelect.value = "";
+  if (sampleSelect) sampleSelect.value = "";
+  if (sampleInput) sampleInput.value = "";
+  populateCalculatorYearOptions(customer);
+  populateCalculatorEventOptions(customer, "");
+  populateCalculatorSampleOptions(customer, "", "");
+  updateCalculatorDates(null);
+  updateForecastCalculator();
+}
+
+function handleCalculatorYearChange() {
+  const customer = document.getElementById("calc-customer")?.value || "";
+  const year = document.getElementById("calc-year")?.value || "";
+  const eventSelect = document.getElementById("calc-event");
+  const sampleSelect = document.getElementById("calc-sample");
+  if (eventSelect) eventSelect.value = "";
+  if (sampleSelect) sampleSelect.value = "";
+  populateCalculatorEventOptions(customer, year);
+  populateCalculatorSampleOptions(customer, year, "");
+  updateCalculatorDates(null);
+  updateForecastCalculator();
+}
+
+function handleCalculatorEventChange() {
+  const customer = document.getElementById("calc-customer")?.value || "";
+  const year = document.getElementById("calc-year")?.value || "";
+  const event = document.getElementById("calc-event")?.value || "";
+  populateCalculatorSampleOptions(customer, year, event);
+  const entry = findScheduleEntry(customer, year, event);
+  updateCalculatorDates(entry);
+  updateForecastCalculator();
+}
+
+function handleCalculatorSampleChange() {
+  if (APP_STATE.calculatorState?.sampleMode === "manual") {
+    return;
+  }
+  updateForecastCalculator();
+}
+
+function handleCalculatorSampleInputChange() {
+  if (APP_STATE.calculatorState?.sampleMode !== "manual") {
+    return;
+  }
+  updateForecastCalculator();
+}
+
+function toggleSampleInputMode() {
+  if (!APP_STATE.calculatorState) {
+    APP_STATE.calculatorState = { sampleMode: "dropdown", scheduleEntry: null };
+  }
+  const state = APP_STATE.calculatorState;
+  const selectWrapper = document.getElementById("calc-sample-select-wrapper");
+  const inputWrapper = document.getElementById("calc-sample-input-wrapper");
+  const toggle = document.getElementById("calc-sample-toggle");
+  const select = document.getElementById("calc-sample");
+  const input = document.getElementById("calc-sample-input");
+  if (state.sampleMode === "dropdown") {
+    state.sampleMode = "manual";
+    if (selectWrapper) selectWrapper.style.display = "none";
+    if (inputWrapper) inputWrapper.style.display = "";
+    if (input && select) {
+      input.value = select.value || input.value || "";
+      input.focus();
+    }
+    if (toggle) toggle.textContent = "Use Sample List";
+  } else {
+    state.sampleMode = "dropdown";
+    if (selectWrapper) selectWrapper.style.display = "";
+    if (inputWrapper) inputWrapper.style.display = "none";
+    if (select && input && input.value && Array.from(select.options).some((opt) => opt.value === input.value)) {
+      select.value = input.value;
+    }
+    if (toggle) toggle.textContent = "Use Manual Entry";
+  }
+  updateForecastCalculator();
+}
+
+function normalizeSampleId(sampleId, customer) {
+  const outcome = {
+    normalized: "",
+    rule: "default",
+  };
+
+  if (typeof sampleId !== "string") {
+    outcome.rule = "non-string";
+    return outcome;
+  }
+
+  let working = sampleId.toUpperCase().trim();
+  if (!working) {
+    outcome.rule = "empty";
+    return outcome;
+  }
+
+  const compactCustomer = (customer || "")
+    .toUpperCase()
+    .replace(/[^A-Z]/g, "");
+  let appliedRule = "default";
+
+  if (["WSLH", "ISLA"].includes(compactCustomer)) {
+    if (/^\d{4}-/.test(working)) {
+      working = working.replace(/^\d{4}-/, "");
+    }
+    appliedRule = "WSLH/ISLA";
+    console.log("[Forecast] Rule applied: WSLH/ISLA");
+  } else if (compactCustomer === "SIGMAQC") {
+    if (/^IN\d{2}/.test(working)) {
+      working = "IN" + working.slice(4);
+    }
+    appliedRule = "SigmaQC";
+    console.log("[Forecast] Rule applied: SigmaQC");
+  } else if (compactCustomer === "AUREVIA") {
+    const aureviaPattern = /([A-Z]+)\d{2}([A-Z0-9]+)/;
+    if (aureviaPattern.test(working)) {
+      working = working.replace(aureviaPattern, "$1$2");
+    }
+    appliedRule = "Aurevia";
+    console.log("[Forecast] Rule applied: Aurevia");
+  } else if (compactCustomer === "LICON") {
+    const liconPattern = /^([A-Z]+)\d+([A-Z][A-Z0-9]*)$/;
+    if (liconPattern.test(working)) {
+      working = working.replace(liconPattern, "$1$2");
+    }
+    appliedRule = "Licon";
+    console.log("[Forecast] Rule applied: Licon");
+  } else if (compactCustomer === "BIORADEQAS") {
+    if (/^\d{6}$/.test(working)) {
+      working = working.slice(0, 2) + working.slice(4);
+    }
+    appliedRule = "Bio-Rad EQAS";
+    console.log("[Forecast] Rule applied: Bio-Rad EQAS");
+  } else {
+    console.log("[Forecast] Rule applied: default");
+  }
+
+  outcome.rule = appliedRule;
+  outcome.normalized = working.replace(/\s+/g, "");
+  return outcome;
+}
+
+function calculateForecast({ customer, sampleId, targetYear }) {
+  const result = {
+    value: 0,
+    method: "invalid-input",
+    normalizationRule: "default",
+    normalizedId: "",
+    points: 0,
+  };
+
+  if (!customer || !sampleId || !Number.isFinite(targetYear)) {
+    return result;
+  }
+
+  const normalization = normalizeSampleId(sampleId, customer);
+  const baseId = normalization.normalized;
+  result.normalizationRule = normalization.rule;
+  result.normalizedId = baseId;
+
+  if (!baseId) {
+    result.method = "normalization-failed";
+    return result;
+  }
+
+  const parseYearFromEntry = (entry) => {
+    const explicit = Number(entry?.year ?? entry?.Year);
+    if (Number.isFinite(explicit)) {
+      return explicit;
+    }
+    const idValue = entry?.sample_id || entry?.sampleId || "";
+    if (typeof idValue === "string") {
+      const match = idValue.match(/\b\d{4}\b/);
+      if (match) {
+        const parsed = Number(match[0]);
+        if (Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+    }
+    const dateFields = [entry?.shipDate, entry?.bleedDate, entry?.date];
+    for (const field of dateFields) {
+      const parsedDate = parseDate(field);
+      if (parsedDate) {
+        return parsedDate.getFullYear();
+      }
+    }
+    return null;
+  };
+
+  const points = [];
+  const considerEntry = (entry) => {
+    if (!entry || entry.customer !== customer) return;
+    const normalizedEntry = normalizeSampleId(
+      entry.sample_id || entry.sampleId || "",
+      customer,
+    );
+    if (!normalizedEntry.normalized || normalizedEntry.normalized !== baseId) return;
+    const year = parseYearFromEntry(entry);
+    if (!Number.isFinite(year)) return;
+    const rawQuantity =
+      entry.quantity ??
+      entry.qty ??
+      entry.quantity_confirmed ??
+      entry.quantityConfirmed ??
+      null;
+    const quantity = Number(rawQuantity);
+    if (!Number.isFinite(quantity)) return;
+    points.push({ x: year, y: quantity });
+  };
+
+  if (Array.isArray(APP_STATE.historicalQuantities)) {
+    APP_STATE.historicalQuantities.forEach(considerEntry);
+  }
+  if (Array.isArray(APP_STATE.confirmedQuantities)) {
+    APP_STATE.confirmedQuantities.forEach(considerEntry);
+  }
+
+  result.points = points.length;
+
+  if (points.length === 0) {
+    console.log("[Forecast] fallback: 0-point");
+    result.method = "0-point";
+    result.value = 0;
+    return result;
+  }
+
+  if (points.length === 1) {
+    console.log("[Forecast] fallback: 1-point");
+    result.method = "1-point";
+    result.value = Math.max(0, Math.round(points[0].y));
+    return result;
+  }
+
+  console.log("[Forecast] regression");
+  const n = points.length;
+  const sums = points.reduce(
+    (acc, point) => {
+      acc.sumX += point.x;
+      acc.sumY += point.y;
+      acc.sumXY += point.x * point.y;
+      acc.sumX2 += point.x * point.x;
+      return acc;
+    },
+    { sumX: 0, sumY: 0, sumXY: 0, sumX2: 0 },
+  );
+
+  const denominator = n * sums.sumX2 - sums.sumX * sums.sumX;
+  let slope = 0;
+  if (Math.abs(denominator) > 0) {
+    slope = (n * sums.sumXY - sums.sumX * sums.sumY) / denominator;
+  }
+  const intercept = (sums.sumY - slope * sums.sumX) / n;
+  const prediction = slope * targetYear + intercept;
+
+  if (!Number.isFinite(prediction)) {
+    console.log("[Forecast] fallback: 0-point");
+    result.method = "0-point";
+    result.value = 0;
+    return result;
+  }
+
+  result.method = "regression";
+  result.value = Math.max(0, Math.round(prediction));
+  return result;
+}
+
+function updateForecastCalculator() {
+  const customer = document.getElementById("calc-customer")?.value || "";
+  const forecastInput = document.getElementById("calc-forecast");
+  if (!forecastInput) return;
+  if (!APP_STATE.calculatorState) {
+    APP_STATE.calculatorState = { sampleMode: "dropdown", scheduleEntry: null };
+  }
+  const state = APP_STATE.calculatorState;
+  let sampleId = "";
+  if (state.sampleMode === "manual") {
+    sampleId = document.getElementById("calc-sample-input")?.value || "";
+  } else {
+    sampleId = document.getElementById("calc-sample")?.value || "";
+  }
+  const yearValue = document.getElementById("calc-year")?.value || "";
+  let targetYear = Number(yearValue);
+  if (!customer || !sampleId) {
+    forecastInput.value = "";
+    return;
+  }
+  if (!Number.isFinite(targetYear)) {
+    const scheduleYear = deriveScheduleYear(state.scheduleEntry);
+    if (Number.isFinite(scheduleYear)) {
+      targetYear = scheduleYear;
+    }
+  }
+  if (!Number.isFinite(targetYear)) {
+    forecastInput.value = "";
+    return;
+  }
+
+  const result = calculateForecast({ customer, sampleId, targetYear });
+
+  if (
+    result.method === "invalid-input" ||
+    result.method === "normalization-failed"
+  ) {
+    forecastInput.value = "";
+    return;
+  }
+
+  forecastInput.value = Number.isFinite(result.value)
+    ? String(result.value)
+    : "";
+}
+
+function findScheduleEntry(customer, year, event) {
+  if (!customer || !event) return null;
+  const numericYear = Number(year);
+  const entries = getScheduleEntriesForCustomer(customer);
+  for (const entry of entries) {
+    if (!entry || entry.event !== event) continue;
+    const entryYear = deriveScheduleYear(entry);
+    if (year && Number.isFinite(numericYear) && Number.isFinite(entryYear) && entryYear !== numericYear) {
+      continue;
+    }
+    if (year && Number.isFinite(numericYear) && entryYear == null) {
+      continue;
+    }
+    return entry;
+  }
+  return null;
+}
+
+function formatDateForDisplay(value) {
+  if (!value) return "—";
+  const date = value instanceof Date ? value : parseDate(value);
+  if (!date) return typeof value === "string" ? value : "—";
+  return date.toLocaleDateString();
+}
+
+function updateCalculatorDates(entry) {
+  const bleedEl = document.getElementById("calc-bleed-date");
+  const shipEl = document.getElementById("calc-ship-date");
+  const expEl = document.getElementById("calc-expiration-date");
+  if (!bleedEl || !shipEl || !expEl) return;
+  if (!APP_STATE.calculatorState) {
+    APP_STATE.calculatorState = { sampleMode: "dropdown", scheduleEntry: null };
+  }
+  if (entry) {
+    bleedEl.textContent = formatDateForDisplay(entry.bleedDate || entry.shipDate);
+    shipEl.textContent = formatDateForDisplay(entry.shipDate);
+    expEl.textContent = formatDateForDisplay(entry.expirationDate);
+    APP_STATE.calculatorState.scheduleEntry = entry;
+  } else {
+    bleedEl.textContent = "—";
+    shipEl.textContent = "—";
+    expEl.textContent = "—";
+    APP_STATE.calculatorState.scheduleEntry = null;
+  }
+}
+
+function findSharingOpportunities() {
+  const container = document.getElementById("sharing-results");
+  if (!container) return;
+  const customer = document.getElementById("calc-customer")?.value || "";
+  const year = document.getElementById("calc-year")?.value || "";
+  const event = document.getElementById("calc-event")?.value || "";
+  if (!customer || !event) {
+    container.innerHTML = '<p style="color: var(--gray);">Select a customer, year, and event to search for sharing opportunities.</p>';
+    return;
+  }
+  if (!APP_STATE.calculatorState) {
+    APP_STATE.calculatorState = { sampleMode: "dropdown", scheduleEntry: null };
+  }
+  const entry = APP_STATE.calculatorState.scheduleEntry || findScheduleEntry(customer, year, event);
+  if (!entry) {
+    container.innerHTML = '<p style="color: var(--gray);">No schedule data found for the selected event. Import schedule.csv to enable this analysis.</p>';
+    return;
+  }
+  const windowStart = parseDate(entry.bleedDate || entry.shipDate);
+  const expirationDate = parseDate(entry.expirationDate);
+  if (!windowStart) {
+    container.innerHTML = '<p style="color: var(--gray);">Missing bleed or ship date for the selected event.</p>';
+    return;
+  }
+  let windowEnd = new Date(windowStart.getTime());
+  windowEnd.setDate(windowEnd.getDate() + 36);
+  if (expirationDate && expirationDate < windowEnd) {
+    windowEnd = expirationDate;
+  }
+  const scheduleEntries = Array.isArray(APP_STATE.schedule) ? APP_STATE.schedule : [];
+  const opportunities = [];
+  scheduleEntries.forEach((other) => {
+    if (!other) return;
+    if (other.customer === customer && other.event === event) {
+      const otherYear = deriveScheduleYear(other);
+      const baseYear = deriveScheduleYear(entry);
+      if (String(otherYear || '') === String(baseYear || '')) {
+        return;
+      }
+    }
+    const otherStart = parseDate(other.bleedDate || other.shipDate);
+    if (!otherStart) return;
+    let otherEnd = new Date(otherStart.getTime());
+    otherEnd.setDate(otherEnd.getDate() + 36);
+    const otherExpiration = parseDate(other.expirationDate);
+    if (otherExpiration && otherExpiration < otherEnd) {
+      otherEnd = otherExpiration;
+    }
+    if (otherEnd >= windowStart && otherStart <= windowEnd) {
+      opportunities.push({
+        customer: other.customer || "",
+        event: other.event || "",
+        year: deriveScheduleYear(other),
+        bleedDate: other.bleedDate || other.shipDate || "",
+        shipDate: other.shipDate || "",
+        expirationDate: other.expirationDate || "",
+        overlapStart: otherStart > windowStart ? otherStart : windowStart,
+        overlapEnd: otherEnd < windowEnd ? otherEnd : windowEnd,
+      });
+    }
+  });
+  opportunities.sort((a, b) => {
+    const aDate = parseDate(a.shipDate) || parseDate(a.bleedDate) || new Date(0);
+    const bDate = parseDate(b.shipDate) || parseDate(b.bleedDate) || new Date(0);
+    return aDate - bDate;
+  });
+  const baseWindowText = `${formatDateForDisplay(windowStart)} – ${formatDateForDisplay(windowEnd)}`;
+  if (opportunities.length === 0) {
+    container.innerHTML = `<div class="alert alert-info">No overlapping manufacturing windows were found for the ${customer} ${event} event. Base sharing window: ${baseWindowText}.</div>`;
+    return;
+  }
+  const rows = opportunities
+    .map((op) => {
+      const overlapText = `${formatDateForDisplay(op.overlapStart)} – ${formatDateForDisplay(op.overlapEnd)}`;
+      const yearText = op.year != null ? op.year : '—';
+      return `<tr><td>${op.customer}</td><td>${op.event}</td><td>${yearText}</td><td>${formatDateForDisplay(op.bleedDate)}</td><td>${formatDateForDisplay(op.shipDate)}</td><td>${formatDateForDisplay(op.expirationDate)}</td><td>${overlapText}</td></tr>`;
+    })
+    .join("");
+  container.innerHTML = `
+    <div class="alert alert-info" style="margin-bottom: 1rem;">
+      Sharing window for <strong>${customer} ${event}</strong>: ${baseWindowText}
+    </div>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Customer</th>
+            <th>Event</th>
+            <th>Year</th>
+            <th>Earliest Bleed</th>
+            <th>Ship Date</th>
+            <th>Expiration</th>
+            <th>Overlap Window</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+// ===============================
+// BUP Generator Functions
+// ===============================
+
+function hasForecastEligibleEvents() {
+  const currentYear = new Date().getFullYear();
+  const futureSpecs = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  const hasFutureSpec = futureSpecs.some((spec) => {
+    if (!spec) return false;
+    const specYear = Number(spec.year);
+    return Number.isFinite(specYear) && specYear >= currentYear;
+  });
+  if (hasFutureSpec) {
+    return true;
+  }
+
+  const scheduleEntries = Array.isArray(APP_STATE.schedule)
+    ? APP_STATE.schedule
+    : [];
+  const now = new Date();
+  for (const entry of scheduleEntries) {
+    if (!entry || entry.type !== "PT") continue;
+    const scheduleDate =
+      parseDate(entry.shipDate) ||
+      parseDate(entry.bleedDate) ||
+      parseDate(entry.expirationDate);
+    if (scheduleDate && scheduleDate >= now) {
+      return true;
+    }
+    const derivedYear = deriveScheduleYear(entry);
+    if (Number.isFinite(derivedYear) && derivedYear > currentYear) {
+      return true;
+    }
+  }
+
+  const specs = Array.isArray(APP_STATE.customerSpecs)
+    ? APP_STATE.customerSpecs
+    : [];
+  return specs.some((spec) => {
+    const year = Number(spec?.year);
+    return Number.isFinite(year) && year > currentYear;
+  });
+}
+
+function updateForecastModeAvailability() {
+  const forecastRadio = document.querySelector(
+    'input[name="bup-mode"][value="forecasted"]',
+  );
+  const confirmedRadio = document.querySelector(
+    'input[name="bup-mode"][value="confirmed"]',
+  );
+  if (!forecastRadio) return;
+
+  const enabled = hasForecastEligibleEvents();
+  forecastRadio.disabled = !enabled;
+  forecastRadio.setAttribute("aria-disabled", String(!enabled));
+
+  const availabilityNotice = document.getElementById("bup-mode-availability");
+  if (availabilityNotice) {
+    availabilityNotice.style.display = enabled ? "none" : "block";
+  }
+
+  if (!enabled && forecastRadio.checked) {
+    forecastRadio.checked = false;
+    if (confirmedRadio) {
+      confirmedRadio.checked = true;
+    }
+    setBUPMode("confirmed", { skipAvailabilityUpdate: true });
+  }
+}
+
+function setBUPMode(mode, options = {}) {
+  const desired = mode === "forecasted" ? "forecasted" : "confirmed";
+  if (!APP_STATE.bupGenerator) {
+    APP_STATE.bupGenerator = { mode: desired, forecastFallbacks: [] };
+  }
+  APP_STATE.bupGenerator.mode = desired;
+  APP_STATE.bupGenerator.forecastFallbacks = [];
+
+  const indicator = document.getElementById("bup-mode-indicator");
+  if (indicator) {
+    indicator.style.display = desired === "forecasted" ? "block" : "none";
+  }
+  const notice = document.getElementById("bup-forecast-notice");
+  if (notice) {
+    notice.style.display = "none";
+    notice.textContent = "";
+  }
+
+  APP_STATE.bupSelectedPool.clear();
+  updateSelectedPoolDisplay();
+  populateBUPFilters();
+  updateBUPEventList();
+
+  if (!options.skipAvailabilityUpdate) {
+    updateForecastModeAvailability();
+  }
+}
+
+function populateBUPEvents() {
+  // Populate filter dropdowns
+  populateBUPFilters();
+  // Update event list
+  updateBUPEventList();
+  updateForecastModeAvailability();
+}
+
+function populateBUPFilters() {
+  const mode = APP_STATE.bupGenerator?.mode || "confirmed";
+  const yearSelect = document.getElementById("bup-filter-year");
+  if (!yearSelect) return;
+
+  const previousValue = yearSelect.value;
+  const yearValues = new Set();
+
+  if (mode === "forecasted") {
+    const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+      ? APP_STATE.futureSpecs.entries
+      : [];
+    futureEntries.forEach((spec) => {
+      if (spec && spec.year !== undefined && spec.year !== null && spec.year !== "") {
+        yearValues.add(String(spec.year));
+      }
+    });
+    const currentYear = new Date().getFullYear();
+    const scheduleEntries = Array.isArray(APP_STATE.schedule)
+      ? APP_STATE.schedule
+      : [];
+    scheduleEntries.forEach((entry) => {
+      if (!entry || entry.type !== "PT") return;
+      const entryYear = deriveScheduleYear(entry);
+      if (Number.isFinite(entryYear) && entryYear >= currentYear) {
+        yearValues.add(String(entryYear));
+      }
+    });
+  } else {
+    const specs = Array.isArray(APP_STATE.customerSpecs)
+      ? APP_STATE.customerSpecs
+      : [];
+    specs
+      .map((s) => s.year)
+      .filter((year) => year !== undefined && year !== null && year !== "")
+      .forEach((year) => yearValues.add(String(year)));
+  }
+
+  const years = Array.from(yearValues).sort((a, b) => Number(b) - Number(a));
+  yearSelect.innerHTML = '<option value="">All Years</option>';
+  years.forEach((year) => {
+    yearSelect.innerHTML += `<option value="${year}">${year}</option>`;
+  });
+  if (previousValue && years.includes(previousValue)) {
+    yearSelect.value = previousValue;
+  } else {
+    yearSelect.value = "";
+  }
+}
+
+function updateBUPEventList() {
+  const customerFilter = document.getElementById("bup-filter-customer").value;
+  const yearFilter = document.getElementById("bup-filter-year").value;
+  const searchFilter = document
+    .getElementById("bup-filter-search")
+    .value.toLowerCase();
+
+  // Get unique events with filters applied
+  const events = {};
+  const mode = APP_STATE.bupGenerator?.mode || "confirmed";
+  const normalizedSearch = searchFilter.trim();
+
+  const addEvent = (customer, event, year) => {
+    if (!customer || !event) return;
+    if (customerFilter && customer !== customerFilter) return;
+    if (yearFilter && String(year) !== String(yearFilter)) return;
+    const safeYear = year !== undefined && year !== null ? String(year) : "";
+    if (!safeYear) return;
+    const eventKey = `${customer}|${event}|${safeYear}`;
+    const eventLabel = `${customer} - ${event} (${safeYear})`;
+    if (
+      normalizedSearch &&
+      !eventLabel.toLowerCase().includes(normalizedSearch)
+    ) {
+      return;
+    }
+    events[eventKey] = eventLabel;
+  };
+
+  if (mode === "forecasted") {
+    const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+      ? APP_STATE.futureSpecs.entries
+      : [];
+    futureEntries.forEach((spec) => {
+      if (!spec) return;
+      addEvent(spec.customer, spec.event, spec.year);
+    });
+
+    const currentYear = new Date().getFullYear();
+    const scheduleEntries = Array.isArray(APP_STATE.schedule)
+      ? APP_STATE.schedule
+      : [];
+    scheduleEntries.forEach((entry) => {
+      if (!entry || entry.type !== "PT") return;
+      const derivedYear = deriveScheduleYear(entry);
+      if (!Number.isFinite(derivedYear) || derivedYear < currentYear) return;
+      addEvent(entry.customer, entry.event, derivedYear);
+    });
+  } else {
+    const specs = Array.isArray(APP_STATE.customerSpecs)
+      ? APP_STATE.customerSpecs
+      : [];
+    specs.forEach((spec) => {
+      if (!spec) return;
+      addEvent(spec.customer, spec.event, spec.year);
+    });
+  }
+
+  // Generate checkbox list
+  const listDiv = document.getElementById("bup-events-list");
+  if (Object.keys(events).length === 0) {
+    listDiv.innerHTML =
+      '<p style="color: var(--gray); text-align: center;">No events match filters</p>';
+  } else {
+    listDiv.innerHTML = Object.keys(events)
+      .sort()
+      .map((key) => {
+        // Check if this event is already in the pool
+        const isInPool = APP_STATE.bupSelectedPool.has(key);
+        const buttonText = isInPool ? "Remove from Pool" : "Add to Pool";
+        const buttonClass = isInPool ? "btn-danger" : "btn-primary";
+
+        return `
+                <div style="margin-bottom: 0.5rem; display: flex; justify-content: space-between; align-items: center;">
+                  <span>${events[key]}</span>
+                  <button class="btn ${buttonClass} btn-sm" onclick="toggleEventInPool('${key}', '${events[
+                    key
+                  ].replace(/'/g, "\\'")}')">
+                    ${buttonText}
+                  </button>
+                </div>
+              `;
+      })
+      .join("");
+  }
+
+  updateSelectedPoolDisplay();
+}
+
+function toggleEventInPool(eventKey, eventLabel) {
+  if (APP_STATE.bupSelectedPool.has(eventKey)) {
+    APP_STATE.bupSelectedPool.delete(eventKey);
+  } else {
+    APP_STATE.bupSelectedPool.add(eventKey);
+  }
+
+  updateBUPEventList(); // Refresh the buttons
+  updateSelectedPoolDisplay();
+}
+
+function removeFromPool(eventKey) {
+  APP_STATE.bupSelectedPool.delete(eventKey);
+  updateBUPEventList();
+  updateSelectedPoolDisplay();
+}
+
+function clearSelectedPool() {
+  if (confirm("Remove all events from the selected pool?")) {
+    APP_STATE.bupSelectedPool.clear();
+    updateBUPEventList();
+    updateSelectedPoolDisplay();
+  }
+}
+
+function updateSelectedPoolDisplay() {
+  const poolDiv = document.getElementById("selected-events-pool");
+  const listDiv = document.getElementById("selected-events-list");
+  const emptyMessage = document.getElementById("empty-pool-message");
+  const count = APP_STATE.bupSelectedPool.size;
+
+  // Update count
+  document.getElementById("bup-selected-count").textContent = count;
+
+  if (count === 0) {
+    poolDiv.style.display = "none";
+    emptyMessage.style.display = "block";
+    listDiv.innerHTML = "";
+  } else {
+    poolDiv.style.display = "block";
+    emptyMessage.style.display = "none";
+
+    // Create event tags
+    listDiv.innerHTML = Array.from(APP_STATE.bupSelectedPool)
+      .map((key) => {
+        const [customer, event, year] = key.split("|");
+        const label = `${customer} - ${event} (${year})`;
+
+        return `
+              <div style="
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.5rem 0.75rem;
+                background: var(--hemo-blue);
+                color: white;
+                border-radius: 20px;
+                font-size: 0.875rem;
+              ">
+                <span>${label}</span>
+                <button onclick="removeFromPool('${key}')" style="
+                  background: none;
+                  border: none;
+                  color: white;
+                  cursor: pointer;
+                  font-size: 1.25rem;
+                  line-height: 1;
+                  padding: 0;
+                ">×</button>
+              </div>
+            `;
+      })
+      .join("");
+  }
+}
+
+function selectAllVisibleEvents() {
+  const customerFilter = document.getElementById("bup-filter-customer").value;
+  const yearFilter = document.getElementById("bup-filter-year").value;
+  const searchFilter = document
+    .getElementById("bup-filter-search")
+    .value.toLowerCase();
+
+  // Get all events matching current filters
+  APP_STATE.customerSpecs.forEach((spec) => {
+    if (customerFilter && spec.customer !== customerFilter) return;
+    if (yearFilter && spec.year != yearFilter) return;
+
+    const eventKey = `${spec.customer}|${spec.event}|${spec.year}`;
+    const eventLabel = `${spec.customer} - ${spec.event} (${spec.year})`;
+
+    if (searchFilter && !eventLabel.toLowerCase().includes(searchFilter))
+      return;
+
+    // Add to pool
+    APP_STATE.bupSelectedPool.add(eventKey);
+  });
+
+  updateBUPEventList();
+  updateSelectedPoolDisplay();
+}
+
+function updateSelectedCount() {
+  const checked = document.querySelectorAll(
+    '#bup-events-list input[type="checkbox"]:checked',
+  );
+  document.getElementById("bup-selected-count").textContent = checked.length;
+}
+
+function getSelectedBUPEvents() {
+  // Now we get events from the pool instead of checkboxes
+  return Array.from(APP_STATE.bupSelectedPool).map((key) => {
+    const [customer, event, year] = key.split("|");
+    return { customer, event, year };
+  });
+}
+
+function generateBUP() {
+  const selectedEvents = getSelectedBUPEvents();
+  if (selectedEvents.length === 0) {
+    showAlert("error", "Please select at least one event");
+    return;
+  }
+
+  const mode = APP_STATE.bupGenerator?.mode || "confirmed";
+  const isForecastMode = mode === "forecasted";
+  const forecastFallbacks = [];
+
+  // Get all samples for selected events
+  const samples = [];
+  selectedEvents.forEach(({ customer, event, year }) => {
+    let eventSpecs = [];
+    if (isForecastMode) {
+      const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+        ? APP_STATE.futureSpecs.entries
+        : [];
+      eventSpecs = futureEntries.filter(
+        (spec) =>
+          spec &&
+          spec.customer === customer &&
+          spec.event === event &&
+          String(spec.year) === String(year),
+      );
+      if (eventSpecs.length === 0) {
+        eventSpecs = (APP_STATE.customerSpecs || []).filter(
+          (spec) =>
+            spec &&
+            spec.customer === customer &&
+            spec.event === event &&
+            String(spec.year) === String(year),
+        );
+      }
+    } else {
+      eventSpecs = (APP_STATE.customerSpecs || []).filter(
+        (spec) =>
+          spec &&
+          spec.customer === customer &&
+          spec.event === event &&
+          String(spec.year) === String(year),
+      );
+    }
+
+    eventSpecs.forEach((spec) => {
+      // Get sample definition for volume and hematocrit
+      const sampleDef = APP_STATE.sampleDefinitions.find(
+        (def) => def.sample_type_id === spec.sample_type_id,
+      );
+
+      if (sampleDef && sampleDef.requires_rbc === "TRUE") {
+        let quantityValue;
+        if (isForecastMode) {
+          let targetYear = Number(year);
+          if (!Number.isFinite(targetYear)) {
+            const scheduleEntry = findScheduleEntry(customer, year, event);
+            const scheduleYear = deriveScheduleYear(scheduleEntry);
+            if (Number.isFinite(scheduleYear)) {
+              targetYear = scheduleYear;
+            }
+          }
+          const forecastResult = calculateForecast({
+            customer,
+            sampleId: spec.sample_id,
+            targetYear,
+          });
+          quantityValue = Number.isFinite(forecastResult.value)
+            ? forecastResult.value
+            : 0;
+          if (forecastResult.method && forecastResult.method !== "regression") {
+            forecastFallbacks.push({
+              customer,
+              event,
+              sampleId: spec.sample_id,
+              method: forecastResult.method,
+            });
+          }
+        } else {
+          quantityValue = getQuantityForSample(customer, event, spec.sample_id);
+        }
+
+        samples.push({
+          ...spec,
+          volume: parseFloat(sampleDef.fill_ml) || 2,
+          hematocrit: parseFloat(sampleDef.hct_percent) || 4,
+          quantity: quantityValue,
+        });
+      }
+    });
+  });
+
+  if (APP_STATE.bupGenerator) {
+    APP_STATE.bupGenerator.forecastFallbacks = forecastFallbacks;
+  }
+
+  // Calculate blood requirements
+  const calculations = calculateBloodRequirements(samples);
+
+  // Group by blood type
+  const bloodGroups = groupByBloodType(calculations);
+
+  // Find sharing opportunities
+  const sharingPlan = findSharingOpportunities(bloodGroups, selectedEvents);
+
+  // NEW: Analyze flexible antigen opportunities
+  const standingOrderDefs = {
+    HQC: STANDING_ORDERS.find((o) => o.product === "Hemo-QC")?.units || [],
+    Mirrscitech:
+      STANDING_ORDERS.find((o) => o.product === "Korea FFMU/Mirrscitech")
+        ?.units || [],
+    C3:
+      STANDING_ORDERS.find((o) => o.product === "C3 Control Cells")?.units ||
+      [],
+  };
+
+  const flexibleOpportunities = analyzeFlexibleAntigens(
+    bloodGroups,
+    standingOrderDefs,
+  );
+
+  const forecastContext = isForecastMode
+    ? {
+        mode,
+        fallbackTypes: new Set(forecastFallbacks.map((item) => item.method)),
+      }
+    : null;
+
+  // Display results with optimization suggestions
+  displayBUPReport(
+    bloodGroups,
+    sharingPlan,
+    selectedEvents,
+    flexibleOpportunities,
+    forecastContext,
+  );
+
+  const notice = document.getElementById("bup-forecast-notice");
+  if (notice) {
+    if (isForecastMode && forecastFallbacks.length > 0) {
+      const affectedSamples = forecastFallbacks.length;
+      notice.textContent =
+        affectedSamples === 1
+          ? "Forecast based on limited historical data for 1 sample."
+          : `Forecast based on limited historical data for ${affectedSamples} samples.`;
+      notice.style.display = "block";
+    } else {
+      notice.style.display = "none";
+      notice.textContent = "";
+    }
+  }
+}
+
+function getQuantityForSample(customer, event, sampleId) {
+  // First check for specific sample quantity
+  let quantity = APP_STATE.confirmedQuantities.find(
+    (q) =>
+      q.customer === customer && q.event === event && q.sample_id === sampleId,
+  );
+
+  if (quantity) return parseInt(quantity.quantity) || 100;
+
+  // Then check for event-level quantity
+  quantity = APP_STATE.confirmedQuantities.find(
+    (q) =>
+      q.customer === customer &&
+      q.event === event &&
+      (!q.sample_id || q.sample_id === "All"),
+  );
+
+  if (quantity) return parseInt(quantity.quantity) || 100;
+
+  // Default quantities by customer
+  const defaults = {
+    ISLA: 600,
+    Aurevia: 800,
+    OneWorld: 1000,
+    AABB: 100,
+  };
+
+  return defaults[customer] || 100;
+}
+
+function getOverageRates(quantity) {
+  const numericQuantity = Number(quantity);
+  if (!Number.isFinite(numericQuantity) || numericQuantity < 200) {
+    return { low: 0.15, high: 0.2 };
+  }
+  if (numericQuantity <= 1000) {
+    return { low: 0.1, high: 0.15 };
+  }
+  if (numericQuantity <= 2000) {
+    return { low: 0.07, high: 0.1 };
+  }
+  return { low: 0.05, high: 0.07 };
+}
+
+function calculateBloodRequirements(samples) {
+  return samples.map((sample) => {
+    const quantityValue = Number(sample.quantity);
+    const quantity = Number.isFinite(quantityValue) ? quantityValue : 100;
+    const volume = sample.volume || 2;
+    const hctDecimal = (sample.hematocrit || 4) / 100;
+
+    // Determine overage based on sample type
+    let overageLowRate;
+    let overageHighRate;
+
+    // Check for DAT positive samples
+    if (
+      sample.is_dat_positive === "TRUE" ||
+      sample.is_dat_positive === true ||
+      sample.sample_id?.includes("DAT")
+    ) {
+      overageLowRate = 0.25;
+      overageHighRate = 0.3;
+    } else if (sample.sample_id?.includes("ELU")) {
+      overageLowRate = 0.25;
+      overageHighRate = 0.3;
+    } else {
+      const rates = getOverageRates(quantity);
+      overageLowRate = rates.low;
+      overageHighRate = rates.high;
+    }
+
+    // Calculate volumes using correct formula
+    const baseVolume = quantity * volume * hctDecimal;
+    const retentionVolume = RETENTION_SAMPLES * volume * hctDecimal;
+    const totalMinVolume = (baseVolume + retentionVolume) * (1 + overageLowRate);
+    const totalMaxVolume = (baseVolume + retentionVolume) * (1 + overageHighRate);
+
+    return {
+      ...sample,
+      baseVolume,
+      retentionVolume,
+      overageMin: 1 + overageLowRate,
+      overageMax: 1 + overageHighRate,
+      totalMinVolume,
+      totalMaxVolume,
+      bloodType: `${sample.abo} ${sample.rh}`.trim(),
+      antigens: sample.antigens || "",
+    };
+  });
+}
+
+function groupByBloodType(calculations) {
+  const groups = {};
+
+  calculations.forEach((calc) => {
+    // Group primarily by ABO/Rh, only separate for critical antigens
+    let key = calc.bloodType;
+
+    // Only add critical antigens to the key if they're specified
+    if (calc.antigens && calc.antigens !== "As measured") {
+      // Extract only critical antigens like Fya/Fyb, K, etc.
+      const criticalAntigens = ["K", "Fya", "Fyb", "s"];
+      const antigenParts = calc.antigens.split(/[,\s]+/);
+      const critical = antigenParts
+        .filter((a) => criticalAntigens.some((c) => a.includes(c)))
+        .join(" ");
+      if (critical) key += `_${critical}`;
+    }
+
+    key = key.replace(/\s+/g, "_");
+
+    if (!groups[key]) {
+      groups[key] = {
+        bloodType: calc.bloodType,
+        antigens: calc.antigens,
+        samples: [],
+        totalMin: 0,
+        totalMax: 0,
+      };
+    }
+    groups[key].samples.push(calc);
+    groups[key].totalMin += calc.totalMinVolume;
+    groups[key].totalMax += calc.totalMaxVolume;
+  });
+
+  return groups;
+}
+
+// Debug: Log exactly what we're working with
+console.log("=== BUP DEBUG for OneWorld 4th ===");
+console.log("Selected Events:", selectedEvents);
+console.log("Blood Groups after calculation:", bloodGroups);
+console.log(
+  "Calendar entries:",
+  APP_STATE.manufacturingCalendar.filter(
+    (e) =>
+      e.description?.includes("HQC") || e.description?.includes("OneWorld"),
+  ),
+);
+
+function findSharingOpportunities(bloodGroups, selectedEvents) {
+  const opportunities = [];
+
+  const selectedEventKeySet = new Set(
+    (selectedEvents || []).map(
+      (event) => `${event.customer}_${event.event}_${event.year}`,
+    ),
+  );
+  const plannedLedgerShares = {};
+
+  // Define standing order inventory with CORRECT specifications
+  const standingOrders = {
+    HQC: [
+      { type: "AsubB", rh: "Pos", volume: 180, antigens: {} }, // HQC-1
+      {
+        type: "O",
+        rh: "Pos",
+        volume: 180,
+        antigens: { phenotype: "R1r", Fya: "neg" },
+      }, // HQC-2
+      { type: "A1", rh: "Neg", volume: 180, antigens: { phenotype: "rr" } }, // HQC-3 (Fya flexible)
+    ],
+    Mirrscitech: [
+      { type: "A1", rh: "Pos", volume: 22, antigens: { phenotype: "R1R1" } },
+      { type: "B", rh: "Pos", volume: 22, antigens: { phenotype: "R2R2" } },
+      { type: "O", rh: "Neg", volume: 22, antigens: { phenotype: "rr" } },
+    ],
+    C3: [
+      { type: "O", rh: "Either", volume: 180 }, // Only ONE unit available - can be Pos OR Neg
+    ],
+  };
+
+  // Calculate HQC overage available for sharing
+  const HQC_OVERAGE_MIN = 77;
+  const HQC_OVERAGE_MAX = 98;
+
+  // Get date windows for all selected events
+  const eventDateWindows = {};
+  selectedEvents.forEach((event) => {
+    if (!event || typeof event.customer !== "string" || typeof event.event !== "string") {
+      return;
+    }
+    const eventKey = `${event.customer}_${event.event}_${event.year}`;
+
+    // Find calendar entries
+    const calendarEntries = APP_STATE.manufacturingCalendar.filter((e) => {
+      const desc = e.description?.toLowerCase() || "";
+      const customerMatch = event.customer
+        .toLowerCase()
+        .split(" ")
+        .some((part) => desc.includes(part.toLowerCase()));
+      const eventMatch =
+        desc.includes(event.event.toLowerCase()) ||
+        desc.includes(event.event.replace(/\s+/g, "").toLowerCase());
+      return customerMatch && eventMatch;
+    });
+
+    const bleedEntry = calendarEntries.find(
+      (e) => e.description?.includes("Bleed") || e.type === "blood-arrival",
+    );
+
+    const shipEntry = calendarEntries.find(
+      (e) => e.description?.includes("Ship") || e.type === "shipment",
+    );
+
+    let expireEntry = calendarEntries.find(
+      (e) => e.description?.includes("Expire") || e.type === "reference",
+    );
+
+    // Calculate expiration if not found (standard 51 days after ship)
+    let expireDate = null;
+    if (expireEntry) {
+      expireDate = new Date(expireEntry.date);
+    } else if (shipEntry) {
+      expireDate = new Date(shipEntry.date);
+      expireDate.setDate(expireDate.getDate() + 51);
+    }
+
+    if (expireDate && shipEntry) {
+      const shipDate = new Date(shipEntry.date);
+
+      // Calculate acceptable window
+      const oldestAcceptable = new Date(expireDate);
+      oldestAcceptable.setDate(oldestAcceptable.getDate() - 77);
+
+      const latestAcceptable = new Date(shipDate);
+      latestAcceptable.setDate(latestAcceptable.getDate() - 10);
+
+      eventDateWindows[eventKey] = {
+        oldest: oldestAcceptable,
+        latest: latestAcceptable,
+        bleedDate: bleedEntry ? new Date(bleedEntry.date) : null,
+      };
+
+      console.log(
+        `Event ${eventKey} window: ${oldestAcceptable.toLocaleDateString()} to ${latestAcceptable.toLocaleDateString()}`,
+      );
+    }
+  });
+
+  // Process each blood group
+  Object.keys(bloodGroups).forEach((groupKey) => {
+    const group = bloodGroups[groupKey];
+    let remaining = group.totalMin;
+    const sources = [];
+
+    // Parse blood type and antigens from the group
+    let [groupABO, groupRh] = (group.bloodType || "").split(" ");
+    const groupAntigens = group.antigens || "";
+
+    // Handle blank/empty specs as "any type acceptable"
+    const isABOFlexible =
+      !groupABO || groupABO === "" || groupABO === "undefined";
+    const isRhFlexible = !groupRh || groupRh === "" || groupRh === "undefined";
+    const areAntigensFlexible =
+      !groupAntigens || groupAntigens === "" || groupAntigens === "As measured";
+
+    console.log(
+      `Processing group: ABO=${isABOFlexible ? "ANY" : groupABO}, Rh=${
+        isRhFlexible ? "ANY" : groupRh
+      }, antigens=${areAntigensFlexible ? "ANY" : groupAntigens}, volume=${remaining}p`,
+    );
+
+    // Find which event this group belongs to
+    let applicableWindow = null;
+    for (const sample of group.samples) {
+      const eventKey = `${sample.customer}_${sample.event}_${sample.year}`;
+      if (eventDateWindows[eventKey]) {
+        applicableWindow = eventDateWindows[eventKey];
+        break;
+      }
+    }
+
+    // Check HQC availability
+    if (document.getElementById("include-hqc")?.checked && applicableWindow) {
+      // Find HQC entries within this specific event's window
+      const hqcEntries = APP_STATE.manufacturingCalendar.filter(
+        (e) =>
+          (e.description?.includes("HB HQC") ||
+            e.description?.includes("HQC")) &&
+          (e.description?.includes("Bleed") || e.type === "blood-arrival"),
+      );
+
+      // Find the one within our window
+      const validHqcEntry = hqcEntries.find((e) => {
+        const entryDate = new Date(e.date);
+        return (
+          entryDate >= applicableWindow.oldest &&
+          entryDate <= applicableWindow.latest
+        );
+      });
+
+      if (validHqcEntry) {
+        const hqcBleedDate = new Date(validHqcEntry.date);
+        console.log(
+          `Found valid HQC bleed date within window: ${hqcBleedDate.toLocaleDateString()}`,
+        );
+
+        // Find the ship date for this HQC entry
+        const hqcShipEntry = APP_STATE.manufacturingCalendar.find(
+          (e) =>
+            e.description?.includes("HB HQC") &&
+            e.description?.includes("Ship") &&
+            e.type === "shipment",
+        );
+
+        if (hqcShipEntry) {
+          const hqcShipDate = new Date(hqcShipEntry.date);
+          const hqcArrivalDate = new Date(hqcShipDate);
+          hqcArrivalDate.setDate(hqcArrivalDate.getDate() + 1); // Add 1 day for overnight shipping
+
+          // Find PT event ship date
+          const ptShipEntry = APP_STATE.manufacturingCalendar.find((e) => {
+            const eventMatches = group.samples.some(
+              (sample) =>
+                e.description?.includes(sample.customer) &&
+                e.description?.includes(sample.event),
+            );
+            return eventMatches && e.description?.includes("Ship");
+          });
+
+          if (ptShipEntry) {
+            const ptShipDate = new Date(ptShipEntry.date);
+            const daysBeforeShip = Math.floor(
+              (ptShipDate - hqcArrivalDate) / (1000 * 60 * 60 * 24),
+            );
+
+            if (daysBeforeShip < 10) {
+              console.log(
+                `HQC arrives too late: only ${daysBeforeShip} days before PT ships (need 10)`,
+              );
+              return; // ✅ Changed from continue to return
+            }
+            console.log(
+              `HQC arrives ${daysBeforeShip} days before PT ships - OK!`,
+            );
+          }
+        }
+
+        // Check each HQC cell type
+        standingOrders.HQC.forEach((stock, index) => {
+          if (remaining > 0) {
+            let compatible = false;
+            let shareVolume = 0;
+            let sourceDescription = "";
+            let flexibleNote = "";
+
+            console.log(
+              `Checking HQC-${index + 1}: ${stock.type} ${stock.rh}, antigens:`,
+              stock.antigens,
+            );
+
+            // HQC-2: O Pos R1r Fya-neg
+            if (index === 1) {
+              // Check basic blood type compatibility (blank = any acceptable)
+              if (
+                (isABOFlexible || groupABO === "O") &&
+                (isRhFlexible || groupRh === "Positive")
+              ) {
+                // Check antigen compatibility - group needs Fya-neg (or blank antigens = any acceptable)
+                if (
+                  areAntigensFlexible ||
+                  (groupAntigens.toLowerCase().includes("fya") &&
+                    (groupAntigens.toLowerCase().includes("neg") ||
+                      groupAntigens.includes("-")))
+                ) {
+                  compatible = true;
+                  shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                  sourceDescription = "HQC-2 (O Pos R1r Fya-neg)";
+                  console.log("✓ HQC-2 is compatible with O Pos Fya-neg!");
+                }
+              }
+            }
+            // HQC-3: A1 Neg rr - can be specified as Fya-pos if needed
+            else if (index === 2) {
+              // Check basic blood type compatibility (A1 is compatible with A, blank = any acceptable)
+              if (
+                (isABOFlexible || groupABO === "A" || groupABO === "A1") &&
+                (isRhFlexible || groupRh === "Negative")
+              ) {
+                // Check if group needs Fya-pos (or blank antigens = any acceptable)
+                if (
+                  areAntigensFlexible ||
+                  (groupAntigens.toLowerCase().includes("fya") &&
+                    (groupAntigens.toLowerCase().includes("pos") ||
+                      groupAntigens.includes("+")))
+                ) {
+                  compatible = true;
+                  shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                  sourceDescription = "HQC-3 (A1 Neg rr)";
+                  flexibleNote = "Specify HQC-3 as Fya-pos ($35)";
+                  console.log(
+                    "✓ HQC-3 can be specified as Fya-pos for sharing!",
+                  );
+                } else if (!groupAntigens.toLowerCase().includes("fya")) {
+                  // If no Fya requirement, still compatible
+                  compatible = true;
+                  shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                  sourceDescription = "HQC-3 (A1 Neg rr)";
+                  console.log("✓ HQC-3 is compatible with A Neg!");
+                }
+              }
+            }
+            // HQC-1: AsubB Pos
+            else if (index === 0) {
+              if (
+                (isABOFlexible || groupABO === "AB") &&
+                (isRhFlexible || groupRh === "Positive")
+              ) {
+                compatible = true;
+                shareVolume = Math.min(HQC_OVERAGE_MAX, remaining);
+                sourceDescription = "HQC-1 (AsubB Pos)";
+              }
+            }
+
+            if (compatible && shareVolume > 0) {
+              const hqcOrder = getStandingOrderByProduct("Hemo-QC");
+              const sourceKey = buildStandingOrderSourceKey(
+                "Hemo-QC",
+                hqcBleedDate,
+              );
+              const theoreticalVolume =
+                getStandingOrderTheoreticalVolume(hqcOrder);
+              const alreadyPlanned = plannedLedgerShares[sourceKey] || 0;
+              const availableVolume = calculateAvailableResourceVolume(
+                sourceKey,
+                theoreticalVolume,
+                selectedEventKeySet,
+                alreadyPlanned,
+              );
+              shareVolume = Math.min(shareVolume, availableVolume);
+
+              if (shareVolume <= 0) {
+                compatible = false;
+              } else {
+                plannedLedgerShares[sourceKey] = alreadyPlanned + shareVolume;
+
+                const minShare = Math.min(
+                  shareVolume,
+                  remaining,
+                  HQC_OVERAGE_MIN,
+                );
+                const maxShare = Math.min(
+                  shareVolume,
+                  remaining,
+                  HQC_OVERAGE_MAX,
+                );
+
+                sources.push({
+                  source: sourceDescription,
+                  type: `${stock.type} ${stock.rh}`,
+                  volumeMin: minShare,
+                  volumeMax: maxShare,
+                  flexibleNote: flexibleNote,
+                });
+                remaining -= shareVolume;
+                console.log(`Added ${shareVolume}p from ${sourceDescription}`);
+
+                if (flexibleNote) {
+                  group.flexibleAntigenNote = flexibleNote;
+                }
+              }
+            }
+          }
+        });
+      } else {
+        console.log("No HQC entry found within date window");
+      }
+    }
+
+    // Check Mirrscitech availability
+    if (
+      document.getElementById("include-mirrscitech")?.checked &&
+      applicableWindow
+    ) {
+      // Find Mirrscitech/Korea entries within this specific event's window
+      const mirrsEntries = APP_STATE.manufacturingCalendar.filter(
+        (e) =>
+          (e.description?.includes("HB Korea") ||
+            e.description?.includes("Korea") ||
+            e.description?.includes("Mirrscitech")) &&
+          (e.description?.includes("Bleed") || e.type === "blood-arrival"),
+      );
+
+      // Find the one within our window
+      const validMirrsEntry = mirrsEntries.find((e) => {
+        const entryDate = new Date(e.date);
+        return (
+          entryDate >= applicableWindow.oldest &&
+          entryDate <= applicableWindow.latest
+        );
+      });
+
+      if (validMirrsEntry) {
+        const mirrsDate = new Date(validMirrsEntry.date);
+        console.log(
+          `Found valid Mirrscitech date within window: ${mirrsDate.toLocaleDateString()}`,
+        );
+
+        standingOrders.Mirrscitech.forEach((stock, index) => {
+          if (remaining > 0) {
+            // Check compatibility (blank = any acceptable)
+            if (
+              (isABOFlexible || stock.type === groupABO) &&
+              (isRhFlexible || stock.rh === groupRh)
+            ) {
+              const used = Math.min(stock.volume, remaining);
+              if (used > 0) {
+                const sourceKey = buildStandingOrderSourceKey(
+                  "Korea FFMU/Mirrscitech",
+                  mirrsDate,
+                );
+                const mirrOrder = getStandingOrderByProduct(
+                  "Korea FFMU/Mirrscitech",
+                );
+                const theoreticalVolume =
+                  getStandingOrderTheoreticalVolume(mirrOrder);
+                const alreadyPlanned = plannedLedgerShares[sourceKey] || 0;
+                const availableVolume = calculateAvailableResourceVolume(
+                  sourceKey,
+                  theoreticalVolume,
+                  selectedEventKeySet,
+                  alreadyPlanned,
+                );
+                const adjustedUsed = Math.min(used, availableVolume);
+                if (adjustedUsed > 0) {
+                  plannedLedgerShares[sourceKey] =
+                    alreadyPlanned + adjustedUsed;
+                  sources.push({
+                    source: `Korea-${index + 1}`,
+                    type: `${stock.type} ${stock.rh} ${stock.antigens.phenotype || ""}`,
+                    volumeMin: adjustedUsed,
+                    volumeMax: adjustedUsed,
+                  });
+                  remaining -= adjustedUsed;
+                }
+              }
+            }
+          }
+        });
+      } else {
+        console.log("No Mirrscitech entry found within date window");
+      }
+    }
+
+    // Check C3 availability
+    if (document.getElementById("include-c3")?.checked && applicableWindow) {
+      // Find C3 entries within this specific event's window
+      const c3Entries = APP_STATE.manufacturingCalendar.filter(
+        (e) =>
+          (e.description?.includes("HB C3") ||
+            e.description?.includes("C3") ||
+            e.description?.includes("C3 Control")) &&
+          (e.description?.includes("Bleed") || e.type === "blood-arrival"),
+      );
+
+      // Find the one within our window
+      const validC3Entry = c3Entries.find((e) => {
+        const entryDate = new Date(e.date);
+        return (
+          entryDate >= applicableWindow.oldest &&
+          entryDate <= applicableWindow.latest
+        );
+      });
+
+      if (validC3Entry) {
+        const c3Date = new Date(validC3Entry.date);
+        console.log(
+          `Found valid C3 date within window: ${c3Date.toLocaleDateString()}`,
+        );
+
+        // C3 has only ONE bonus unit available - can be O Pos OR O Neg
+        if (remaining > 0) {
+          // Check if group needs O (any Rh acceptable for C3)
+          if (isABOFlexible || groupABO === "O") {
+            // C3 can provide either Pos or Neg, so check compatibility
+            const c3Compatible =
+              isRhFlexible ||
+              groupRh === "Positive" || // Pos can receive either
+              groupRh === "Negative"; // Neg needs Neg, but C3 can be specified as Neg
+
+            if (c3Compatible) {
+              const used = Math.min(180, remaining); // C3 bonus is always 180mL
+              const sourceKey = buildStandingOrderSourceKey(
+                "C3 Control Cells",
+                c3Date,
+              );
+              const c3Order = getStandingOrderByProduct("C3 Control Cells");
+              const theoreticalVolume =
+                getStandingOrderTheoreticalVolume(c3Order);
+              const alreadyPlanned = plannedLedgerShares[sourceKey] || 0;
+              const availableVolume = calculateAvailableResourceVolume(
+                sourceKey,
+                theoreticalVolume,
+                selectedEventKeySet,
+                alreadyPlanned,
+              );
+              const adjustedUsed = Math.min(used, availableVolume);
+              if (adjustedUsed > 0) {
+                plannedLedgerShares[sourceKey] = alreadyPlanned + adjustedUsed;
+                sources.push({
+                  source: "C3 Bonus",
+                  type: `O ${isRhFlexible ? "Pos/Neg" : groupRh}`,
+                  volumeMin: adjustedUsed,
+                  volumeMax: adjustedUsed,
+                });
+                remaining -= adjustedUsed;
+                console.log(`Added ${adjustedUsed}p from C3 Bonus`);
+              }
+            }
+          }
+        }
+      } else {
+        console.log("No C3 entry found within date window");
+      }
+    }
+
+    // Check MQC availability
+    if (document.getElementById("include-mqc")?.checked && applicableWindow) {
+      // Find MQC entries within this specific event's window
+      const mqcEntries = APP_STATE.manufacturingCalendar.filter(
+        (e) =>
+          (e.description?.includes("HB MQC") ||
+            e.description?.includes("MQC-CAT") ||
+            e.description?.includes("MQC")) &&
+          (e.description?.includes("Bleed") || e.type === "blood-arrival"),
+      );
+
+      // Find the one within our window
+      const validMqcEntry = mqcEntries.find((e) => {
+        const entryDate = new Date(e.date);
+        return (
+          entryDate >= applicableWindow.oldest &&
+          entryDate <= applicableWindow.latest
+        );
+      });
+
+      if (validMqcEntry) {
+        const mqcDate = new Date(validMqcEntry.date);
+        console.log(
+          `Found valid MQC date within window: ${mqcDate.toLocaleDateString()}`,
+        );
+
+        // MQC has 2 cell types per your standing orders configuration
+        const mqcCells = [
+          { type: "A1B", rh: "Pos", volume: 180 }, // MQC-1
+          { type: "O", rh: "Neg", volume: 180, antigens: "K+" }, // MQC-2
+        ];
+
+        mqcCells.forEach((stock, index) => {
+          if (remaining > 0) {
+            // Check compatibility (blank = any acceptable)
+            let compatible = false;
+
+            if (index === 0) {
+              // MQC-1: A1B Pos
+              compatible =
+                (isABOFlexible || groupABO === "AB") &&
+                (isRhFlexible || groupRh === "Positive");
+            } else if (index === 1) {
+              // MQC-2: O Neg K+
+              compatible =
+                (isABOFlexible || groupABO === "O") &&
+                (isRhFlexible || groupRh === "Negative");
+              // Could add K+ antigen check here if needed
+            }
+
+            if (compatible) {
+              const used = Math.min(stock.volume, remaining);
+              if (used > 0) {
+                const sourceKey = buildStandingOrderSourceKey(
+                  "MQC/MQC-CAT",
+                  mqcDate,
+                );
+                const mqcOrder = getStandingOrderByProduct("MQC/MQC-CAT");
+                const theoreticalVolume =
+                  getStandingOrderTheoreticalVolume(mqcOrder);
+                const alreadyPlanned = plannedLedgerShares[sourceKey] || 0;
+                const availableVolume = calculateAvailableResourceVolume(
+                  sourceKey,
+                  theoreticalVolume,
+                  selectedEventKeySet,
+                  alreadyPlanned,
+                );
+                const adjustedUsed = Math.min(used, availableVolume);
+                if (adjustedUsed > 0) {
+                  plannedLedgerShares[sourceKey] =
+                    alreadyPlanned + adjustedUsed;
+                  sources.push({
+                    source: `MQC-${index + 1}`,
+                    type: `${stock.type} ${stock.rh}${
+                      stock.antigens ? " " + stock.antigens : ""
+                    }`,
+                    volumeMin: adjustedUsed,
+                    volumeMax: adjustedUsed,
+                  });
+                  remaining -= adjustedUsed;
+                  console.log(`Added ${adjustedUsed}p from MQC-${index + 1}`);
+                }
+              }
+            }
+          }
+        });
+      } else {
+        console.log("No MQC entry found within date window");
+      }
+    }
+
+    // ===============================
+    // PT-TO-PT EVENT SHARING SECTION
+    // ===============================
+
+    // Check for PT event sharing opportunities
+    if (applicableWindow) {
+      console.log("Checking for PT event sharing opportunities...");
+      // Debug: Show all calendar entries in window
+      const allEventsInWindow = APP_STATE.manufacturingCalendar.filter((e) => {
+        if (!e.date) return false;
+        const eventDate = new Date(e.date);
+        return (
+          eventDate >= applicableWindow.oldest &&
+          eventDate <= applicableWindow.latest
+        );
+      });
+
+      console.log(
+        `All events in window:`,
+        allEventsInWindow.map((e) => ({
+          desc: e.description,
+          type: e.type,
+          eventType: e.eventType,
+          date: e.date,
+        })),
+      );
+
+      // Find ALL PT events in the calendar within the sharing window
+      const ptEvents = APP_STATE.manufacturingCalendar.filter((e) => {
+        if (
+          !e.date ||
+          !e.eventType ||
+          e.eventType !== "PT" ||
+          !e.type ||
+          e.type !== "blood-arrival"
+        ) {
+          return false;
+        }
+
+        const eventDate = new Date(e.date);
+        return (
+          eventDate >= applicableWindow.oldest &&
+          eventDate <= applicableWindow.latest
+        );
+      });
+
+      console.log(`Found ${ptEvents.length} PT events within sharing window`);
+
+      // For each PT event, check if it has blood we can use
+      ptEvents.forEach((ptEvent) => {
+        if (remaining <= 0) return; // No more blood needed
+
+        // Parse the PT event description to get customer and event info
+        const eventDesc = ptEvent.description || "";
+
+        // Extract customer and event from description FIRST
+        // Format could be: "ISLA 3rd - Bleed" or "OneWorld 3rd - Bleed"
+        const cleanDesc = eventDesc
+          .replace(" - Bleed", "")
+          .replace(" - Ship", "");
+        const parts = cleanDesc.split(" ");
+        if (parts.length < 2) return;
+
+        const ptCustomer = parts[0];
+        // Event might be "3rd", "3rd 2025", "PT 2025-01", etc.
+        const ptEventParts = parts.slice(1);
+
+        // Skip if this PT event is part of the same event we're currently analyzing
+        // (We don't want ISLA 3rd to share with ISLA 3rd)
+        const analyzingCustomer = group.samples[0]?.customer;
+        const analyzingEvent = group.samples[0]?.event;
+
+        // Check if this PT event matches what we're analyzing
+        if (
+          ptCustomer === analyzingCustomer &&
+          ptEventParts.some(
+            (part) =>
+              analyzingEvent &&
+              analyzingEvent.toLowerCase().includes(part.toLowerCase()),
+          )
+        ) {
+          console.log(
+            `Skipping same event: ${eventDesc} (analyzing ${analyzingCustomer} ${analyzingEvent})`,
+          );
+          return;
+        }
+
+        console.log(
+          `Checking PT event: ${eventDesc} (eventType: ${ptEvent.eventType})`,
+        );
+
+        // Find specs for this PT event - be more flexible in matching
+        const ptSpecs = APP_STATE.customerSpecs.filter((spec) => {
+          // Check customer match
+          const customerMatch =
+            spec.customer &&
+            spec.customer.toLowerCase().includes(ptCustomer.toLowerCase());
+
+          // Check event match - be flexible
+          const eventMatch =
+            spec.event &&
+            ptEventParts.some((part) =>
+              spec.event.toLowerCase().includes(part.toLowerCase()),
+            );
+
+          return customerMatch && eventMatch;
+        });
+
+        if (ptSpecs.length === 0) {
+          console.log(
+            `No specs found for ${eventDesc} - customer: ${ptCustomer}, event parts: ${ptEventParts.join(
+              " ",
+            )}`,
+          );
+          return;
+        } else {
+          // Log the first spec found to verify
+          console.log(
+            `Found ${ptSpecs.length} specs for ${ptCustomer}: ${ptSpecs[0].event} (${ptSpecs[0].abo} ${ptSpecs[0].rh})`,
+          );
+        }
+
+        // Check each spec for compatibility
+        ptSpecs.forEach((ptSpec) => {
+          if (remaining <= 0) return;
+
+          // Parse PT event blood type
+          const ptABO = ptSpec.abo || "";
+          const ptRh = ptSpec.rh || "";
+          const ptAntigens = ptSpec.antigens || "";
+
+          // Check blood type compatibility
+          let compatible = false;
+
+          // Check ABO compatibility
+          const aboCompatible =
+            isABOFlexible ||
+            ptABO === "" ||
+            ptABO === groupABO ||
+            groupABO === "AB" || // AB can receive any
+            (groupABO === "A" && ptABO === "O") || // A can receive O
+            (groupABO === "B" && ptABO === "O"); // B can receive O
+
+          // Check Rh compatibility
+          const rhCompatible =
+            isRhFlexible ||
+            ptRh === "" ||
+            ptRh === groupRh ||
+            groupRh === "Positive"; // Pos can receive Neg
+
+          // Check antigen compatibility (simplified - in production would be more complex)
+          const antigenCompatible =
+            areAntigensFlexible ||
+            ptAntigens === "" ||
+            ptAntigens === "As measured" ||
+            ptAntigens === groupAntigens;
+
+          compatible = aboCompatible && rhCompatible && antigenCompatible;
+
+          if (compatible) {
+            // Calculate how much overage this PT event has available to share
+            // First, find out how much this PT event actually needs
+            const ptSampleDef = APP_STATE.sampleDefinitions.find(
+              (def) => def.sample_type_id === ptSpec.sample_type_id,
+            );
+
+            const ptQuantity = getQuantityForSample(
+              ptSpec.customer,
+              ptSpec.event,
+              ptSpec.sample_id,
+            );
+            const ptVolume = parseFloat(ptSampleDef?.fill_ml) || 2;
+            const ptHematocrit = parseFloat(ptSampleDef?.hct_percent) || 4;
+            const ptHctDecimal = ptHematocrit / 100;
+
+            // Calculate what the PT event needs
+            const ptBaseVolume = ptQuantity * ptVolume * ptHctDecimal;
+            const ptRetentionVolume =
+              RETENTION_SAMPLES * ptVolume * ptHctDecimal;
+
+            // Determine overage factor for the PT event
+            let ptOverageFactor = 1.1; // Default
+            if (
+              ptSpec.is_dat_positive === "TRUE" ||
+              ptSpec.sample_id?.includes("DAT")
+            ) {
+              ptOverageFactor = 1.3;
+            } else if (ptQuantity < 200) {
+              ptOverageFactor = 1.15;
+            } else if (ptQuantity < 1000) {
+              ptOverageFactor = 1.1;
+            } else if (ptQuantity < 2000) {
+              ptOverageFactor = 1.08;
+            } else {
+              ptOverageFactor = 1.06;
+            }
+
+            const ptTotalNeeded =
+              (ptBaseVolume + ptRetentionVolume) * ptOverageFactor;
+            const ptUnitsOrdered = Math.ceil(ptTotalNeeded / RBC_UNIT_ML);
+            const ptActualOrdered = ptUnitsOrdered * RBC_UNIT_ML;
+            const ptOverage = ptActualOrdered - ptTotalNeeded;
+
+            console.log(
+              `PT Event ${ptSpec.customer} ${ptSpec.event} ${
+                ptSpec.sample_id
+              }: needs ${ptTotalNeeded.toFixed(
+                0,
+              )}mL, orders ${ptActualOrdered}mL, overage available: ${ptOverage.toFixed(0)}mL`,
+            );
+
+            const shareVolume = Math.min(ptOverage, remaining);
+
+            if (shareVolume > 0) {
+              const sourceKey = buildPTEventSourceKey(ptSpec);
+              const theoreticalVolume = estimateSpecAllocationVolume(ptSpec);
+              const alreadyPlanned = plannedLedgerShares[sourceKey] || 0;
+              const availableVolume = calculateAvailableResourceVolume(
+                sourceKey,
+                theoreticalVolume,
+                selectedEventKeySet,
+                alreadyPlanned,
+              );
+              const adjustedShareVolume = Math.min(
+                shareVolume,
+                availableVolume,
+              );
+
+              if (adjustedShareVolume > 0) {
+                plannedLedgerShares[sourceKey] =
+                  alreadyPlanned + adjustedShareVolume;
+                sources.push({
+                  source: `PT: ${ptSpec.customer} ${ptSpec.event}`,
+                  type: `${ptABO} ${ptRh}`,
+                  volumeMin: adjustedShareVolume,
+                  volumeMax: adjustedShareVolume,
+                  isPTEvent: true,
+                });
+                remaining -= adjustedShareVolume;
+
+                console.log(
+                  `✓ Can share ${adjustedShareVolume.toFixed(0)}mL from ${ptSpec.customer} ${
+                    ptSpec.event
+                  }`,
+                );
+
+                // Track this as a flexible opportunity if antigens were made compatible
+                if (ptAntigens !== groupAntigens && !areAntigensFlexible) {
+                  group.ptSharingNote = `Consider matching antigens with ${ptSpec.customer} ${ptSpec.event} for sharing`;
+                }
+              }
+            }
+          } else {
+            console.log(
+              `✗ Not compatible: ${ptSpec.customer} ${ptSpec.event} (${ptABO} ${ptRh})`,
+            );
+          }
+        });
+      });
+
+      if (sources.filter((s) => s.isPTEvent).length > 0) {
+        console.log(
+          `Total PT event sharing: ${sources
+            .filter((s) => s.isPTEvent)
+            .reduce((sum, s) => sum + s.volumeMin, 0)}mL`,
+        );
+      }
+    }
+
+    // ===============================
+    // END PT-TO-PT SHARING SECTION
+    // ===============================
+
+    // This is where we push the opportunities
+    opportunities.push({
+      bloodGroup: group,
+      sources,
+      remaining: Math.max(0, remaining),
+      unitsNeeded: Math.ceil(Math.max(0, remaining) / RBC_UNIT_ML),
+      flexibleAntigenNote: group.flexibleAntigenNote,
+    });
+  });
+
+  return opportunities;
+}
+
+function isCompatibleBlood(stock, group) {
+  // Parse blood types
+  const stockABO = stock.type.split(" ")[0];
+  const stockRh = stock.type.includes("Neg") ? "Neg" : "Pos";
+  const groupABO = group.bloodType.split(" ")[0];
+  const groupRh = group.bloodType.includes("Neg") ? "Neg" : "Pos";
+
+  // Check ABO compatibility
+  if (groupABO === stockABO) {
+    // Exact match
+  } else if (groupABO === "AB") {
+    // AB can receive any type
+  } else if (groupABO === "A" && stockABO === "O") {
+    // A can receive O
+  } else if (groupABO === "B" && stockABO === "O") {
+    // B can receive O
+  } else {
+    return false;
+  }
+
+  // Check Rh compatibility
+  if (groupRh === "Neg" && stockRh === "Pos") {
+    return false;
+  }
+
+  // Check specific antigens if required
+  if (group.antigens && group.antigens !== "As measured") {
+    if (stock.antigens) {
+      // Simplified antigen matching - in production would be more complex
+      return true;
+    }
+  }
+
+  return true;
+}
+
+function isCompatible(sourceType, targetType, targetAntigens) {
+  // Simplified compatibility check
+  const [sourceABO, sourceRh] = sourceType.split(/\s+/);
+  const [targetABO, targetRh] = targetType.split(/\s+/);
+
+  // Basic ABO/Rh compatibility
+  if (targetABO === "O" && sourceABO !== "O") return false;
+  if (targetABO === "A" && !["A", "O"].includes(sourceABO)) return false;
+  if (targetABO === "B" && !["B", "O"].includes(sourceABO)) return false;
+  if (targetABO === "AB") return true; // Universal recipient
+
+  if (targetRh === "Neg" && sourceRh === "Pos") return false;
+
+  return true;
+}
+
+function isBaseBloodCompatible(stockType, neededType) {
+  // Extract ABO and Rh
+  const stockABO = stockType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || "";
+  const stockRh = stockType.includes("Neg") ? "Neg" : "Pos";
+  const neededABO = neededType.match(/^(A|B|AB|O|AsubB|A1)/)?.[0] || "";
+  const neededRh = neededType.includes("Neg") ? "Neg" : "Pos";
+
+  // Check ABO compatibility
+  let aboCompatible = false;
+  if (stockABO === neededABO) {
+    aboCompatible = true;
+  } else if (neededABO === "A" && (stockABO === "A1" || stockABO === "AsubB")) {
+    aboCompatible = true; // A subtypes are compatible
+  }
+
+  // Check Rh compatibility
+  const rhCompatible =
+    stockRh === neededRh || (neededRh === "Pos" && stockRh === "Neg");
+
+  return aboCompatible && rhCompatible;
+}
+
+function identifyFlexibleAntigens(stock, group) {
+  const flexible = [];
+
+  // If group needs specific antigens that aren't in stock description
+  if (group.antigens && group.antigens !== "As measured") {
+    const neededAntigens = group.antigens.split(/[,\s]+/);
+    const stockAntigens = stock.antigens ? stock.antigens.split(/[,\s]+/) : [];
+
+    neededAntigens.forEach((antigen) => {
+      if (
+        !stockAntigens.includes(antigen) &&
+        TRACKED_ANTIGENS.includes(antigen.replace(/pos|neg/i, "").trim())
+      ) {
+        flexible.push(antigen);
+      }
+    });
+  }
+
+  return flexible;
+}
+
+function calculateOptimizationSavings(volumeNeeded, antigenCount) {
+  const unitsAvoided = Math.ceil(volumeNeeded / RBC_UNIT_ML);
+  const bloodCost = unitsAvoided * BLOOD_UNIT_COSTS.standard;
+  const antigenCost = antigenCount * ANTIGEN_COSTS.standard;
+  return {
+    bloodCostAvoided: bloodCost,
+    antigenSpecCost: antigenCost,
+    netSavings: bloodCost - antigenCost,
+    unitsAvoided: unitsAvoided,
+  };
+}
+
+function generateOptimizationSuggestions(opportunities) {
+  if (opportunities.length === 0) return "";
+
+  let html = '<div class="alert alert-info" style="margin: 1rem 0;">';
+  html +=
+    "<strong>💡 Flexible Antigen Optimization Opportunities Detected:</strong><br><br>";
+
+  opportunities.forEach((opp, index) => {
+    const savings = calculateOptimizationSavings(
+      opp.volumeNeeded,
+      opp.flexibleAntigens.length,
+    );
+    html += `
+                                          <div style="margin-bottom: 1rem; padding: 0.5rem; background: var(--white); border-radius: 4px;">
+                                            <strong>${index + 1}. ${opp.product} (${
+                                              opp.stockType
+                                            })</strong><br>
+                                            <span style="color: var(--gray);">Can share with: ${opp.samples.join(", ")}</span><br>
+                                            <span style="color: var(--success);">Specify antigens: ${opp.flexibleAntigens.join(", ")}</span><br>
+                                            <span style="color: var(--hemo-blue);">
+                                              Cost: $${savings.antigenSpecCost} | Save: $${
+                                                savings.bloodCostAvoided
+                                              } |
+                                              <strong>Net: $${savings.netSavings}</strong>
+                                            </span>
+                                          </div>
+                                        `;
+  });
+
+  html +=
+    "<small>Add these antigen specifications when ordering standing inventory to enable sharing.</small>";
+  html += "</div>";
+
+  return html;
+}
+
+// ===============================
+// Flexible Antigen Optimization
+// ===============================
+
+function analyzeFlexibleAntigens(bloodGroups, standingOrders) {
+  const opportunities = [];
+
+  // For each blood group needed
+  Object.keys(bloodGroups).forEach((groupKey) => {
+    const group = bloodGroups[groupKey];
+
+    // Check each standing order for potential matches
+    ["HQC", "Mirrscitech", "C3"].forEach((productName) => {
+      const product = standingOrders[productName];
+      if (!product) return;
+
+      product.forEach((stock) => {
+        // Check if base ABO/Rh matches
+        if (isBaseBloodCompatible(stock.type, group.bloodType)) {
+          // Identify which antigens are flexible (not specified in original spec)
+          const flexibleAntigens = identifyFlexibleAntigens(stock, group);
+
+          if (flexibleAntigens.length > 0) {
+            const volumeAvailable = stock.volume || 180;
+            const volumeNeeded = group.totalMin;
+
+            if (volumeAvailable >= volumeNeeded * 0.5) {
+              // At least 50% coverage
+              opportunities.push({
+                product: productName,
+                stockType: stock.type,
+                bloodGroup: group.bloodType,
+                flexibleAntigens: flexibleAntigens,
+                volumeAvailable: volumeAvailable,
+                volumeNeeded: volumeNeeded,
+                samples: group.samples.map(
+                  (s) => `${s.customer} ${s.sample_id}`,
+                ),
+                potentialSavings: calculateOptimizationSavings(
+                  volumeNeeded,
+                  flexibleAntigens.length,
+                ),
+              });
+            }
+          }
+        }
+      });
+    });
+  });
+
+  return opportunities;
+}
+
+function displayBUPReport(
+  bloodGroups,
+  sharingPlan,
+  selectedEvents,
+  flexibleOpportunities,
+  forecastContext = null,
+) {
+  const reportDiv = document.getElementById("bup-report");
+  const summaryDiv = document.getElementById("bup-summary");
+  const contentDiv = document.getElementById("bup-content");
+
+  // Calculate summary statistics
+  let totalVolumeNeeded = 0;
+  let totalVolumeFromInventory = 0;
+  let totalNewVolume = 0;
+  let totalUnitsNeeded = 0;
+
+  sharingPlan.forEach((plan) => {
+    totalVolumeNeeded += plan.bloodGroup.totalMin || 0;
+    plan.sources.forEach((source) => {
+      // Use volumeMin since we changed to min/max structure
+      totalVolumeFromInventory += source.volumeMin || source.volume || 0;
+    });
+    totalNewVolume += plan.remaining || 0;
+    totalUnitsNeeded += plan.unitsNeeded || 0;
+  });
+
+  // Display optimization opportunities if any
+  let summaryHeader = "";
+  if (forecastContext?.mode === "forecasted") {
+    summaryHeader +=
+      '<div class="alert alert-info" style="margin-bottom: 0.5rem; font-weight: 600;">Mode: Forecasted</div>';
+  }
+  if (flexibleOpportunities && flexibleOpportunities.length > 0) {
+    summaryHeader += generateOptimizationSuggestions(flexibleOpportunities);
+    summaryHeader += '<hr style="margin: 1rem 0;">';
+  }
+  if (forecastContext?.fallbackTypes && forecastContext.fallbackTypes.size > 0) {
+    summaryHeader +=
+      '<div class="form-hint" style="color: var(--warning); margin-bottom: 0.5rem;">Forecast based on limited data.</div>';
+  }
+  summaryDiv.innerHTML = summaryHeader;
+
+  // Calculate max volumes for ranges
+  let totalMaxVolumeNeeded = 0;
+  let totalMaxVolumeFromInventory = 0;
+  let totalMaxNewVolume = 0;
+
+  sharingPlan.forEach((plan) => {
+    totalMaxVolumeNeeded +=
+      plan.bloodGroup.totalMax || plan.bloodGroup.totalMin || 0;
+    plan.sources.forEach((source) => {
+      totalMaxVolumeFromInventory +=
+        source.volumeMax || source.volumeMin || source.volume || 0;
+    });
+    // Calculate max new volume based on what's left
+    const maxRemaining =
+      (plan.bloodGroup.totalMax || plan.bloodGroup.totalMin) -
+      plan.sources.reduce((sum, s) => sum + (s.volumeMin || 0), 0);
+    totalMaxNewVolume += Math.max(0, maxRemaining);
+  });
+
+  // Display summary with ranges
+  summaryDiv.innerHTML += `
+        <strong>BUP Summary:</strong><br>
+        Events: ${selectedEvents.map((e) => `${e.customer} ${e.event}`).join(", ")}<br>
+        Total pRBC needed: ${totalVolumeNeeded.toFixed(0)}-${totalMaxVolumeNeeded.toFixed(0)}p<br>
+        Pull from inventory: ${totalVolumeFromInventory.toFixed(
+          0,
+        )}-${totalMaxVolumeFromInventory.toFixed(0)}p<br>
+        New blood to order: ${totalNewVolume.toFixed(0)}-${totalMaxNewVolume.toFixed(0)}p<br>
+        <strong>Units to order: ${totalUnitsNeeded} units</strong>
+      `;
+
+  // Display detailed report organized like manual BUP
+  let html = '<div class="bup-section">';
+  html += '<div class="bup-header">Order Requirements</div>';
+  html += '<div class="bup-content">';
+
+  // Group by order status (new orders vs pull from inventory)
+  let orderNumber = 1;
+  let pullNumber = 1;
+
+  // First show items that need new orders
+  html += "<h4>Order New:</h4>";
+  sharingPlan.forEach((plan) => {
+    if (plan.unitsNeeded > 0) {
+      const group = plan.bloodGroup;
+      // Calculate proper min/max for new orders based on remaining overage
+      const orderMin = plan.remaining;
+      const orderMax =
+        plan.remaining > 0
+          ? plan.bloodGroup.totalMax -
+            (plan.bloodGroup.totalMin - plan.remaining)
+          : 0;
+
+      html += `
+        <div style="margin-bottom: 1rem; padding: 0.75rem; background: var(--light); border-radius: 6px;">
+          <strong>${orderNumber}. ${group.bloodType}${
+            group.antigens && group.antigens !== "As measured"
+              ? " " + group.antigens
+              : ""
+          }</strong> = ${orderMin > 0 ? orderMin.toFixed(0) : "0"}-${
+            orderMax > 0 ? orderMax.toFixed(0) : "0"
+          }p (${plan.unitsNeeded} unit${plan.unitsNeeded > 1 ? "s" : ""})<br>
+                      <div style="margin-left: 1.5rem; margin-top: 0.5rem;">
+                  `;
+
+      // List samples contributing to this group with their ranges
+      group.samples.forEach((sample) => {
+        html += `${sample.customer} ${sample.sample_id}: ${sample.totalMinVolume.toFixed(
+          0,
+        )}-${sample.totalMaxVolume.toFixed(0)}p<br>`;
+      });
+
+      html += "</div></div>";
+      orderNumber++;
+    }
+  });
+
+  if (orderNumber === 1) {
+    html += '<p style="color: var(--gray);">No new orders needed</p>';
+  }
+
+  // Then show items pulled from inventory
+  html += '<h4 style="margin-top: 1.5rem;">Pull from Inventory:</h4>';
+  sharingPlan.forEach((plan) => {
+    if (plan.sources.length > 0) {
+      const group = plan.bloodGroup;
+      html += `
+                                      <div style="margin-bottom: 1rem; padding: 0.75rem; background: var(--light); border-radius: 6px;">
+                                        <strong>${pullNumber}. ${group.bloodType}${
+                                          group.antigens &&
+                                          group.antigens !== "As measured"
+                                            ? " " + group.antigens
+                                            : ""
+                                        }</strong> = ${
+                                          group.totalMin > 0
+                                            ? group.totalMin.toFixed(0) +
+                                              "-" +
+                                              group.totalMax.toFixed(0) +
+                                              "p"
+                                            : "0p"
+                                        }<br>
+                                        <div style="margin-left: 1.5rem; margin-top: 0.5rem;">
+                                    `;
+
+      // Show source breakdown with ranges
+      plan.sources.forEach((source) => {
+        const volumeDisplay =
+          source.volumeMin && source.volumeMax
+            ? `${source.volumeMin.toFixed(0)}-${source.volumeMax.toFixed(0)}p`
+            : `${source.volume.toFixed(1)}p`;
+        html += `<span style="color: var(--success);">→ ${source.source}: ${volumeDisplay}</span><br>`;
+        if (source.flexibleNote) {
+          html += `<span style="color: var(--info); margin-left: 2rem; font-size: 0.875rem;">💡 ${source.flexibleNote}</span><br>`;
+        }
+      });
+
+      // List samples
+      html +=
+        '<div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid var(--border);">';
+      group.samples.forEach((sample) => {
+        html += `${sample.customer} ${sample.sample_id}: ${sample.totalMinVolume.toFixed(
+          0,
+        )}-${sample.totalMaxVolume.toFixed(0)}p<br>`;
+      });
+      html += "</div>";
+
+      html += "</div></div>";
+      pullNumber++;
+    }
+  });
+
+  if (pullNumber === 1) {
+    html +=
+      '<p style="color: var(--gray);">No inventory available for sharing</p>';
+  }
+
+  html += "</div></div>";
+  contentDiv.innerHTML = html;
+
+  reportDiv.style.display = "block";
+  APP_STATE.bupAnalysis.optimizedPlan = sharingPlan;
+}
+
+function toggleBUPView() {
+  showAlert("info", "Alternative view coming in next version");
+}
+
+function exportBUP() {
+  const plan = APP_STATE.bupAnalysis.optimizedPlan;
+  if (!plan) {
+    showAlert("error", "No BUP to export");
+    return;
+  }
+
+  // Create text report
+  let text = "BLOOD UTILIZATION PLAN\n";
+  text += "=".repeat(50) + "\n\n";
+  text += `Generated: ${new Date().toLocaleString()}\n\n`;
+
+  plan.forEach((item, index) => {
+    text += `${index + 1}. ${item.bloodGroup.bloodType} ${item.bloodGroup.antigens}\n`;
+    text += `   Volume: ${item.bloodGroup.totalMin.toFixed(
+      1,
+    )}-${item.bloodGroup.totalMax.toFixed(1)}p\n`;
+    if (item.sources.length > 0) {
+      text += "   Sources:\n";
+      item.sources.forEach((s) => {
+        text += `     - ${s.source}: ${s.volume.toFixed(1)}p\n`;
+      });
+    }
+    if (item.remaining > 0) {
+      text += `   Order: ${item.remaining.toFixed(1)}p (${item.unitsNeeded} units)\n`;
+    }
+    text += "\n";
+  });
+
+  // Download file
+  const blob = new Blob([text], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `BUP_${new Date().toISOString().split("T")[0]}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+
+  showAlert("success", "BUP exported successfully");
+}
+
+// ===============================
+// Calendar Functions
+// ===============================
+
+// Initialize calendar dropdowns
+function initializeCalendarDropdowns() {
+  const modalSelect = document.getElementById("modal-calendar-type");
+  const manualSelect = document.getElementById("calendar-type");
+
+  // Build the same HTML for both dropdowns
+  let optionsHTML = "";
+  for (const [category, items] of Object.entries(CALENDAR_CATEGORIES)) {
+    optionsHTML += `<optgroup label="${category}">`;
+    items.forEach((item) => {
+      optionsHTML += `<option value="${item.value}">${item.label}</option>`;
+    });
+    optionsHTML += "</optgroup>";
+  }
+
+  if (modalSelect) modalSelect.innerHTML = optionsHTML;
+  if (manualSelect) manualSelect.innerHTML = optionsHTML;
+}
+
+// Handle type change
+function handleTypeChange(formType) {
+  const type = document.getElementById(
+    formType === "modal" ? "modal-calendar-type" : "calendar-type",
+  ).value;
+  const recurrenceDiv = document.getElementById(
+    `${formType}-recurrence-settings`,
+  );
+
+  // Check if type belongs to recurring category
+  const isRecurring = CALENDAR_CATEGORIES[RECURRENCE_ENABLED_CATEGORY]?.some(
+    (item) => item.value === type,
+  );
+
+  if (recurrenceDiv) {
+    recurrenceDiv.style.display = isRecurring ? "block" : "none";
+  }
+}
+
+// Handle unit change
+function handleUnitChange(formType) {
+  const unit = document.getElementById(`${formType}-recurrence-unit`).value;
+  const customGroup = document.getElementById(
+    `${formType}-custom-pattern-group`,
+  );
+
+  if (customGroup) {
+    customGroup.style.display = unit === "custom" ? "block" : "none";
+  }
+}
+
+// Handle end type change
+function handleEndTypeChange(formType) {
+  const endType = document.getElementById(
+    `${formType}-recurrence-end-type`,
+  ).value;
+  const countGroup = document.getElementById(`${formType}-end-count-group`);
+  const dateGroup = document.getElementById(`${formType}-end-date-group`);
+
+  if (countGroup)
+    countGroup.style.display = endType === "count" ? "block" : "none";
+  if (dateGroup)
+    dateGroup.style.display = endType === "date" ? "block" : "none";
+}
+
+// Generate recurring instances
+function generateRecurringInstances(baseEntry, recurrenceSettings) {
+  const instances = [];
+  const startDate = new Date(baseEntry.date);
+  const parentId = "recurring_" + Date.now();
+
+  // Calculate end condition
+  let maxInstances = 100; // Safety limit
+  let endDate = null;
+
+  if (recurrenceSettings.endType === "count") {
+    maxInstances = parseInt(recurrenceSettings.endCount);
+  } else if (recurrenceSettings.endType === "date") {
+    endDate = new Date(recurrenceSettings.endDate);
+  } else {
+    // Never ends - generate 2 years worth
+    endDate = new Date(startDate);
+    endDate.setFullYear(endDate.getFullYear() + 2);
+  }
+
+  // Generate instances
+  for (let i = 0; i < maxInstances; i++) {
+    const instanceDate = new Date(startDate);
+
+    if (recurrenceSettings.unit === "days") {
+      instanceDate.setDate(
+        instanceDate.getDate() + i * recurrenceSettings.interval,
+      );
+    } else if (recurrenceSettings.unit === "weeks") {
+      instanceDate.setDate(
+        instanceDate.getDate() + i * recurrenceSettings.interval * 7,
+      );
+    } else if (recurrenceSettings.unit === "months") {
+      instanceDate.setMonth(
+        instanceDate.getMonth() + i * recurrenceSettings.interval,
+      );
+    } else if (recurrenceSettings.unit === "custom") {
+      // For custom patterns, just create single instance for now
+      // Future enhancement: parse custom pattern
+      if (i > 0) break;
+    }
+
+    // Check end date
+    if (endDate && instanceDate > endDate) break;
+
+    // Create instance
+    instances.push({
+      id: `${parentId}_${i}`,
+      date: instanceDate.toISOString().split("T")[0],
+      type: baseEntry.type,
+      description: baseEntry.description + (i === 0 ? " 🔄" : ""),
+      recurrence: {
+        ...recurrenceSettings,
+        parentId: parentId,
+        instanceNumber: i,
+      },
+    });
+  }
+
+  return instances;
+}
+
+// Show recurrence modification dialog
+function showRecurrenceModificationDialog(action, callback) {
+  const dialog = document.createElement("div");
+  dialog.className = "modal active";
+  dialog.innerHTML = `
+                                            <div class="modal-content" style="max-width: 500px;">
+                                                <div class="modal-header">
+                                                    <h3 class="modal-title">${
+                                                      action === "edit"
+                                                        ? "Edit"
+                                                        : "Delete"
+                                                    } Recurring Event</h3>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p>This is a recurring event. Apply changes to:</p>
+                                                    <div style="margin: 1rem 0;">
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="single" checked>
+                                                            Only this instance
+                                                        </label>
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="future">
+                                                            This and all future instances
+                                                        </label>
+                                                        <label style="display: block; margin: 0.5rem 0;">
+                                                            <input type="radio" name="recurrence-scope" value="all">
+                                                            All instances (past and future)
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button class="btn btn-outline" onclick="this.closest('.modal').remove()">Cancel</button>
+                                                    <button class="btn ${
+                                                      action === "delete"
+                                                        ? "btn-danger"
+                                                        : "btn-primary"
+                                                    }"
+                                                            onclick="handleRecurrenceScope('${action}', this)">
+                                                        ${action === "edit" ? "Apply" : "Delete"}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        `;
+  document.body.appendChild(dialog);
+}
+
+// Handle recurrence scope selection
+function handleRecurrenceScope(action, button) {
+  const modal = button.closest(".modal");
+  const scope = modal.querySelector(
+    'input[name="recurrence-scope"]:checked',
+  ).value;
+  modal.remove();
+
+  // Store scope for use in save/delete operations
+  window.currentRecurrenceScope = scope;
+
+  if (action === "delete") {
+    performRecurringDelete(scope);
+  }
+}
+
+// Perform recurring delete
+function performRecurringDelete(scope) {
+  const entry = APP_STATE.manufacturingCalendar.find(
+    (e) => e.id === editingCalendarEntryId,
+  );
+  if (!entry || !entry.recurrence) return;
+
+  const parentId = entry.recurrence.parentId;
+  const instanceNumber = entry.recurrence.instanceNumber;
+
+  if (scope === "single") {
+    // Delete only this instance
+    APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+      (e) => e.id !== editingCalendarEntryId,
+    );
+  } else if (scope === "future") {
+    // Delete this and future instances
+    APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+      (e) =>
+        !(
+          e.recurrence?.parentId === parentId &&
+          e.recurrence.instanceNumber >= instanceNumber
+        ),
+    );
+  } else if (scope === "all") {
+    // Delete all instances
+    APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+      (e) => e.recurrence?.parentId !== parentId,
+    );
+  }
+
+  logActivity("Deleted recurring calendar entry", entry.description);
+  showAlert("success", "Calendar entry deleted");
+  renderCalendar();
+  persistState();
+  closeCalendarEntryModal();
+}
+
+function initializeCalendar() {
+  // Initialize dropdowns
+  initializeCalendarDropdowns();
+
+  renderCalendar();
+}
+
+function renderCalendar() {
+  const year = APP_STATE.currentYear;
+  const month = APP_STATE.currentMonth;
+
+  // Update header
+  const monthNames = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  document.getElementById("calendar-month-year").textContent =
+    `${monthNames[month]} ${year}`;
+
+  // Calculate calendar days
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  let html = "";
+
+  // Weekday headers
+  const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  weekdays.forEach((day) => {
+    html += `<div class="calendar-weekday">${day}</div>`;
+  });
+
+  // Empty cells before first day
+  for (let i = 0; i < firstDay; i++) {
+    html += '<div class="calendar-day"></div>';
+  }
+
+  // Days of month
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = new Date(year, month, day);
+    const dateStr = date.toISOString().split("T")[0];
+
+    // Get events for this day
+    const events = APP_STATE.manufacturingCalendar.filter(
+      (event) => event.date === dateStr,
+    );
+
+    html += `<div class="calendar-day" data-date="${dateStr}" onclick="openAddEventModal('${dateStr}')">
+                                                <div class="calendar-day-number">${day}</div>`;
+
+    events.forEach((event) => {
+      if (event.hidden) return; // Skip hidden reference entries
+      const eventClass =
+        event.eventType === "Product" ? "standing-order" : event.type;
+      const sharingIndicator = event.eventType === "PT" ? " 🔄" : "";
+      html += `<div class="calendar-event ${eventClass}" onclick="openCalendarEntry(event, '${
+        event.id
+      }')" style="cursor: pointer;" title="${event.eventType || ""}">
+                                                    ${event.description}${sharingIndicator}
+                                                </div>`;
+    });
+
+    html += "</div>";
+  }
+
+  document.getElementById("calendar-grid").innerHTML = html;
+}
+
+function resetCalendarAddEventModal() {
+  editingCalendarEntryId = null;
+  const submitButton = document.getElementById("calendar-add-event-submit");
+  if (submitButton) {
+    submitButton.textContent = "Add Event";
+    submitButton.onclick = addCalendarEvent;
+  }
+
+  const title = document.getElementById("calendar-add-event-modal-title");
+  if (title) {
+    title.textContent = "Add Event";
+  }
+
+  const deleteButton = document.getElementById("modal-delete-event-btn");
+  if (deleteButton) {
+    deleteButton.style.display = "none";
+  }
+
+  const arrivalGroup = document.getElementById("modal-arrival-date-group");
+  if (arrivalGroup) {
+    arrivalGroup.style.display = "none";
+  }
+
+  const arrivalInput = document.getElementById("modal-arrival-date");
+  if (arrivalInput) {
+    arrivalInput.value = "";
+  }
+
+  const mainDateLabel = document.getElementById("modal-main-date-label");
+  if (mainDateLabel) {
+    mainDateLabel.textContent = "Date";
+  }
+}
+
+function toggleShipmentFields() {
+  const typeSelect = document.getElementById("modal-calendar-type");
+  const arrivalGroup = document.getElementById("modal-arrival-date-group");
+  const arrivalInput = document.getElementById("modal-arrival-date");
+  const mainDateLabel = document.getElementById("modal-main-date-label");
+
+  if (!arrivalGroup || !mainDateLabel) {
+    return;
+  }
+
+  const selectedType = typeSelect ? typeSelect.value : "";
+  const isShipment = selectedType === "blood-shipment";
+
+  arrivalGroup.style.display = isShipment ? "block" : "none";
+  mainDateLabel.textContent = isShipment ? "Ship Date" : "Date";
+
+  if (!isShipment && arrivalInput) {
+    arrivalInput.value = "";
+  }
+}
+
+function openAddEventModal(dateStr) {
+  resetCalendarAddEventModal();
+
+  const modal = document.getElementById("calendar-add-event-modal");
+  if (!modal) return;
+
+  const deleteButton = document.getElementById("modal-delete-event-btn");
+  if (deleteButton) {
+    deleteButton.style.display = "none";
+  }
+
+  const dateInput = document.getElementById("modal-calendar-date");
+  if (dateInput) {
+    dateInput.value = dateStr;
+  }
+
+  const typeSelect = document.getElementById("modal-calendar-type");
+  if (typeSelect) {
+    typeSelect.selectedIndex = -1;
+    typeSelect.value = "";
+  }
+
+  const arrivalField = document.getElementById("modal-arrival-date");
+  if (arrivalField) {
+    arrivalField.value = "";
+  }
+
+  const notesField = document.getElementById("modal-calendar-notes");
+  if (notesField) {
+    notesField.value = "";
+  }
+
+  toggleShipmentFields();
+
+  modal.classList.add("active");
+}
+
+function closeCalendarAddEventModal() {
+  const modal = document.getElementById("calendar-add-event-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  resetCalendarAddEventModal();
+}
+
+function getCalendarTypeLabel(type) {
+  for (const items of Object.values(CALENDAR_CATEGORIES)) {
+    const match = items.find((item) => item.value === type);
+    if (match) {
+      return match.label;
+    }
+  }
+  return type;
+}
+
+function buildCalendarDescription(type, notes) {
+  const trimmedNotes = notes ? notes.trim() : "";
+  if (trimmedNotes) {
+    return trimmedNotes;
+  }
+  return getCalendarTypeLabel(type);
+}
+
+function addCalendarEvent() {
+  const dateInput = document.getElementById("modal-calendar-date");
+  const typeSelect = document.getElementById("modal-calendar-type");
+  const notesField = document.getElementById("modal-calendar-notes");
+  const arrivalInput = document.getElementById("modal-arrival-date");
+
+  const date = dateInput ? dateInput.value : "";
+  const type = typeSelect ? typeSelect.value : "";
+  const notes = notesField ? notesField.value.trim() : "";
+
+  if (type === "manual-bleed-date") {
+    if (!date) {
+      showAlert("error", "Please fill in all required fields");
+      return;
+    }
+
+    const eventDetails = prompt(
+      "Please enter the Customer and Event for this bleed date (e.g., WSLH 1st):",
+    );
+
+    if (!eventDetails) {
+      return;
+    }
+
+    const manualBleedEvent = {
+      id: "cal_" + Date.now(),
+      date: date,
+      type: "blood-arrival",
+      description: `${eventDetails} - Bleed`,
+      eventType: "PT",
+    };
+
+    APP_STATE.manufacturingCalendar.push(manualBleedEvent);
+
+    renderCalendar();
+    persistState();
+    logActivity("Added manual bleed date", `${eventDetails} - Bleed`);
+    showAlert("success", "Manual bleed date added");
+    closeCalendarAddEventModal();
+    return;
+  }
+
+  if (!date || !type) {
+    showAlert("error", "Please fill in all required fields");
+    return;
+  }
+
+  if (type === "blood-shipment") {
+    const arrivalDate = arrivalInput ? arrivalInput.value : "";
+
+    if (!arrivalDate) {
+      showAlert("error", "Please provide both ship and arrival dates");
+      return;
+    }
+
+    if (arrivalDate < date) {
+      showAlert("error", "Arrival date cannot be before the ship date");
+      return;
+    }
+
+    const baseDescription = buildCalendarDescription(type, notes);
+    const timestamp = Date.now();
+    const shipmentId = "ship_" + timestamp;
+
+    const shipEvent = {
+      id: "cal_" + timestamp,
+      date: date,
+      type: "shipment",
+      description: `${baseDescription} - Departs`,
+      shipmentId,
+    };
+
+    const arrivalEvent = {
+      id: "cal_" + (timestamp + 1),
+      date: arrivalDate,
+      type: "blood-arrival",
+      description: `${baseDescription} - Arrives`,
+      shipmentId,
+    };
+
+    if (notes) {
+      shipEvent.notes = notes;
+      arrivalEvent.notes = notes;
+    }
+
+    APP_STATE.manufacturingCalendar.push(shipEvent, arrivalEvent);
+
+    logActivity(
+      "Added blood shipment",
+      `${baseDescription} (${date} → ${arrivalDate})`,
+    );
+    showAlert("success", "Blood shipment scheduled");
+
+    renderCalendar();
+    persistState();
+    closeCalendarAddEventModal();
+    return;
+  } else {
+    const description = buildCalendarDescription(type, notes);
+
+    const newEvent = {
+      id: "cal_" + Date.now(),
+      date: date,
+      type: type,
+      description: description,
+    };
+
+    if (notes) {
+      newEvent.notes = notes;
+    }
+
+    APP_STATE.manufacturingCalendar.push(newEvent);
+
+    logActivity("Added calendar event", description);
+    showAlert("success", "Calendar event added");
+
+    renderCalendar();
+    persistState();
+    closeCalendarAddEventModal();
+  }
+}
+
+function previousMonth() {
+  APP_STATE.currentMonth--;
+  if (APP_STATE.currentMonth < 0) {
+    APP_STATE.currentMonth = 11;
+    APP_STATE.currentYear--;
+  }
+  renderCalendar();
+}
+
+function nextMonth() {
+  APP_STATE.currentMonth++;
+  if (APP_STATE.currentMonth > 11) {
+    APP_STATE.currentMonth = 0;
+    APP_STATE.currentYear++;
+  }
+  renderCalendar();
+}
+
+function goToToday() {
+  const today = new Date();
+  APP_STATE.currentMonth = today.getMonth();
+  APP_STATE.currentYear = today.getFullYear();
+  renderCalendar();
+}
+
+function openCalendarEntry(event, entryId) {
+  // Stop event propagation to prevent day click
+  if (event) {
+    event.stopPropagation();
+  }
+
+  const entry = APP_STATE.manufacturingCalendar.find((e) => e.id === entryId);
+
+  if (entry) {
+    const dateInput = document.getElementById("modal-calendar-date");
+    const typeSelect = document.getElementById("modal-calendar-type");
+    const notesField = document.getElementById("modal-calendar-notes");
+    const arrivalField = document.getElementById("modal-arrival-date");
+    const title = document.getElementById("calendar-add-event-modal-title");
+    const submitButton = document.getElementById("calendar-add-event-submit");
+    const deleteButton = document.getElementById("modal-delete-event-btn");
+
+    let pairedEntry = null;
+    if (entry.shipmentId) {
+      pairedEntry = APP_STATE.manufacturingCalendar.find(
+        (e) => e.shipmentId === entry.shipmentId && e.id !== entry.id,
+      );
+    }
+
+    if (dateInput) {
+      if (entry.shipmentId && entry.type === "blood-arrival" && pairedEntry) {
+        dateInput.value = pairedEntry.date;
+      } else {
+        dateInput.value = entry.date;
+      }
+    }
+
+    if (arrivalField) {
+      if (entry.shipmentId) {
+        const arrivalDate =
+          entry.type === "blood-arrival" ? entry.date : pairedEntry?.date || "";
+        arrivalField.value = arrivalDate;
+      } else {
+        arrivalField.value = "";
+      }
+    }
+
+    if (typeSelect) {
+      typeSelect.value = entry.shipmentId ? "blood-shipment" : entry.type;
+    }
+
+    if (notesField) {
+      if (entry.shipmentId) {
+        const baseNotes =
+          entry.notes ??
+          entry.description?.replace(/ - (Departs|Arrives)$/i, "") ??
+          "";
+        notesField.value = baseNotes;
+      } else {
+        notesField.value = entry.notes ?? entry.description ?? "";
+      }
+    }
+    if (title) title.textContent = "Edit Event";
+    if (submitButton) {
+      submitButton.textContent = "Save Changes";
+      submitButton.onclick = saveCalendarEntry;
+    }
+    if (deleteButton) {
+      deleteButton.style.display = "block";
+    }
+
+    toggleShipmentFields();
+
+    editingCalendarEntryId = entry.id;
+    document.getElementById("calendar-add-event-modal").classList.add("active");
+  }
+}
+
+function closeCalendarEntryModal() {
+  closeCalendarAddEventModal();
+}
+
+function saveCalendarEntry() {
+  let entryIndex = -1;
+  let existingEntry = null;
+
+  if (editingCalendarEntryId) {
+    entryIndex = APP_STATE.manufacturingCalendar.findIndex(
+      (e) => e.id === editingCalendarEntryId,
+    );
+
+    if (entryIndex > -1) {
+      existingEntry = APP_STATE.manufacturingCalendar[entryIndex];
+
+      if (existingEntry.shipmentId) {
+        alert(
+          "Editing linked shipment events is not yet supported. Please delete the existing events and create a new one.",
+        );
+        return;
+      }
+    }
+  }
+
+  const date = document.getElementById("modal-calendar-date").value;
+  const type = document.getElementById("modal-calendar-type").value;
+  const notesField = document.getElementById("modal-calendar-notes");
+  const notes = notesField ? notesField.value.trim() : "";
+  const description = buildCalendarDescription(type, notes);
+
+  if (!date || !type) {
+    showAlert("error", "Please fill in all required fields");
+    return;
+  }
+
+  if (editingCalendarEntryId) {
+    if (entryIndex > -1 && existingEntry) {
+      existingEntry.date = date;
+      existingEntry.type = type;
+      existingEntry.description = description;
+      if (notes) {
+        existingEntry.notes = notes;
+      } else {
+        delete existingEntry.notes;
+      }
+      logActivity("Updated calendar event", description);
+      showAlert("success", "Calendar event updated");
+    }
+  } else {
+    const newEntry = {
+      id: "cal_" + Date.now(),
+      date: date,
+      type: type,
+      description: description,
+    };
+    if (notes) {
+      newEntry.notes = notes;
+    }
+    APP_STATE.manufacturingCalendar.push(newEntry);
+    logActivity("Added calendar event", description);
+    showAlert("success", "Calendar event added");
+  }
+
+  renderCalendar();
+  persistState();
+  closeCalendarEntryModal();
+}
+
+function deleteCalendarEvent() {
+  if (!editingCalendarEntryId) {
+    return;
+  }
+
+  const entry = APP_STATE.manufacturingCalendar.find(
+    (e) => e.id === editingCalendarEntryId,
+  );
+  if (!entry) {
+    return;
+  }
+
+  const confirmed = confirm("Are you sure you want to delete this event?");
+  if (!confirmed) {
+    return;
+  }
+
+  if (entry.shipmentId) {
+    const shipmentId = entry.shipmentId;
+    const relatedEvents = APP_STATE.manufacturingCalendar.filter(
+      (e) => e.shipmentId === shipmentId,
+    );
+
+    APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+      (e) => e.shipmentId !== shipmentId,
+    );
+
+    const summary = relatedEvents
+      .map((e) => `${e.description ?? e.type ?? ""} (${e.date})`)
+      .join(" | ");
+
+    logActivity("Deleted blood shipment", summary || shipmentId);
+    showAlert("success", "Blood shipment deleted");
+  } else {
+    APP_STATE.manufacturingCalendar = APP_STATE.manufacturingCalendar.filter(
+      (e) => e.id !== editingCalendarEntryId,
+    );
+
+    logActivity(
+      "Deleted calendar event",
+      entry.description ?? entry.type ?? "",
+    );
+    showAlert("success", "Calendar event deleted");
+  }
+
+  renderCalendar();
+  persistState();
+  closeCalendarAddEventModal();
+}
+// ===============================
+// Sharing Analysis
+// ===============================
+
+function analyzeSharingOpportunities() {
+  const startDate = document.getElementById("sharing-start-date").value;
+  const endDate = document.getElementById("sharing-end-date").value;
+
+  if (!startDate || !endDate) {
+    showAlert("error", "Please select date range");
+    return;
+  }
+
+  // Find all PT events in range
+  const ptEvents = APP_STATE.manufacturingCalendar.filter((event) => {
+    return (
+      event.eventType === "PT" &&
+      event.date >= startDate &&
+      event.date <= endDate &&
+      event.type === "blood-arrival"
+    );
+  });
+
+  let html = "<h4>Sharing Opportunities Analysis</h4>";
+
+  ptEvents.forEach((event) => {
+    // Calculate sharing window for this event
+    const bleedDate = new Date(event.date);
+
+    // Find the expiration entry for this event
+    const baseDescription = event.description.replace(" - Bleed", "");
+    const expirationEntry = APP_STATE.manufacturingCalendar.find(
+      (e) => e.description === baseDescription + " - Expires",
+    );
+
+    if (expirationEntry) {
+      const expDate = new Date(expirationEntry.date);
+      const oldestBleed = new Date(expDate);
+      oldestBleed.setDate(oldestBleed.getDate() - 77);
+
+      // Find compatible events
+      const compatible = APP_STATE.manufacturingCalendar.filter((other) => {
+        if (other.id === event.id || other.type !== "blood-arrival")
+          return false;
+        const otherDate = new Date(other.date);
+        return otherDate >= oldestBleed && otherDate <= bleedDate;
+      });
+
+      html += `
+                                                            <div class="sharing-window-display">
+                                                                <h5>${baseDescription}</h5>
+                                                                <p>Bleed: ${event.date}, Expires: ${
+                                                                  expirationEntry.date
+                                                                }</p>
+                                                                <p>Can share with: ${
+                                                                  compatible.length
+                                                                } events</p>
+                                                                <ul>
+                                                                    ${compatible
+                                                                      .map(
+                                                                        (c) =>
+                                                                          `<li>${c.description} (${c.date})</li>`,
+                                                                      )
+                                                                      .join("")}
+                                                                </ul>
+                                                            </div>
+                                                        `;
+    }
+  });
+
+  document.getElementById("sharing-analysis-results").innerHTML =
+    html || "<p>No PT events found in range</p>";
+}
+
+// ===============================
+// Reporting Panel
+// ===============================
+
+function initializeReportingPanel() {
+  const typeSelect = document.getElementById("report-type-select");
+  const yearSelect = document.getElementById("report-year-select");
+  if (!typeSelect) {
+    return;
+  }
+
+  const reportTypes = [
+    { value: "annual-cost", label: "Annual Cost Analysis" },
+    { value: "overage-utilization", label: "Overage Utilization Report" },
+    { value: "supplier-performance", label: "Supplier Performance Review" },
+  ];
+
+  typeSelect.innerHTML = reportTypes
+    .map((type) => `<option value="${type.value}">${type.label}</option>`)
+    .join("");
+
+  if (yearSelect) {
+    const yearSet = new Set();
+    const collectYears = (records) => {
+      if (!Array.isArray(records)) return;
+      records.forEach((record) => {
+        let rawYear = record?.year;
+        if (rawYear === undefined || rawYear === null || rawYear === "") {
+          const derivedYear = getYearFromDate(
+            record?.date || record?.timestamp,
+          );
+          if (derivedYear != null) {
+            rawYear = derivedYear;
+          }
+        }
+
+        if (rawYear === undefined || rawYear === null || rawYear === "") return;
+        const trimmed = String(rawYear).trim();
+        if (!trimmed) return;
+        yearSet.add(trimmed);
+      });
+    };
+
+    collectYears(APP_STATE.historicalQuantities);
+    collectYears(APP_STATE.confirmedQuantities);
+    collectYears(APP_STATE.optimizationDecisions);
+
+    const sortedYears = Array.from(yearSet).sort((a, b) => {
+      const numA = Number(a);
+      const numB = Number(b);
+      const aIsNum = Number.isFinite(numA);
+      const bIsNum = Number.isFinite(numB);
+      if (aIsNum && bIsNum) {
+        return numB - numA;
+      }
+      if (aIsNum) return -1;
+      if (bIsNum) return 1;
+      return String(b).localeCompare(String(a));
+    });
+
+    yearSelect.innerHTML = sortedYears.length
+      ? sortedYears
+          .map((year) => `<option value="${year}">${year}</option>`)
+          .join("")
+      : '<option value="">No years available</option>';
+  }
+
+  if (!typeSelect.dataset.reportingInitialized) {
+    typeSelect.addEventListener("change", handleReportTypeChange);
+    const generateBtn = document.getElementById("generate-report-btn");
+    if (generateBtn) {
+      generateBtn.addEventListener("click", generateReport);
+    }
+    typeSelect.dataset.reportingInitialized = "true";
+  }
+
+  handleReportTypeChange();
+}
+
+function handleReportTypeChange() {
+  const typeSelect = document.getElementById("report-type-select");
+  const yearFilter = document.getElementById("report-year-filter");
+  const dateRangeFilter = document.getElementById("report-date-range-filter");
+
+  if (!typeSelect || !yearFilter || !dateRangeFilter) {
+    return;
+  }
+
+  if (
+    typeSelect.value === "annual-cost" ||
+    typeSelect.value === "overage-utilization"
+  ) {
+    yearFilter.style.display = "";
+    dateRangeFilter.style.display = "none";
+  } else {
+    yearFilter.style.display = "none";
+    dateRangeFilter.style.display = "";
+  }
+}
+
+function generateReport(event) {
+  event?.preventDefault();
+
+  const typeSelect = document.getElementById("report-type-select");
+  const yearSelect = document.getElementById("report-year-select");
+  const outputCard = document.getElementById("report-output-card");
+  const outputTitle = document.getElementById("report-output-title");
+  const outputContent = document.getElementById("report-output-content");
+
+  if (!typeSelect || !outputCard || !outputTitle || !outputContent) {
+    return;
+  }
+
+  if (!generateReport.baseTemplate && outputContent.innerHTML != null) {
+    generateReport.baseTemplate = outputContent.innerHTML;
+  }
+
+  const reportLookup = {
+    "annual-cost": "Annual Cost Analysis",
+    "overage-utilization": "Overage Utilization Report",
+    "supplier-performance": "Supplier Performance Review",
+  };
+
+  const selectedType = typeSelect.value;
+  outputTitle.textContent = reportLookup[selectedType] || "Report Results";
+
+  if (selectedType === "annual-cost") {
+    const rawYear = yearSelect?.value;
+    const selectedYear = rawYear ? Number(rawYear) : NaN;
+    if (!rawYear || !Number.isFinite(selectedYear)) {
+      showAlert(
+        "warning",
+        "Please select a year to generate the annual cost analysis.",
+      );
+      return;
+    }
+
+    if (generateReport.baseTemplate) {
+      outputContent.innerHTML = generateReport.baseTemplate;
+    }
+    const reportData = getAnnualCostData(selectedYear);
+    renderAnnualCostReport(reportData, selectedYear);
+    outputCard.style.display = "block";
+    return;
+  }
+
+  if (selectedType === "overage-utilization") {
+    const rawYear = yearSelect?.value;
+    const selectedYear = rawYear ? Number(rawYear) : NaN;
+    if (!rawYear || !Number.isFinite(selectedYear)) {
+      showAlert(
+        "warning",
+        "Please select a year to generate the overage utilization report.",
+      );
+      return;
+    }
+
+    const reportData = getOverageUtilizationData(selectedYear);
+    renderOverageUtilizationReport(reportData, selectedYear);
+    outputCard.style.display = "block";
+    return;
+  }
+
+  outputContent.innerHTML =
+    '<p class="text-muted">The selected report type has not been implemented yet.</p>';
+  outputCard.style.display = "block";
+}
+
+function getAnnualCostData(year) {
+  if (!Number.isFinite(year)) {
+    return [];
+  }
+
+  const allCosts = [];
+  const targetYear = Number(year);
+
+  const collectQuantitiesForYear = (collection) => {
+    if (!Array.isArray(collection)) return [];
+    return collection.filter((entry) => {
+      const entryYear =
+        entry?.year != null ? Number(entry.year) : getYearFromDate(entry?.date);
+      return entryYear === targetYear;
+    });
+  };
+
+  const activeYearQuantities = collectQuantitiesForYear(APP_STATE.confirmedQuantities);
+  const historicalYearQuantities = collectQuantitiesForYear(
+    APP_STATE.historicalQuantities,
+  );
+  const totalUnits = [
+    ...activeYearQuantities,
+    ...historicalYearQuantities,
+  ].reduce((sum, entry) => {
+    const quantity = Number(entry?.quantity);
+    return Number.isFinite(quantity) ? sum + quantity : sum;
+  }, 0);
+
+  const defaultUnitPrice = 500;
+  const bloodSupplier = (APP_STATE.bloodSuppliers || [])[0];
+  const supplierUnitPrice = Number(bloodSupplier?.pricing?.baseUnit);
+  const costPerUnit =
+    Number.isFinite(supplierUnitPrice) && supplierUnitPrice > 0
+      ? supplierUnitPrice
+      : defaultUnitPrice;
+  const totalBloodCost = totalUnits * costPerUnit;
+
+  allCosts.push({
+    category: "Blood Purchase",
+    item: "Bulk RBC Units",
+    date: `${targetYear}-12-31`,
+    cost: totalBloodCost,
+  });
+
+  (APP_STATE.antibodies || []).forEach((specificity) => {
+    const lots = Array.isArray(specificity?.inventory)
+      ? specificity.inventory
+      : [];
+    lots.forEach((lot) => {
+      const lotYear = getYearFromDate(lot?.qualificationDate);
+      if (lotYear !== targetYear) return;
+
+      const purchasePrice = Number(lot?.purchasePrice);
+      if (!Number.isFinite(purchasePrice)) return;
+
+      const specificityName = specificity?.specificity || "Unnamed Specificity";
+      const lotNumber = lot?.lotNumber || "N/A";
+
+      allCosts.push({
+        category: "Antibody Purchase",
+        item: `${specificityName} (Lot: ${lotNumber})`,
+        date: lot?.qualificationDate || `${targetYear}-01-01`,
+        cost: purchasePrice,
+      });
+    });
+  });
+
+  (APP_STATE.vendors || []).forEach((vendor) => {
+    const purchases = Array.isArray(vendor?.purchases) ? vendor.purchases : [];
+    purchases.forEach((purchase) => {
+      const purchaseDate = purchase?.purchaseDate || purchase?.date || null;
+      const purchaseYear = getYearFromDate(purchaseDate);
+      if (purchaseYear !== targetYear) return;
+
+      const purchaseCost = Number(purchase?.cost);
+      if (!Number.isFinite(purchaseCost)) return;
+
+      const description = purchase?.description || "Purchase";
+      const vendorName = vendor?.name || "Vendor";
+
+      allCosts.push({
+        category: "Other Raw Material",
+        item: `${description} (${vendorName})`,
+        date: purchaseDate || `${targetYear}-01-01`,
+        cost: purchaseCost,
+      });
+    });
+  });
+
+  return allCosts;
+}
+
+function getOverageUtilizationData(year) {
+  if (!Number.isFinite(year)) {
+    return { accepted: [], missed: [] };
+  }
+
+  const targetYear = Number(year);
+  const decisions = Array.isArray(APP_STATE.optimizationDecisions)
+    ? APP_STATE.optimizationDecisions
+    : [];
+
+  const decisionsForYear = decisions.filter((entry) => {
+    if (!entry) return false;
+    let entryYear = entry.year;
+    if (entryYear === undefined || entryYear === null || entryYear === "") {
+      entryYear = getYearFromDate(entry.date || entry.timestamp);
+    }
+
+    const numericYear = Number(entryYear);
+    return Number.isFinite(numericYear) && numericYear === targetYear;
+  });
+
+  const acceptedDecisions = [];
+  const missedOpportunities = [];
+
+  decisionsForYear.forEach((decision) => {
+    const normalizedOutcome = (
+      decision?.outcome ||
+      decision?.decision ||
+      decision?.status ||
+      ""
+    )
+      .toString()
+      .toLowerCase();
+
+    const isAccepted =
+      decision?.accepted === true ||
+      normalizedOutcome === "accepted" ||
+      normalizedOutcome === "realized" ||
+      normalizedOutcome === "utilized";
+
+    const isMissed =
+      decision?.missed === true ||
+      decision?.manualEntryMade === true ||
+      normalizedOutcome === "missed" ||
+      normalizedOutcome === "missed opportunity" ||
+      normalizedOutcome === "allocation skipped" ||
+      normalizedOutcome === "manual entry";
+
+    if (isAccepted) {
+      acceptedDecisions.push(decision);
+      return;
+    }
+
+    if (isMissed) {
+      missedOpportunities.push(decision);
+      return;
+    }
+
+    const estimatedSavings = extractNumericValue(decision?.estimatedSavings);
+    const potentialSavings = extractNumericValue(decision?.potentialSavings);
+
+    if (estimatedSavings > 0) {
+      acceptedDecisions.push(decision);
+    } else if (potentialSavings > 0) {
+      missedOpportunities.push(decision);
+    } else {
+      missedOpportunities.push(decision);
+    }
+  });
+
+  return { accepted: acceptedDecisions, missed: missedOpportunities };
+}
+
+function renderOverageUtilizationReport(reportData, year) {
+  const outputContent = document.getElementById("report-output-content");
+  if (!outputContent) {
+    return;
+  }
+
+  const accepted = Array.isArray(reportData?.accepted)
+    ? reportData.accepted
+    : [];
+  const missed = Array.isArray(reportData?.missed) ? reportData.missed : [];
+
+  const realizedSavings = accepted.reduce((sum, decision) => {
+    return sum + extractNumericValue(decision?.estimatedSavings);
+  }, 0);
+
+  const potentialSavings = missed.reduce((sum, decision) => {
+    return sum + extractNumericValue(decision?.potentialSavings);
+  }, 0);
+
+  const decisionCount = accepted.length + missed.length;
+  const optimizationRate =
+    decisionCount > 0 ? (accepted.length / decisionCount) * 100 : 0;
+
+  const percentFormatter = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+
+  const summaryHtml = `
+          <div class="metrics-grid" style="grid-template-columns: repeat(3, 1fr); margin-bottom: 2rem;">
+            <div class="metric-card">
+              <div class="metric-label">Realized Savings</div>
+              <div class="metric-value">${formatCurrency(realizedSavings)}</div>
+            </div>
+            <div class="metric-card">
+              <div class="metric-label">Potential Savings Missed</div>
+              <div class="metric-value">${formatCurrency(potentialSavings)}</div>
+            </div>
+            <div class="metric-card">
+              <div class="metric-label">Optimization Adoption Rate</div>
+              <div class="metric-value">${percentFormatter.format(optimizationRate)}%</div>
+            </div>
+          </div>
+        `;
+
+  const tablesHtml = `
+          <div class="mt-4">
+            <h4>Realized Savings</h4>
+            <div class="table-container mt-2">
+              <table id="realized-savings-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Recipient Event</th>
+                    <th>Source</th>
+                    <th>Savings</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <div class="mt-4">
+            <h4>Missed Opportunities</h4>
+            <div class="table-container mt-2">
+              <table id="missed-opportunities-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Recipient Event</th>
+                    <th>Manual Entry Made</th>
+                    <th>Missed Overage Source</th>
+                    <th>Potential Savings Lost</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        `;
+
+  outputContent.innerHTML = summaryHtml + tablesHtml;
+
+  const formatDateLabel = (value) => {
+    if (!value) {
+      return "";
+    }
+
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+    }
+
+    return String(value);
+  };
+
+  const getEventLabel = (decision) => {
+    const customer =
+      decision?.customer || decision?.recipient || decision?.recipientCustomer;
+    const eventName =
+      decision?.event || decision?.recipientEvent || decision?.eventName;
+    if (customer && eventName) {
+      return `${customer} ${eventName}`;
+    }
+    return eventName || customer || "";
+  };
+
+  const getSourceLabel = (decision) => {
+    return (
+      decision?.source ||
+      decision?.sourceType ||
+      decision?.sourceKey ||
+      decision?.overageSource ||
+      ""
+    );
+  };
+
+  const realizedBody = outputContent.querySelector(
+    "#realized-savings-table tbody",
+  );
+  const missedBody = outputContent.querySelector(
+    "#missed-opportunities-table tbody",
+  );
+
+  if (realizedBody) {
+    realizedBody.innerHTML =
+      accepted.length > 0
+        ? accepted
+            .map((decision) => {
+              const savings = formatCurrency(
+                extractNumericValue(decision?.estimatedSavings),
+              );
+              return `
+                      <tr>
+                        <td>${formatDateLabel(decision?.date || decision?.timestamp)}</td>
+                        <td>${getEventLabel(decision)}</td>
+                        <td>${getSourceLabel(decision)}</td>
+                        <td>${savings}</td>
+                      </tr>
+                    `;
+            })
+            .join("")
+        : `<tr><td colspan="4" class="text-muted">No realized savings recorded for ${year}.</td></tr>`;
+  }
+
+  if (missedBody) {
+    missedBody.innerHTML =
+      missed.length > 0
+        ? missed
+            .map((decision) => {
+              const manualEntry =
+                decision?.manualEntryMade === true ||
+                (decision?.decision || "").toString().toLowerCase() ===
+                  "manual entry"
+                  ? "Yes"
+                  : "No";
+              const potential = formatCurrency(
+                extractNumericValue(decision?.potentialSavings),
+              );
+              return `
+                      <tr>
+                        <td>${formatDateLabel(decision?.date || decision?.timestamp)}</td>
+                        <td>${getEventLabel(decision)}</td>
+                        <td>${manualEntry}</td>
+                        <td>${getSourceLabel(decision)}</td>
+                        <td>${potential}</td>
+                      </tr>
+                    `;
+            })
+            .join("")
+        : `<tr><td colspan="5" class="text-muted">No missed opportunities recorded for ${year}.</td></tr>`;
+  }
+}
+
+function renderAnnualCostReport(data, year) {
+  const summaryContainer = document.getElementById("report-summary-cards");
+  const tableBody = document.querySelector("#report-details-table tbody");
+  const chartTitle = document.getElementById("chart-title");
+
+  if (!summaryContainer || !tableBody) {
+    return;
+  }
+
+  const totals = {
+    "Blood Purchase": 0,
+    "Antibody Purchase": 0,
+    "Other Raw Material": 0,
+  };
+
+  const sanitizedData = Array.isArray(data) ? data : [];
+
+  sanitizedData.forEach((entry) => {
+    const numericCost = Number(entry?.cost);
+    if (!Number.isFinite(numericCost)) {
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(totals, entry.category)) {
+      totals[entry.category] += numericCost;
+    }
+  });
+
+  const cardConfig = [
+    { label: "Blood Purchases", key: "Blood Purchase" },
+    { label: "Antibody Purchases", key: "Antibody Purchase" },
+    { label: "Other Raw Materials", key: "Other Raw Material" },
+  ];
+
+  summaryContainer.innerHTML = cardConfig
+    .map(
+      ({ label, key }) => `
+              <div class="metric-card">
+                <div class="metric-label">${label}</div>
+                <div class="metric-value">${formatCurrency(totals[key] || 0)}</div>
+              </div>
+            `,
+    )
+    .join("");
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  const sortedData = [...sanitizedData].sort((a, b) => {
+    const aDate = new Date(a?.date || `${year}-01-01`).getTime();
+    const bDate = new Date(b?.date || `${year}-01-01`).getTime();
+    return aDate - bDate;
+  });
+
+  tableBody.innerHTML = sortedData
+    .map((entry) => {
+      const numericCost = Number(entry?.cost);
+      const formattedCost = Number.isFinite(numericCost)
+        ? currencyFormatter.format(numericCost)
+        : (entry?.cost ?? "");
+      const dateLabel = entry?.date || "";
+
+      return `
+              <tr>
+                <td>${entry?.category || ""}</td>
+                <td>${entry?.item || ""}</td>
+                <td>${dateLabel}</td>
+                <td>${formattedCost}</td>
+              </tr>
+            `;
+    })
+    .join("");
+
+  if (chartTitle) {
+    chartTitle.textContent = `Annual Spend Comparison (${year})`;
+  }
+
+  window.currentReportData = { data: sortedData, year };
+  renderSpendChart("annual");
+}
+
+function renderSpendChart(viewType) {
+  const chart = document.getElementById("spend-chart");
+  const toggleButtons = document.querySelectorAll("#chart-toggle-buttons .btn");
+  const chartTitle = document.getElementById("chart-title");
+
+  if (!chart) {
+    return;
+  }
+
+  const reportState = window.currentReportData;
+  if (
+    !reportState ||
+    !Array.isArray(reportState.data) ||
+    !Number.isFinite(reportState.year)
+  ) {
+    chart.innerHTML =
+      '<p class="text-muted">Run the annual cost report to view spend trends.</p>';
+    return;
+  }
+
+  const { data, year } = reportState;
+
+  const aggregateAnnual = () => {
+    const years = [];
+    for (let offset = 4; offset >= 0; offset--) {
+      years.push(year - offset);
+    }
+
+    return years.map((yr) => {
+      const yearData = yr === year ? data : getAnnualCostData(yr);
+      const total = yearData.reduce((sum, entry) => {
+        const numeric = Number(entry?.cost);
+        return Number.isFinite(numeric) ? sum + numeric : sum;
+      }, 0);
+      return { label: String(yr), value: total };
+    });
+  };
+
+  const getMonthIndex = (value) => {
+    if (!value) return null;
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.getMonth();
+    }
+
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value));
+    if (match) {
+      return Number(match[2]) - 1;
+    }
+
+    return null;
+  };
+
+  const aggregateQuarterly = () => {
+    const quarters = [
+      { label: "Q1", value: 0 },
+      { label: "Q2", value: 0 },
+      { label: "Q3", value: 0 },
+      { label: "Q4", value: 0 },
+    ];
+
+    data.forEach((entry) => {
+      const monthIndex = getMonthIndex(entry?.date);
+      if (monthIndex == null) return;
+
+      const numeric = Number(entry?.cost);
+      if (!Number.isFinite(numeric)) return;
+
+      const quarterIndex = Math.floor(monthIndex / 3);
+      quarters[quarterIndex].value += numeric;
+    });
+
+    return quarters;
+  };
+
+  const aggregateMonthly = () => {
+    const monthNames = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ];
+    const months = monthNames.map((label) => ({ label, value: 0 }));
+
+    data.forEach((entry) => {
+      const monthIndex = getMonthIndex(entry?.date);
+      if (monthIndex == null) return;
+
+      const numeric = Number(entry?.cost);
+      if (!Number.isFinite(numeric)) return;
+
+      months[monthIndex].value += numeric;
+    });
+
+    return months;
+  };
+
+  let aggregatedData;
+  switch (viewType) {
+    case "quarterly":
+      aggregatedData = aggregateQuarterly();
+      if (chartTitle) {
+        chartTitle.textContent = `Quarterly Spend Distribution (${year})`;
+      }
+      break;
+    case "monthly":
+      aggregatedData = aggregateMonthly();
+      if (chartTitle) {
+        chartTitle.textContent = `Monthly Spend Distribution (${year})`;
+      }
+      break;
+    case "annual":
+    default:
+      aggregatedData = aggregateAnnual();
+      if (chartTitle) {
+        chartTitle.textContent = `Annual Spend Comparison (${year})`;
+      }
+      break;
+  }
+
+  if (!Array.isArray(aggregatedData) || aggregatedData.length === 0) {
+    chart.innerHTML =
+      '<p class="text-muted">No data available for the selected view.</p>';
+    return;
+  }
+
+  const maxValue = aggregatedData.reduce((max, entry) => {
+    return entry.value > max ? entry.value : max;
+  }, 0);
+
+  const valueFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+  chart.innerHTML = "";
+
+  aggregatedData.forEach((entry) => {
+    const column = document.createElement("div");
+    column.style.flex = "1";
+    column.style.minWidth = "40px";
+    column.style.display = "flex";
+    column.style.flexDirection = "column";
+    column.style.alignItems = "center";
+    column.style.justifyContent = "flex-end";
+
+    const valueLabel = document.createElement("div");
+    valueLabel.textContent = valueFormatter.format(entry.value || 0);
+    valueLabel.style.fontSize = "0.75rem";
+    valueLabel.style.marginBottom = "0.25rem";
+
+    const bar = document.createElement("div");
+    const heightPercent = maxValue > 0 ? (entry.value / maxValue) * 100 : 0;
+    if (heightPercent <= 0) {
+      bar.style.height = "4px";
+    } else {
+      bar.style.height = `${heightPercent}%`;
+    }
+    bar.style.width = "100%";
+    bar.style.maxWidth = "60px";
+    bar.style.background = "var(--hemo-blue)";
+    bar.style.borderRadius = "6px 6px 0 0";
+    bar.style.minHeight = "4px";
+
+    const label = document.createElement("div");
+    label.textContent = entry.label;
+    label.style.fontSize = "0.75rem";
+    label.style.marginTop = "0.5rem";
+
+    column.appendChild(valueLabel);
+    column.appendChild(bar);
+    column.appendChild(label);
+    chart.appendChild(column);
+  });
+
+  toggleButtons.forEach((button) => {
+    if (!button) return;
+    if (button.dataset.view === viewType) {
+      button.classList.add("active");
+    } else {
+      button.classList.remove("active");
+    }
+  });
+}
+
+// ===============================
+// CSV Import Functions
+// ===============================
+
+async function handleSampleDefinitionsCsvImport() {
+  const input = document.getElementById("sample-definitions-import-file");
+  const feedback = document.getElementById(
+    "sample-definitions-import-feedback",
+  );
+  const file = input?.files?.[0];
+  if (!file) {
+    alert("Select sample_definitions.csv first.");
+    return;
+  }
+
+  try {
+    const csv = await file.text();
+    const lines = csv.split(/\r?\n/).filter((line) => line.trim());
+    if (lines.length <= 1) {
+      if (feedback)
+        feedback.textContent = "No sample definitions found in file.";
+      return;
+    }
+
+    const headers = lines[0].split(",").map((h) => h.trim());
+    const existingSampleKeys = new Set(
+      (APP_STATE.sampleDefinitions || [])
+        .map((sample) => {
+          if (sample?.sample_type_id == null) return null;
+          const key = String(sample.sample_type_id).trim();
+          return key || null;
+        })
+        .filter((key) => key),
+    );
+    let imported = 0;
+    let skipped = 0;
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split(",");
+      const sample = {};
+
+      headers.forEach((header, index) => {
+        sample[header] = values[index]?.trim();
+      });
+
+      const key =
+        sample.sample_type_id != null
+          ? String(sample.sample_type_id).trim()
+          : "";
+
+      if (key && existingSampleKeys.has(key)) {
+        skipped++;
+        continue;
+      }
+
+      APP_STATE.sampleDefinitions.push(sample);
+      if (key) {
+        existingSampleKeys.add(key);
+      }
+      imported++;
+    }
+
+    updateSampleTable();
+    logActivity("Imported sample definitions", `${imported} samples`);
+    showAlert("success", `Loaded ${imported} sample definitions`);
+    persistState();
+    updateDashboard();
+    if (feedback) {
+      feedback.textContent = `Import complete. Loaded ${imported} sample definitions, skipped ${skipped} duplicates.`;
+    }
+  } catch (error) {
+    console.error("Sample definitions import error:", error);
+    if (feedback) feedback.textContent = "Import failed.";
+  } finally {
+    if (input) input.value = "";
+  }
+}
+
+async function handleHistoricalSpecificationsCsvImport() {
+  const input = document.getElementById(
+    "historical-specifications-import-file",
+  );
+  const feedback = document.getElementById(
+    "historical-specifications-import-feedback",
+  );
+  const files = input?.files;
+
+  if (!files || files.length === 0) {
+    alert("Select specification CSV files first.");
+    return;
+  }
+
+  let totalSpecs = 0;
+  let totalSkipped = 0;
+  const buildSpecKey = (spec) => {
+    const customer = String(spec?.customer ?? "").trim();
+    const event = String(spec?.event ?? "").trim();
+    const year = String(spec?.year ?? "").trim();
+    const sampleId = String(spec?.sample_id ?? "").trim();
+    return `${customer}|${event}|${year}|${sampleId}`;
+  };
+  const existingSpecKeys = new Set(
+    (APP_STATE.customerSpecs || []).map((spec) => buildSpecKey(spec)),
+  );
+
+  for (const file of Array.from(files)) {
+    try {
+      const csv = await file.text();
+      const lines = csv.split(/\r?\n/).filter((line) => line.trim());
+      if (lines.length <= 1) continue;
+
+      const headers = lines[0].split(",").map((h) => h.trim());
+      let imported = 0;
+      let skipped = 0;
+
+      for (let i = 1; i < lines.length; i++) {
+        const values = lines[i].split(",");
+        const spec = {};
+
+        headers.forEach((header, index) => {
+          spec[header] = values[index]?.trim();
+        });
+
+        const key = buildSpecKey(spec);
+
+        if (existingSpecKeys.has(key)) {
+          skipped++;
+          continue;
+        }
+
+        APP_STATE.customerSpecs.push(spec);
+        existingSpecKeys.add(key);
+        imported++;
+      }
+
+      totalSpecs += imported;
+      totalSkipped += skipped;
+      updateAllTables();
+      populateSpecFilters();
+      logActivity("Imported specifications", `${imported} from ${file.name}`);
+      showAlert(
+        "success",
+        `Loaded ${imported} specifications from ${file.name}${skipped ? `, skipped ${skipped} duplicates` : ""}`,
+      );
+      persistState();
+      updateDashboard();
+      populateCustomerDropdowns();
+    } catch (error) {
+      console.error("Specification import error:", error);
+    }
+  }
+
+  if (feedback) {
+    feedback.textContent =
+      totalSpecs === 0 && totalSkipped === 0
+        ? "No specifications imported."
+        : `Import complete. Loaded ${totalSpecs} specifications, skipped ${totalSkipped} duplicates.`;
+  }
+
+  if (input) input.value = "";
+}
+
+async function handleScheduleCsvImport() {
+  const input = document.getElementById("schedule-import-file");
+  const feedback = document.getElementById("schedule-import-feedback");
+  const file = input?.files?.[0];
+  if (!file) {
+    alert("Select schedule.csv first.");
+    return;
+  }
+
+  try {
+    const csv = await file.text();
+    const lines = csv.split(/\r?\n/);
+    if (!lines.length) {
+      if (feedback) feedback.textContent = "Schedule file was empty.";
+      return;
+    }
+
+    const headers = lines[0].split(",").map((h) => h.trim());
+    let imported = 0;
+    let skipped = 0;
+
+    const scheduleMap = new Map(
+      (APP_STATE.schedule || []).map((entry) => {
+        const key = `${entry.customer || ""}|${entry.event || ""}|${entry.year ?? ""}`;
+        return [key, { ...entry }];
+      }),
+    );
+
+    for (let i = 1; i < lines.length; i++) {
+      if (!lines[i] || !lines[i].trim()) continue;
+
+      const values = lines[i].split(",").map((v) => v.trim());
+      const row = {};
+
+      headers.forEach((header, index) => {
+        row[header] = values[index] || "";
+      });
+
+      const customer = row.customer || "";
+      const event = row.event || "";
+      const shipDate = row.ship_date || "";
+      const bleedDate = row.bleed_date || "";
+      const expirationDate = row.expiration_date || "";
+      const derivedYearRaw = row.year || "";
+      let derivedYear = Number(derivedYearRaw);
+      if (!Number.isFinite(derivedYear)) {
+        const shipYear = parseDate(shipDate)?.getFullYear();
+        const expireYear = parseDate(expirationDate)?.getFullYear();
+        derivedYear = Number.isFinite(shipYear)
+          ? shipYear
+          : Number.isFinite(expireYear)
+          ? expireYear
+          : null;
+      }
+      const scheduleKey = `${customer}|${event}|${derivedYear ?? ""}`;
+      const existingEntry = scheduleMap.get(scheduleKey);
+      const scheduleEntry = {
+        id:
+          existingEntry?.id ||
+          `schedule_${customer || "unknown"}_${event || "event"}_${derivedYear ?? "na"}`,
+        customer,
+        event,
+        type: row.type || "",
+        bleedDate,
+        shipDate,
+        expirationDate,
+        year: Number.isFinite(derivedYear) ? derivedYear : null,
+      };
+      scheduleMap.set(scheduleKey, scheduleEntry);
+
+      if (row.bleed_date) {
+        const bleedId = `sched_bleed_${row.customer}_${row.event}_${Date.now()}`;
+        const existingBleed = APP_STATE.manufacturingCalendar.find(
+          (e) =>
+            e.date === row.bleed_date &&
+            e.description.includes(row.customer) &&
+            e.description.includes("Bleed"),
+        );
+
+        if (!existingBleed) {
+          APP_STATE.manufacturingCalendar.push({
+            id: bleedId,
+            date: row.bleed_date,
+            type: "blood-arrival",
+            description: `${row.customer} ${row.event} - Bleed`,
+            imported: true,
+            eventType: row.type,
+          });
+          imported++;
+        } else {
+          skipped++;
+        }
+      }
+
+      if (row.ship_date) {
+        const shipId = `sched_ship_${row.customer}_${row.event}_${Date.now()}`;
+        const existingShip = APP_STATE.manufacturingCalendar.find(
+          (e) =>
+            e.date === row.ship_date &&
+            e.description.includes(row.customer) &&
+            e.description.includes("Ship"),
+        );
+
+        if (!existingShip) {
+          APP_STATE.manufacturingCalendar.push({
+            id: shipId,
+            date: row.ship_date,
+            type: "shipment",
+            description: `${row.customer} ${row.event} - Ship`,
+            imported: true,
+            eventType: row.type,
+          });
+          imported++;
+        } else {
+          skipped++;
+        }
+      }
+
+      if (row.expiration_date) {
+        const expId = `sched_exp_${row.customer}_${row.event}_${Date.now()}`;
+        APP_STATE.manufacturingCalendar.push({
+          id: expId,
+          date: row.expiration_date,
+          type: "reference",
+          description: `${row.customer} ${row.event} - Expires`,
+          imported: true,
+          hidden: true,
+          eventType: row.type,
+        });
+      }
+    }
+
+    APP_STATE.schedule = Array.from(scheduleMap.values());
+
+    renderCalendar();
+    logActivity("Imported schedule", `${file.name}: ${imported} entries`);
+    persistState();
+    showAlert("success", "Schedule imported successfully");
+    if (feedback) {
+      feedback.textContent = `Import complete. ${imported} entries added, ${skipped} skipped.`;
+    }
+  } catch (error) {
+    console.error("Schedule import error:", error);
+    if (feedback) feedback.textContent = "Import failed.";
+  } finally {
+    if (input) input.value = "";
+  }
+}
+
+async function handleOrderQuantitiesCsvImport() {
+  const input = document.getElementById("order-quantities-import-file");
+  const feedback = document.getElementById("order-quantities-import-feedback");
+  const file = input?.files?.[0];
+  if (!file) {
+    alert("Select order_quantities_confirmed.csv first.");
+    return;
+  }
+
+  try {
+    const csv = await file.text();
+    const lines = csv.split(/\r?\n/).filter((line) => line.trim());
+    if (lines.length <= 1) {
+      if (feedback) feedback.textContent = "No quantity records found in file.";
+      return;
+    }
+
+    const headers = lines[0].split(",").map((h) => h.trim());
+    const buildQuantityKey = (record) => {
+      const customer = String(record?.customer ?? "").trim();
+      const event = String(record?.event ?? "").trim();
+      const year = String(record?.year ?? "").trim();
+      const sampleId = String(record?.sample_id ?? "").trim();
+      return `${customer}|${event}|${year}|${sampleId}`;
+    };
+    const existingQuantityKeys = new Set(
+      (APP_STATE.confirmedQuantities || []).map((record) => buildQuantityKey(record)),
+    );
+    let imported = 0;
+    let skipped = 0;
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split(",");
+      const quantity = {};
+
+      headers.forEach((header, index) => {
+        quantity[header] = values[index]?.trim();
+      });
+
+      const key = buildQuantityKey(quantity);
+
+      if (existingQuantityKeys.has(key)) {
+        skipped++;
+        continue;
+      }
+
+      APP_STATE.confirmedQuantities.push({
+        ...quantity,
+        id: "qty_" + Date.now() + "_" + i,
+        quantity: parseInt(quantity.quantity) || 0,
+      });
+      existingQuantityKeys.add(key);
+      imported++;
+    }
+
+    updateQuantitiesTable();
+    populateQuantityFilters();
+    populateQuantityMigrationOptions();
+    updateDashboard();
+    logActivity("Imported quantities", `${imported} records`);
+    showAlert(
+      "success",
+      `Loaded ${imported} quantity records${skipped ? `, skipped ${skipped} duplicates` : ""}`,
+    );
+    persistState();
+    if (feedback)
+      feedback.textContent = `Import complete. Loaded ${imported} quantity records, skipped ${skipped} duplicates.`;
+  } catch (error) {
+    console.error("Order quantities import error:", error);
+    if (feedback) feedback.textContent = "Import failed.";
+  } finally {
+    if (input) input.value = "";
+  }
+}
+
+function updateQuantitiesTable() {
+  const tbody = document.querySelector("#quantities-table tbody");
+
+  const allQuantities = Array.isArray(APP_STATE.confirmedQuantities)
+    ? APP_STATE.confirmedQuantities
+    : [];
+
+  // Apply filters
+  let quantities = allQuantities.slice();
+
+  if (APP_STATE.quantityFilters.customer) {
+    quantities = quantities.filter(
+      (q) => q.customer === APP_STATE.quantityFilters.customer,
+    );
+  }
+  if (APP_STATE.quantityFilters.event) {
+    quantities = quantities.filter(
+      (q) => q.event === APP_STATE.quantityFilters.event,
+    );
+  }
+  if (APP_STATE.quantityFilters.year) {
+    quantities = quantities.filter(
+      (q) => q.year == APP_STATE.quantityFilters.year,
+    );
+  }
+  if (APP_STATE.quantityFilters.sampleId) {
+    quantities = quantities.filter(
+      (q) =>
+        q.sample_id &&
+        q.sample_id
+          .toLowerCase()
+          .includes(APP_STATE.quantityFilters.sampleId.toLowerCase()),
+    );
+  }
+  if (APP_STATE.quantityFilters.poNumber) {
+    quantities = quantities.filter(
+      (q) =>
+        q.po_number &&
+        q.po_number
+          .toLowerCase()
+          .includes(APP_STATE.quantityFilters.poNumber.toLowerCase()),
+    );
+  }
+
+  APP_STATE.quantityFilters.filteredQuantities = quantities;
+
+  // Update count
+  const countEl = document.getElementById("qty-filter-count");
+  if (countEl) {
+    if (quantities.length === allQuantities.length) {
+      countEl.textContent = `Showing all ${quantities.length} quantities`;
+    } else {
+      countEl.textContent = `Showing ${quantities.length} of ${allQuantities.length} quantities (filtered)`;
+    }
+  }
+
+  if (quantities.length === 0) {
+    tbody.innerHTML = `
+                  <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray);">
+                          ${
+                            allQuantities.length === 0
+                              ? "No quantities loaded"
+                              : "No quantities match filters"
+                          }
+                      </td>
+                  </tr>
+                `;
+    updateTablePaginationUI("orderQuantities", paginateData([], "orderQuantities"));
+    return;
+  }
+
+  const pagination = paginateData(quantities, "orderQuantities");
+  tbody.innerHTML = pagination.pageItems
+    .map(
+      (qty) => `
+                    <tr>
+                        <td>${qty.customer}</td>
+                        <td>${qty.event}</td>
+                        <td>${qty.year}</td>
+                        <td>${qty.sample_id || "All"}</td>
+                        <td><strong>${qty.quantity}</strong></td>
+                        <td>${qty.po_number || "-"}</td>
+                        <td><span class="status-tag ${
+                          qty.status === "Confirmed" ? "available" : "limited"
+                        }">${qty.status || "Pending"}</span></td>
+                        <td>
+                            <button class="btn btn-outline btn-sm" onclick="editQuantity('${
+                              qty.id
+                            }')">Edit</button>
+                            <button class="btn btn-danger btn-sm" onclick="deleteQuantity('${
+                              qty.id
+                            }')">Delete</button>
+                        </td>
+                    </tr>
+                  `,
+    )
+    .join("");
+  updateTablePaginationUI("orderQuantities", pagination);
+}
+
+function populateQuantityFilters() {
+  const quantities = Array.isArray(APP_STATE.confirmedQuantities)
+    ? APP_STATE.confirmedQuantities
+    : [];
+  const customerSelect = document.getElementById("qty-filter-customer");
+  if (customerSelect) {
+    const previousValue = customerSelect.value;
+    const storedValue = APP_STATE.quantityFilters.customer || "";
+    const desiredValue = previousValue || storedValue;
+    const customers = Array.from(
+      new Set(quantities.map((q) => q.customer).filter((customer) => customer)),
+    ).sort((a, b) => a.localeCompare(b));
+    customerSelect.innerHTML =
+      '<option value="">All Customers</option>' +
+      customers.map((customer) => `<option value="${customer}">${customer}</option>`).join("");
+    if (
+      desiredValue &&
+      customers.some((customer) => String(customer) === String(desiredValue))
+    ) {
+      customerSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      customerSelect.value = "";
+    }
+  }
+  const selectedCustomer = customerSelect ? customerSelect.value : "";
+  updateQuantityYearEventOptions(selectedCustomer);
+}
+
+
+function updateQuantityYearEventOptions(customer) {
+  const quantities = Array.isArray(APP_STATE.confirmedQuantities)
+    ? APP_STATE.confirmedQuantities
+    : [];
+  const effectiveCustomer =
+    customer !== undefined && customer !== null
+      ? customer
+      : APP_STATE.quantityFilters.customer ||
+        document.getElementById("qty-filter-customer")?.value ||
+        "";
+  const filtered = effectiveCustomer
+    ? quantities.filter((q) => q && q.customer === effectiveCustomer)
+    : quantities;
+
+  const yearSelect = document.getElementById("qty-filter-year");
+  if (yearSelect) {
+    const previousValue = yearSelect.value;
+    const storedValue = APP_STATE.quantityFilters.year || "";
+    const desiredValue = previousValue || storedValue;
+    const years = Array.from(
+      new Set(
+        filtered
+          .map((q) => q?.year)
+          .filter((year) => year !== undefined && year !== null && year !== ""),
+      ),
+    ).sort((a, b) => Number(b) - Number(a));
+    yearSelect.innerHTML =
+      '<option value="">All Years</option>' +
+      years.map((year) => `<option value="${year}">${year}</option>`).join("");
+    if (
+      desiredValue &&
+      years.some((year) => String(year) === String(desiredValue))
+    ) {
+      yearSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      yearSelect.value = "";
+    }
+  }
+
+  const eventSelect = document.getElementById("qty-filter-event");
+  if (eventSelect) {
+    const previousValue = eventSelect.value;
+    const storedValue = APP_STATE.quantityFilters.event || "";
+    const desiredValue = previousValue || storedValue;
+    const events = Array.from(
+      new Set(filtered.map((q) => q?.event).filter((event) => event)),
+    ).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    eventSelect.innerHTML =
+      '<option value="">All Events</option>' +
+      events.map((event) => `<option value="${event}">${event}</option>`).join("");
+    if (desiredValue && events.includes(desiredValue)) {
+      eventSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      eventSelect.value = "";
+    }
+  }
+}
+
+function handleQuantityCustomerChange() {
+  const customer = document.getElementById("qty-filter-customer")?.value || "";
+  updateQuantityYearEventOptions(customer);
+  filterQuantities();
+}
+
+function filterQuantities() {
+  APP_STATE.quantityFilters.customer =
+    document.getElementById("qty-filter-customer")?.value || "";
+  APP_STATE.quantityFilters.event =
+    document.getElementById("qty-filter-event")?.value || "";
+  APP_STATE.quantityFilters.year =
+    document.getElementById("qty-filter-year")?.value || "";
+  APP_STATE.quantityFilters.sampleId =
+    document.getElementById("qty-filter-sample")?.value || "";
+  APP_STATE.quantityFilters.poNumber =
+    document.getElementById("qty-filter-po")?.value || "";
+
+  resetTablePagination("orderQuantities");
+  updateQuantitiesTable();
+}
+
+function clearQuantityFilters() {
+  document.getElementById("qty-filter-customer").value = "";
+  document.getElementById("qty-filter-event").value = "";
+  document.getElementById("qty-filter-year").value = "";
+  document.getElementById("qty-filter-sample").value = "";
+  document.getElementById("qty-filter-po").value = "";
+
+  APP_STATE.quantityFilters = {
+    customer: "",
+    event: "",
+    year: "",
+    sampleId: "",
+    poNumber: "",
+    filteredQuantities: [],
+  };
+
+  populateQuantityFilters();
+  resetTablePagination("orderQuantities");
+  updateQuantitiesTable();
+}
+
+function deleteAllQuantities() {
+  if (!APP_STATE.writeAccess) return;
+
+  const count = APP_STATE.confirmedQuantities.length;
+  if (count === 0) {
+    showAlert("warning", "No quantities to delete");
+    return;
+  }
+
+  if (
+    confirm(
+      `Are you sure you want to delete ALL ${count} quantity records?\n\nThis action cannot be undone.`,
+    )
+  ) {
+    APP_STATE.confirmedQuantities = [];
+    updateQuantitiesTable();
+    populateQuantityFilters();
+    populateQuantityMigrationOptions();
+    updateDashboard();
+    logActivity("Deleted all quantities", `${count} records deleted`);
+    persistState();
+    showAlert("success", `Deleted ${count} quantity records`);
+  }
+}
+
+function deleteFilteredQuantities() {
+  if (!APP_STATE.writeAccess) return;
+
+  const filtered = APP_STATE.quantityFilters.filteredQuantities;
+  const count = filtered.length;
+
+  if (count === 0) {
+    showAlert("warning", "No filtered quantities to delete");
+    return;
+  }
+
+  if (
+    confirm(
+      `Are you sure you want to delete ${count} filtered quantity records?\n\nThis action cannot be undone.`,
+    )
+  ) {
+    // Remove filtered items from main array
+    const idsToDelete = filtered.map((q) => q.id);
+    APP_STATE.confirmedQuantities = APP_STATE.confirmedQuantities.filter(
+      (q) => !idsToDelete.includes(q.id),
+    );
+
+    clearQuantityFilters();
+    populateQuantityFilters();
+    updateQuantitiesTable();
+    populateQuantityMigrationOptions();
+    updateDashboard();
+    logActivity("Deleted filtered quantities", `${count} records deleted`);
+    persistState();
+    showAlert("success", `Deleted ${count} quantity records`);
+  }
+}
+
+function deleteQuantity(id) {
+  if (!APP_STATE.writeAccess) return;
+
+  APP_STATE.confirmedQuantities = APP_STATE.confirmedQuantities.filter((q) => q.id !== id);
+  updateQuantitiesTable();
+  populateQuantityFilters();
+  populateQuantityMigrationOptions();
+  updateDashboard();
+  logActivity("Deleted quantity record");
+  persistState();
+}
+
+function openQuantityModal(quantityId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage quantities");
+    return;
+  }
+
+  const modal = document.getElementById("quantity-modal");
+  const title = document.getElementById("quantity-modal-title");
+
+  if (quantityId) {
+    // Editing existing quantity
+    const quantity = APP_STATE.confirmedQuantities.find((q) => q.id === quantityId);
+    if (quantity) {
+      title.textContent = "Edit Quantity";
+      document.getElementById("qty-modal-customer").value =
+        quantity.customer || "";
+      document.getElementById("qty-modal-event").value = quantity.event || "";
+      document.getElementById("qty-modal-year").value = quantity.year || "";
+      document.getElementById("qty-modal-sample").value =
+        quantity.sample_id || "";
+      document.getElementById("qty-modal-quantity").value =
+        quantity.quantity || "";
+      document.getElementById("qty-modal-po").value = quantity.po_number || "";
+      document.getElementById("qty-modal-status").value =
+        quantity.status || "Confirmed";
+      APP_STATE.editingQuantityId = quantityId;
+    }
+  } else {
+    // Adding new quantity
+    title.textContent = "Add Quantity";
+    document.getElementById("qty-modal-customer").value = "";
+    document.getElementById("qty-modal-event").value = "";
+    document.getElementById("qty-modal-year").value = new Date().getFullYear();
+    document.getElementById("qty-modal-sample").value = "";
+    document.getElementById("qty-modal-quantity").value = "";
+    document.getElementById("qty-modal-po").value = "";
+    document.getElementById("qty-modal-status").value = "Confirmed";
+    APP_STATE.editingQuantityId = null;
+  }
+
+  modal.classList.add("active");
+}
+
+function editQuantity(quantityId) {
+  openQuantityModal(quantityId);
+}
+
+function closeQuantityModal() {
+  document.getElementById("quantity-modal").classList.remove("active");
+  APP_STATE.editingQuantityId = null;
+}
+
+function saveQuantity() {
+  const customer = document.getElementById("qty-modal-customer").value.trim();
+  const event = document.getElementById("qty-modal-event").value.trim();
+  const year = document.getElementById("qty-modal-year").value;
+  const sampleId = document.getElementById("qty-modal-sample").value.trim();
+  const quantity = parseInt(
+    document.getElementById("qty-modal-quantity").value,
+  );
+  const poNumber = document.getElementById("qty-modal-po").value.trim();
+  const status = document.getElementById("qty-modal-status").value;
+
+  // Validation
+  if (!customer || !event || !year || !quantity) {
+    showAlert("error", "Customer, event, year, and quantity are required");
+    return;
+  }
+
+  if (APP_STATE.editingQuantityId) {
+    // Update existing
+    const index = APP_STATE.confirmedQuantities.findIndex(
+      (q) => q.id === APP_STATE.editingQuantityId,
+    );
+    if (index !== -1) {
+      APP_STATE.confirmedQuantities[index] = {
+        ...APP_STATE.confirmedQuantities[index],
+        customer,
+        event,
+        year,
+        sample_id: sampleId || null,
+        quantity,
+        po_number: poNumber || null,
+        status,
+      };
+      logActivity("Updated quantity", `${customer} ${event} ${year}`);
+      showAlert("success", "Quantity updated successfully");
+    }
+  } else {
+    // Add new
+    const newQuantity = {
+      id: "qty_" + Date.now(),
+      customer,
+      event,
+      year,
+      sample_id: sampleId || null,
+      quantity,
+      po_number: poNumber || null,
+      status,
+    };
+    APP_STATE.confirmedQuantities.push(newQuantity);
+    logActivity("Added quantity", `${customer} ${event} ${year}`);
+    showAlert("success", "Quantity added successfully");
+  }
+
+  updateQuantitiesTable();
+  populateQuantityFilters();
+  populateQuantityMigrationOptions();
+  updateDashboard();
+  persistState();
+  closeQuantityModal();
+}
+
+async function handleHistoricalQuantitiesCsvImport() {
+  const input = document.getElementById("historical-quantities-import-file");
+  const feedback = document.getElementById(
+    "historical-quantities-import-feedback",
+  );
+  const file = input?.files?.[0];
+  if (!file) {
+    alert("Select order_quantities_historical.csv first.");
+    return;
+  }
+
+  try {
+    const csv = await file.text();
+    const lines = csv.split(/\r?\n/).filter((line) => line.trim());
+    if (lines.length <= 1) {
+      if (feedback)
+        feedback.textContent = "No historical quantity records found in file.";
+      return;
+    }
+
+    const headers = lines[0].split(",").map((h) => h.trim());
+    const buildHistoricalQuantityKey = (record) => {
+      const customer = String(record?.customer ?? "").trim();
+      const event = String(record?.event ?? "").trim();
+      const year = String(record?.year ?? "").trim();
+      const sampleId = String(record?.sample_id ?? "").trim();
+      return `${customer}|${event}|${year}|${sampleId}`;
+    };
+    const existingHistoricalKeys = new Set(
+      (APP_STATE.historicalQuantities || []).map((record) =>
+        buildHistoricalQuantityKey(record),
+      ),
+    );
+    let imported = 0;
+    let skipped = 0;
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split(",");
+      const quantity = {};
+
+      headers.forEach((header, index) => {
+        quantity[header] = values[index]?.trim();
+      });
+
+      const key = buildHistoricalQuantityKey(quantity);
+
+      if (existingHistoricalKeys.has(key)) {
+        skipped++;
+        continue;
+      }
+
+      APP_STATE.historicalQuantities.push({
+        ...quantity,
+        id: "hqty_" + Date.now() + "_" + i,
+        quantity: parseInt(quantity.quantity) || 0,
+      });
+      existingHistoricalKeys.add(key);
+      imported++;
+    }
+
+    updateHistoricalQuantitiesTable();
+    populateHistoricalQuantityFilters();
+    updateDashboard();
+    logActivity("Imported historical quantities", `${imported} records`);
+    showAlert(
+      "success",
+      `Loaded ${imported} historical quantity records${skipped ? `, skipped ${skipped} duplicates` : ""}`,
+    );
+    persistState();
+    if (feedback) {
+      feedback.textContent = `Import complete. Loaded ${imported} historical quantity records, skipped ${skipped} duplicates.`;
+    }
+  } catch (error) {
+    console.error("Historical quantities import error:", error);
+    if (feedback) feedback.textContent = "Import failed.";
+  } finally {
+    if (input) input.value = "";
+  }
+}
+
+function updateHistoricalQuantitiesTable() {
+  const tbody = document.querySelector("#historical-quantities-table tbody");
+  if (!tbody) return;
+
+  const allQuantities = Array.isArray(APP_STATE.historicalQuantities)
+    ? APP_STATE.historicalQuantities
+    : [];
+
+  let quantities = allQuantities.slice();
+
+  if (APP_STATE.historicalQuantityFilters.customer) {
+    quantities = quantities.filter(
+      (q) => q.customer === APP_STATE.historicalQuantityFilters.customer,
+    );
+  }
+  if (APP_STATE.historicalQuantityFilters.event) {
+    quantities = quantities.filter(
+      (q) => q.event === APP_STATE.historicalQuantityFilters.event,
+    );
+  }
+  if (APP_STATE.historicalQuantityFilters.year) {
+    quantities = quantities.filter(
+      (q) => q.year == APP_STATE.historicalQuantityFilters.year,
+    );
+  }
+  if (APP_STATE.historicalQuantityFilters.sampleId) {
+    quantities = quantities.filter(
+      (q) =>
+        q.sample_id &&
+        q.sample_id
+          .toLowerCase()
+          .includes(APP_STATE.historicalQuantityFilters.sampleId.toLowerCase()),
+    );
+  }
+  if (APP_STATE.historicalQuantityFilters.poNumber) {
+    quantities = quantities.filter(
+      (q) =>
+        q.po_number &&
+        q.po_number
+          .toLowerCase()
+          .includes(APP_STATE.historicalQuantityFilters.poNumber.toLowerCase()),
+    );
+  }
+
+  APP_STATE.historicalQuantityFilters.filteredQuantities = quantities;
+
+  const countEl = document.getElementById("hqty-filter-count");
+  if (countEl) {
+    if (quantities.length === allQuantities.length) {
+      countEl.textContent = `Showing all ${quantities.length} historical quantities`;
+    } else {
+      countEl.textContent = `Showing ${quantities.length} of ${allQuantities.length} historical quantities (filtered)`;
+    }
+  }
+
+  if (quantities.length === 0) {
+    tbody.innerHTML = `
+                  <tr>
+                      <td colspan="8" class="text-center" style="color: var(--gray);">
+                          ${
+                            allQuantities.length === 0
+                              ? "No historical quantities loaded"
+                              : "No historical quantities match filters"
+                          }
+                      </td>
+                  </tr>
+                `;
+    updateTablePaginationUI(
+      "historicalQuantities",
+      paginateData([], "historicalQuantities"),
+    );
+    return;
+  }
+
+  const pagination = paginateData(quantities, "historicalQuantities");
+  tbody.innerHTML = pagination.pageItems
+    .map(
+      (qty) => `
+                    <tr>
+                        <td>${qty.customer}</td>
+                        <td>${qty.event}</td>
+                        <td>${qty.year}</td>
+                        <td>${qty.sample_id || "All"}</td>
+                        <td><strong>${qty.quantity}</strong></td>
+                        <td>${qty.po_number || "-"}</td>
+                        <td><span class="status-tag ${
+                          qty.status === "Confirmed" ? "available" : "limited"
+                        }">${qty.status || "Pending"}</span></td>
+                        <td>
+                            <button class="btn btn-outline btn-sm" onclick="editHistoricalQuantity('${
+                              qty.id
+                            }')">Edit</button>
+                            <button class="btn btn-danger btn-sm" onclick="deleteHistoricalQuantity('${
+                              qty.id
+                            }')">Delete</button>
+                        </td>
+                    </tr>
+                  `,
+    )
+    .join("");
+  updateTablePaginationUI("historicalQuantities", pagination);
+}
+
+function populateHistoricalQuantityFilters() {
+  const quantities = Array.isArray(APP_STATE.historicalQuantities)
+    ? APP_STATE.historicalQuantities
+    : [];
+  const customerSelect = document.getElementById("hqty-filter-customer");
+  if (customerSelect) {
+    const previousValue = customerSelect.value;
+    const storedValue = APP_STATE.historicalQuantityFilters.customer || "";
+    const desiredValue = previousValue || storedValue;
+    const customers = Array.from(
+      new Set(quantities.map((q) => q.customer).filter((customer) => customer)),
+    ).sort((a, b) => a.localeCompare(b));
+    customerSelect.innerHTML =
+      '<option value="">All Customers</option>' +
+      customers.map((customer) => `<option value="${customer}">${customer}</option>`).join("");
+    if (
+      desiredValue &&
+      customers.some((customer) => String(customer) === String(desiredValue))
+    ) {
+      customerSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      customerSelect.value = "";
+    }
+  }
+  const selectedCustomer = customerSelect ? customerSelect.value : "";
+  updateHistoricalQuantityYearEventOptions(selectedCustomer);
+}
+
+
+function updateHistoricalQuantityYearEventOptions(customer) {
+  const quantities = Array.isArray(APP_STATE.historicalQuantities)
+    ? APP_STATE.historicalQuantities
+    : [];
+  const effectiveCustomer =
+    customer !== undefined && customer !== null
+      ? customer
+      : APP_STATE.historicalQuantityFilters.customer ||
+        document.getElementById("hqty-filter-customer")?.value ||
+        "";
+  const filtered = effectiveCustomer
+    ? quantities.filter((q) => q && q.customer === effectiveCustomer)
+    : quantities;
+
+  const yearSelect = document.getElementById("hqty-filter-year");
+  if (yearSelect) {
+    const previousValue = yearSelect.value;
+    const storedValue = APP_STATE.historicalQuantityFilters.year || "";
+    const desiredValue = previousValue || storedValue;
+    const years = Array.from(
+      new Set(
+        filtered
+          .map((q) => q?.year)
+          .filter((year) => year !== undefined && year !== null && year !== ""),
+      ),
+    ).sort((a, b) => Number(b) - Number(a));
+    yearSelect.innerHTML =
+      '<option value="">All Years</option>' +
+      years.map((year) => `<option value="${year}">${year}</option>`).join("");
+    if (
+      desiredValue &&
+      years.some((year) => String(year) === String(desiredValue))
+    ) {
+      yearSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      yearSelect.value = "";
+    }
+  }
+
+  const eventSelect = document.getElementById("hqty-filter-event");
+  if (eventSelect) {
+    const previousValue = eventSelect.value;
+    const storedValue = APP_STATE.historicalQuantityFilters.event || "";
+    const desiredValue = previousValue || storedValue;
+    const events = Array.from(
+      new Set(filtered.map((q) => q?.event).filter((event) => event)),
+    ).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    eventSelect.innerHTML =
+      '<option value="">All Events</option>' +
+      events.map((event) => `<option value="${event}">${event}</option>`).join("");
+    if (desiredValue && events.includes(desiredValue)) {
+      eventSelect.value = desiredValue;
+    } else if (!previousValue && !storedValue) {
+      eventSelect.value = "";
+    }
+  }
+}
+
+function handleHistoricalQuantityCustomerChange() {
+  const customer = document.getElementById("hqty-filter-customer")?.value || "";
+  updateHistoricalQuantityYearEventOptions(customer);
+  filterHistoricalQuantities();
+}
+
+function filterHistoricalQuantities() {
+  APP_STATE.historicalQuantityFilters.customer =
+    document.getElementById("hqty-filter-customer")?.value || "";
+  APP_STATE.historicalQuantityFilters.event =
+    document.getElementById("hqty-filter-event")?.value || "";
+  APP_STATE.historicalQuantityFilters.year =
+    document.getElementById("hqty-filter-year")?.value || "";
+  APP_STATE.historicalQuantityFilters.sampleId =
+    document.getElementById("hqty-filter-sample")?.value || "";
+  APP_STATE.historicalQuantityFilters.poNumber =
+    document.getElementById("hqty-filter-po")?.value || "";
+
+  resetTablePagination("historicalQuantities");
+  updateHistoricalQuantitiesTable();
+}
+
+function clearHistoricalQuantityFilters() {
+  if (document.getElementById("hqty-filter-customer"))
+    document.getElementById("hqty-filter-customer").value = "";
+  if (document.getElementById("hqty-filter-event"))
+    document.getElementById("hqty-filter-event").value = "";
+  if (document.getElementById("hqty-filter-year"))
+    document.getElementById("hqty-filter-year").value = "";
+  if (document.getElementById("hqty-filter-sample"))
+    document.getElementById("hqty-filter-sample").value = "";
+  if (document.getElementById("hqty-filter-po"))
+    document.getElementById("hqty-filter-po").value = "";
+
+  APP_STATE.historicalQuantityFilters = {
+    customer: "",
+    event: "",
+    year: "",
+    sampleId: "",
+    poNumber: "",
+    filteredQuantities: [],
+  };
+
+  populateHistoricalQuantityFilters();
+  resetTablePagination("historicalQuantities");
+  updateHistoricalQuantitiesTable();
+}
+
+function deleteAllHistoricalQuantities() {
+  if (!APP_STATE.writeAccess) return;
+
+  const count = APP_STATE.historicalQuantities.length;
+  if (count === 0) {
+    showAlert("warning", "No historical quantities to delete");
+    return;
+  }
+
+  if (
+    confirm(
+      `Are you sure you want to delete ALL ${count} historical quantity records?\\n\\nThis action cannot be undone.`,
+    )
+  ) {
+    APP_STATE.historicalQuantities = [];
+    updateHistoricalQuantitiesTable();
+    populateHistoricalQuantityFilters();
+    updateDashboard();
+    logActivity(
+      "Deleted all historical quantities",
+      `${count} records deleted`,
+    );
+    persistState();
+    showAlert("success", `Deleted ${count} historical quantity records`);
+  }
+}
+
+function deleteFilteredHistoricalQuantities() {
+  if (!APP_STATE.writeAccess) return;
+
+  const filtered = APP_STATE.historicalQuantityFilters.filteredQuantities || [];
+  const count = filtered.length;
+
+  if (count === 0) {
+    showAlert("warning", "No filtered historical quantities to delete");
+    return;
+  }
+
+  if (
+    confirm(
+      `Are you sure you want to delete ${count} filtered historical quantity records?\\n\\nThis action cannot be undone.`,
+    )
+  ) {
+    const idsToDelete = filtered.map((q) => q.id);
+    APP_STATE.historicalQuantities = APP_STATE.historicalQuantities.filter(
+      (q) => !idsToDelete.includes(q.id),
+    );
+
+    clearHistoricalQuantityFilters();
+    populateHistoricalQuantityFilters();
+    updateHistoricalQuantitiesTable();
+    updateDashboard();
+    logActivity(
+      "Deleted filtered historical quantities",
+      `${count} records deleted`,
+    );
+    persistState();
+    showAlert("success", `Deleted ${count} historical quantity records`);
+  }
+}
+
+function deleteHistoricalQuantity(id) {
+  if (!APP_STATE.writeAccess) return;
+
+  APP_STATE.historicalQuantities = APP_STATE.historicalQuantities.filter(
+    (q) => q.id !== id,
+  );
+  updateHistoricalQuantitiesTable();
+  populateHistoricalQuantityFilters();
+  updateDashboard();
+  logActivity("Deleted historical quantity record");
+  persistState();
+}
+
+function editHistoricalQuantity(quantityId) {
+  openHistoricalQuantityModal(quantityId);
+}
+
+function openHistoricalQuantityModal(quantityId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert(
+      "warning",
+      "Please complete setup to manage historical quantities",
+    );
+    return;
+  }
+
+  const modal = document.getElementById("historical-quantity-modal");
+  const title = document.getElementById("historical-quantity-modal-title");
+
+  if (quantityId) {
+    const quantity = APP_STATE.historicalQuantities.find(
+      (q) => q.id === quantityId,
+    );
+    if (quantity) {
+      title.textContent = "Edit Historical Quantity";
+      document.getElementById("hqty-modal-customer").value =
+        quantity.customer || "";
+      document.getElementById("hqty-modal-event").value = quantity.event || "";
+      document.getElementById("hqty-modal-year").value = quantity.year || "";
+      document.getElementById("hqty-modal-sample").value =
+        quantity.sample_id || "";
+      document.getElementById("hqty-modal-quantity").value =
+        quantity.quantity || "";
+      document.getElementById("hqty-modal-po").value = quantity.po_number || "";
+      document.getElementById("hqty-modal-status").value =
+        quantity.status || "Confirmed";
+      APP_STATE.editingHistoricalQuantityId = quantityId;
+    }
+  } else {
+    title.textContent = "Add Historical Quantity";
+    document.getElementById("hqty-modal-customer").value = "";
+    document.getElementById("hqty-modal-event").value = "";
+    document.getElementById("hqty-modal-year").value = new Date().getFullYear();
+    document.getElementById("hqty-modal-sample").value = "";
+    document.getElementById("hqty-modal-quantity").value = "";
+    document.getElementById("hqty-modal-po").value = "";
+    document.getElementById("hqty-modal-status").value = "Confirmed";
+    APP_STATE.editingHistoricalQuantityId = null;
+  }
+
+  modal.classList.add("active");
+}
+
+function closeHistoricalQuantityModal() {
+  document
+    .getElementById("historical-quantity-modal")
+    .classList.remove("active");
+  APP_STATE.editingHistoricalQuantityId = null;
+}
+
+function saveHistoricalQuantity() {
+  const customer = document.getElementById("hqty-modal-customer").value.trim();
+  const event = document.getElementById("hqty-modal-event").value.trim();
+  const year = document.getElementById("hqty-modal-year").value;
+  const sampleId = document.getElementById("hqty-modal-sample").value.trim();
+  const quantity = parseInt(
+    document.getElementById("hqty-modal-quantity").value,
+  );
+  const poNumber = document.getElementById("hqty-modal-po").value.trim();
+  const status = document.getElementById("hqty-modal-status").value;
+
+  if (!customer || !event || !year || !quantity) {
+    showAlert("error", "Customer, event, year, and quantity are required");
+    return;
+  }
+
+  if (APP_STATE.editingHistoricalQuantityId) {
+    const index = APP_STATE.historicalQuantities.findIndex(
+      (q) => q.id === APP_STATE.editingHistoricalQuantityId,
+    );
+    if (index !== -1) {
+      APP_STATE.historicalQuantities[index] = {
+        ...APP_STATE.historicalQuantities[index],
+        customer,
+        event,
+        year,
+        sample_id: sampleId || null,
+        quantity,
+        po_number: poNumber || null,
+        status,
+      };
+      logActivity(
+        "Updated historical quantity",
+        `${customer} ${event} ${year}`,
+      );
+      showAlert("success", "Historical quantity updated successfully");
+    }
+  } else {
+    const newQuantity = {
+      id: "hqty_" + Date.now(),
+      customer,
+      event,
+      year,
+      sample_id: sampleId || null,
+      quantity,
+      po_number: poNumber || null,
+      status,
+    };
+    APP_STATE.historicalQuantities.push(newQuantity);
+    logActivity("Added historical quantity", `${customer} ${event} ${year}`);
+    showAlert("success", "Historical quantity added successfully");
+  }
+
+  updateHistoricalQuantitiesTable();
+  populateHistoricalQuantityFilters();
+  updateDashboard();
+  persistState();
+  closeHistoricalQuantityModal();
+}
+
+// ===============================
+// Table Updates
+// ===============================
+
+function getTablePaginationState(key) {
+  if (!APP_STATE.tablePagination) {
+    APP_STATE.tablePagination = {};
+  }
+  if (!APP_STATE.tablePagination[key]) {
+    APP_STATE.tablePagination[key] = { currentPage: 1, pageSize: 25 };
+  }
+  return APP_STATE.tablePagination[key];
+}
+
+function resetTablePagination(key) {
+  const state = getTablePaginationState(key);
+  state.currentPage = 1;
+}
+
+function paginateData(data, key) {
+  const state = getTablePaginationState(key);
+  const items = Array.isArray(data) ? data : [];
+  const totalItems = items.length;
+  const rawSize =
+    state.pageSize === "all"
+      ? totalItems > 0
+        ? totalItems
+        : 1
+      : Number(state.pageSize) || 25;
+  const totalPages = totalItems > 0 ? Math.ceil(totalItems / rawSize) : 1;
+  if (state.currentPage > totalPages) {
+    state.currentPage = totalPages;
+  }
+  if (state.currentPage < 1) {
+    state.currentPage = 1;
+  }
+  const startIndex = state.pageSize === "all" ? 0 : (state.currentPage - 1) * rawSize;
+  const endIndex = state.pageSize === "all" ? totalItems : startIndex + rawSize;
+  return {
+    pageItems:
+      state.pageSize === "all"
+        ? items.slice()
+        : items.slice(startIndex, Math.min(endIndex, totalItems)),
+    totalItems,
+    start: totalItems === 0 ? 0 : startIndex + 1,
+    end: totalItems === 0 ? 0 : Math.min(endIndex, totalItems),
+    totalPages,
+  };
+}
+
+function updateTablePaginationUI(key, meta) {
+  const container = document.querySelector(
+    `.table-pagination[data-pagination="${key}"]`,
+  );
+  if (!container || !meta) return;
+  const state = getTablePaginationState(key);
+  const sizeSelect = container.querySelector(".pagination-size");
+  if (sizeSelect) {
+    const desired = state.pageSize === "all" ? "all" : String(state.pageSize || 25);
+    if (sizeSelect.value !== desired) {
+      sizeSelect.value = desired;
+    }
+  }
+  const info = container.querySelector(".pagination-info");
+  if (info) {
+    info.textContent =
+      meta.totalItems > 0
+        ? `Showing ${meta.start}-${meta.end} of ${meta.totalItems} entries`
+        : "No entries";
+  }
+  const pageSelect = container.querySelector(".pagination-page-select");
+  if (pageSelect) {
+    const totalPages = Math.max(1, meta.totalPages || 1);
+    if (pageSelect.options.length !== totalPages) {
+      pageSelect.innerHTML = "";
+      for (let i = 1; i <= totalPages; i++) {
+        const option = document.createElement("option");
+        option.value = String(i);
+        option.textContent = `Page ${i}`;
+        pageSelect.appendChild(option);
+      }
+    }
+    if (pageSelect.value !== String(state.currentPage)) {
+      pageSelect.value = String(state.currentPage);
+    }
+  }
+  const prevButton = container.querySelector(".pagination-prev");
+  if (prevButton) {
+    prevButton.disabled = meta.totalItems === 0 || state.currentPage <= 1;
+  }
+  const nextButton = container.querySelector(".pagination-next");
+  if (nextButton) {
+    nextButton.disabled =
+      meta.totalItems === 0 || state.currentPage >= Math.max(1, meta.totalPages || 1);
+  }
+}
+
+function refreshPaginatedTable(key) {
+  if (key === "samples") {
+    updateSampleTable();
+  } else if (key === "orderQuantities") {
+    updateQuantitiesTable();
+  } else if (key === "historicalQuantities") {
+    updateHistoricalQuantitiesTable();
+  }
+}
+
+function handleTablePageSizeChange(key, value) {
+  const state = getTablePaginationState(key);
+  state.pageSize = value === "all" ? "all" : Number(value) || 25;
+  state.currentPage = 1;
+  refreshPaginatedTable(key);
+}
+
+function changeTablePage(key, direction) {
+  const state = getTablePaginationState(key);
+  const meta = paginateData(
+    key === "samples"
+      ? APP_STATE.sampleDefinitions
+      : key === "orderQuantities"
+      ? APP_STATE.quantityFilters.filteredQuantities || []
+      : APP_STATE.historicalQuantityFilters.filteredQuantities || [],
+    key,
+  );
+  if (direction === "prev" && state.currentPage > 1) {
+    state.currentPage--;
+  } else if (direction === "next" && state.currentPage < Math.max(1, meta.totalPages)) {
+    state.currentPage++;
+  }
+  refreshPaginatedTable(key);
+}
+
+function goToTablePage(key, pageValue) {
+  const state = getTablePaginationState(key);
+  const target = Number(pageValue);
+  if (Number.isFinite(target) && target >= 1) {
+    state.currentPage = target;
+    refreshPaginatedTable(key);
+  }
+}
+
+function setupPaginationControls() {
+  const containers = document.querySelectorAll(
+    ".table-pagination[data-pagination]",
+  );
+  containers.forEach((container) => {
+    const key = container.getAttribute("data-pagination");
+    if (!key) return;
+    const sizeSelect = container.querySelector(".pagination-size");
+    if (sizeSelect && !sizeSelect.dataset.bound) {
+      sizeSelect.dataset.bound = "true";
+      sizeSelect.addEventListener("change", (event) => {
+        handleTablePageSizeChange(key, event.target.value);
+      });
+    }
+    const prevButton = container.querySelector(".pagination-prev");
+    if (prevButton && !prevButton.dataset.bound) {
+      prevButton.dataset.bound = "true";
+      prevButton.addEventListener("click", () => changeTablePage(key, "prev"));
+    }
+    const nextButton = container.querySelector(".pagination-next");
+    if (nextButton && !nextButton.dataset.bound) {
+      nextButton.dataset.bound = "true";
+      nextButton.addEventListener("click", () => changeTablePage(key, "next"));
+    }
+    const pageSelect = container.querySelector(".pagination-page-select");
+    if (pageSelect && !pageSelect.dataset.bound) {
+      pageSelect.dataset.bound = "true";
+      pageSelect.addEventListener("change", (event) => {
+        goToTablePage(key, event.target.value);
+      });
+    }
+  });
+}
+
+function updateAllTables() {
+  updateSampleTable();
+  updateSpecTable();
+  updateQuantitiesTable();
+  updateHistoricalQuantitiesTable();
+}
+
+function updateSampleTable() {
+  const tbody = document.querySelector("#sample-table tbody");
+
+  const samples = Array.isArray(APP_STATE.sampleDefinitions)
+    ? APP_STATE.sampleDefinitions
+    : [];
+
+  if (samples.length === 0) {
+    tbody.innerHTML = `
+                                                        <tr>
+                                                            <td colspan="6" class="text-center" style="color: var(--gray);">
+                                                                No sample definitions loaded
+                                                            </td>
+                                                        </tr>
+                                                    `;
+    updateTablePaginationUI("samples", paginateData([], "samples"));
+    return;
+  }
+
+  const pagination = paginateData(samples, "samples");
+  const offset = pagination.start - 1;
+  tbody.innerHTML = pagination.pageItems
+    .map(
+      (sample, index) => `
+                                                    <tr>
+                                                        <td>${sample.sample_type_id}</td>
+                                                        <td>${sample.sample_type_name}</td>
+                                                        <td>${sample.fill_ml}</td>
+                                                        <td>${sample.hct_percent}</td>
+                                                        <td>${
+                                                          sample.requires_rbc ===
+                                                            "TRUE" ||
+                                                          sample.requires_rbc ===
+                                                            "true"
+                                                            ? "✓"
+                                                            : ""
+                                                        }</td>
+                                                        <td>
+                                                            <button class="btn btn-danger btn-sm" onclick="deleteSample(${offset + index})" ${
+                                                              !APP_STATE.writeAccess
+                                                                ? "disabled"
+                                                                : ""
+                                                            }>Delete</button>
+                                                        </td>
+                                                    </tr>
+                                                `,
+    )
+    .join("");
+  updateTablePaginationUI("samples", pagination);
+}
+
+function populateSpecFilters() {
+  const specs = Array.isArray(APP_STATE.customerSpecs) ? APP_STATE.customerSpecs : [];
+  const customerSelect = document.getElementById("spec-filter-customer");
+  if (customerSelect) {
+    const previousValue = customerSelect.value;
+    const customers = Array.from(
+      new Set(specs.map((spec) => spec.customer).filter((customer) => customer)),
+    ).sort((a, b) => a.localeCompare(b));
+    customerSelect.innerHTML =
+      '<option value="">All Customers</option>' +
+      customers.map((customer) => `<option value="${customer}">${customer}</option>`).join("");
+    if (previousValue && customers.includes(previousValue)) {
+      customerSelect.value = previousValue;
+    } else {
+      customerSelect.value = "";
+    }
+  }
+  updateSpecFilterOptionsForCustomer();
+}
+
+
+function updateSpecFilterOptionsForCustomer() {
+  const specs = Array.isArray(APP_STATE.customerSpecs) ? APP_STATE.customerSpecs : [];
+  const customer = document.getElementById("spec-filter-customer")?.value || "";
+  const filtered = customer
+    ? specs.filter((spec) => spec && spec.customer === customer)
+    : specs;
+
+  const yearSelect = document.getElementById("spec-filter-year");
+  if (yearSelect) {
+    const previousValue = yearSelect.value;
+    const years = Array.from(
+      new Set(
+        filtered
+          .map((spec) => spec?.year)
+          .filter((year) => year !== undefined && year !== null && year !== ""),
+      ),
+    ).sort((a, b) => Number(b) - Number(a));
+    yearSelect.innerHTML =
+      '<option value="">All Years</option>' +
+      years.map((year) => `<option value="${year}">${year}</option>`).join("");
+    if (previousValue && years.some((year) => String(year) === String(previousValue))) {
+      yearSelect.value = previousValue;
+    } else {
+      yearSelect.value = "";
+    }
+  }
+
+  const eventSelect = document.getElementById("spec-filter-event");
+  if (eventSelect) {
+    const previousValue = eventSelect.value;
+    const events = Array.from(
+      new Set(filtered.map((spec) => spec?.event).filter((event) => event)),
+    ).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    eventSelect.innerHTML =
+      '<option value="">All Events</option>' +
+      events.map((event) => `<option value="${event}">${event}</option>`).join("");
+    if (previousValue && events.includes(previousValue)) {
+      eventSelect.value = previousValue;
+    } else {
+      eventSelect.value = "";
+    }
+  }
+
+  const sampleIdSelect = document.getElementById("spec-filter-sample-id");
+  if (sampleIdSelect) {
+    const previousValue = sampleIdSelect.value;
+    const sampleIds = Array.from(
+      new Set(filtered.map((spec) => spec?.sample_id).filter((id) => id)),
+    ).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    sampleIdSelect.innerHTML =
+      '<option value="">All Sample IDs</option>' +
+      sampleIds.map((id) => `<option value="${id}">${id}</option>`).join("");
+    if (previousValue && sampleIds.includes(previousValue)) {
+      sampleIdSelect.value = previousValue;
+    } else {
+      sampleIdSelect.value = "";
+    }
+  }
+
+  const sampleTypeSelect = document.getElementById("spec-filter-sample-type");
+  if (sampleTypeSelect) {
+    const previousValue = sampleTypeSelect.value;
+    const sampleTypes = Array.from(
+      new Set(filtered.map((spec) => spec?.sample_type_id).filter((type) => type)),
+    ).sort((a, b) => a.localeCompare(b));
+    sampleTypeSelect.innerHTML =
+      '<option value="">All Sample Types</option>' +
+      sampleTypes.map((type) => `<option value="${type}">${type}</option>`).join("");
+    if (previousValue && sampleTypes.includes(previousValue)) {
+      sampleTypeSelect.value = previousValue;
+    } else {
+      sampleTypeSelect.value = "";
+    }
+  }
+}
+
+function handleSpecCustomerChange() {
+  updateSpecFilterOptionsForCustomer();
+  filterSpecs();
+}
+
+function updateSpecTable() {
+  const tbody = document.querySelector("#spec-table tbody");
+
+  // Apply filters
+  let specs = APP_STATE.customerSpecs;
+
+  if (APP_STATE.specPagination.filterCustomer) {
+    specs = specs.filter(
+      (spec) => spec.customer === APP_STATE.specPagination.filterCustomer,
+    );
+  }
+
+  // Event filter
+  if (APP_STATE.specPagination.filterEvent) {
+    specs = specs.filter(
+      (spec) => spec.event === APP_STATE.specPagination.filterEvent,
+    );
+  }
+
+  // Year filter
+  if (APP_STATE.specPagination.filterYear) {
+    specs = specs.filter(
+      (spec) => spec.year == APP_STATE.specPagination.filterYear,
+    );
+  }
+
+  // Sample ID filter
+  if (APP_STATE.specPagination.filterSampleId) {
+    specs = specs.filter(
+      (spec) => spec.sample_id === APP_STATE.specPagination.filterSampleId,
+    );
+  }
+
+  // Sample Type filter
+  if (APP_STATE.specPagination.filterSampleType) {
+    specs = specs.filter(
+      (spec) =>
+        spec.sample_type_id === APP_STATE.specPagination.filterSampleType,
+    );
+  }
+
+  const filterActive =
+    APP_STATE.specPagination.filterCustomer ||
+    APP_STATE.specPagination.filterEvent ||
+    APP_STATE.specPagination.filterYear ||
+    APP_STATE.specPagination.filterSampleId ||
+    APP_STATE.specPagination.filterSampleType;
+
+  APP_STATE.specPagination.filteredSpecs = specs;
+
+  if (specs.length === 0) {
+    tbody.innerHTML = `
+                                                <tr>
+                                                    <td colspan="8" class="text-center" style="color: var(--gray);">
+                                                        ${
+                                                          filterActive
+                                                            ? "No specifications match current filters"
+                                                            : "No specifications loaded"
+                                                        }
+                                                    </td>
+                                                </tr>
+                                            `;
+    updateSpecPaginationControls();
+    return;
+  }
+
+  // Calculate pagination
+  const pageSize =
+    APP_STATE.specPagination.pageSize === "all"
+      ? specs.length
+      : parseInt(APP_STATE.specPagination.pageSize);
+  const totalPages = Math.ceil(specs.length / pageSize);
+  const currentPage = Math.min(
+    APP_STATE.specPagination.currentPage,
+    totalPages,
+  );
+  APP_STATE.specPagination.currentPage = currentPage;
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, specs.length);
+  const pageSpecs = specs.slice(startIndex, endIndex);
+
+  tbody.innerHTML = pageSpecs
+    .map(
+      (spec, index) => `
+                                            <tr>
+                                                <td>${spec.customer}</td>
+                                                <td>${spec.event}</td>
+                                                <td>${spec.year}</td>
+                                                <td>${spec.sample_id}</td>
+                                                <td>${spec.sample_type_id}</td>
+                                                <td>
+                                                    <span class="blood-tag ${(
+                                                      spec.abo +
+                                                      "-" +
+                                                      spec.rh
+                                                    )
+                                                      .toLowerCase()
+                                                      .replace(" ", "-")
+                                                      .replace("+", "pos")}">
+                                                        ${spec.abo} ${spec.rh}
+                                                    </span>
+                                                </td>
+                                                <td>
+                                                    ${
+                                                      spec.antibody_1
+                                                        ? `<span class="status-tag">${spec.antibody_1}</span>`
+                                                        : ""
+                                                    }
+                                                    ${
+                                                      spec.antibody_2
+                                                        ? `<span class="status-tag">${spec.antibody_2}</span>`
+                                                        : ""
+                                                    }
+                                                </td>
+                                                <td>
+                                                    <button
+                                                        class="btn btn-danger btn-sm"
+                                                        onclick="deleteSpec(${index})"
+                                                        ${
+                                                          !APP_STATE.writeAccess
+                                                            ? "disabled"
+                                                            : ""
+                                                        }>
+                                                        Delete
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                        `,
+    )
+    .join("");
+
+  updateSpecPaginationControls();
+}
+
+function deleteSample(index) {
+  if (!APP_STATE.writeAccess) return;
+
+  if (confirm("Delete this sample definition?")) {
+    APP_STATE.sampleDefinitions.splice(index, 1);
+    updateSampleTable();
+    logActivity("Deleted sample definition");
+    persistState();
+  }
+}
+
+function deleteAllSamples() {
+  if (!APP_STATE.writeAccess) return;
+
+  const count = APP_STATE.sampleDefinitions.length;
+
+  if (count === 0) {
+    showAlert("warning", "No sample definitions to delete");
+    return;
+  }
+
+  if (
+    confirm(
+      `Are you sure you want to delete all ${count} sample definitions?\n\nThis action cannot be undone.`,
+    )
+  ) {
+    APP_STATE.sampleDefinitions = [];
+    updateAllTables();
+    logActivity("Deleted all sample definitions", `${count} items deleted`);
+    persistState();
+    updateDashboard();
+    showAlert("success", `Deleted ${count} sample definitions`);
+  }
+}
+
+function deleteSpec(index) {
+  if (!APP_STATE.writeAccess) return;
+
+  // Get the actual spec from the filtered list
+  const filteredSpecs = APP_STATE.specPagination.filteredSpecs;
+  const specToDelete = filteredSpecs[index];
+
+  if (!specToDelete) {
+    showAlert("error", "Could not find specification to delete");
+    return;
+  }
+
+  if (confirm("Delete this specification?")) {
+    // Find and remove from the main array
+    const mainIndex = APP_STATE.customerSpecs.findIndex(
+      (spec) =>
+        spec.customer === specToDelete.customer &&
+        spec.event === specToDelete.event &&
+        spec.year === specToDelete.year &&
+        spec.sample_id === specToDelete.sample_id,
+    );
+
+    if (mainIndex > -1) {
+      APP_STATE.customerSpecs.splice(mainIndex, 1);
+      updateSpecTable();
+      populateSpecFilters(); // Refresh filter dropdowns
+      logActivity("Deleted specification");
+      persistState();
+      updateDashboard();
+    } else {
+      showAlert("error", "Could not find specification in main list");
+    }
+  }
+}
+
+function deleteAllSpecs() {
+  if (!APP_STATE.writeAccess) return;
+
+  const filteredSpecs = APP_STATE.specPagination.filteredSpecs;
+  const count = filteredSpecs.length;
+
+  if (count === 0) {
+    showAlert("warning", "No specifications to delete");
+    return;
+  }
+
+  const filterDescription = [];
+  if (APP_STATE.specPagination.filterCustomer) {
+    filterDescription.push(
+      `customer: ${APP_STATE.specPagination.filterCustomer}`,
+    );
+  }
+  if (APP_STATE.specPagination.filterEvent) {
+    filterDescription.push(`event: ${APP_STATE.specPagination.filterEvent}`);
+  }
+  if (APP_STATE.specPagination.filterYear) {
+    filterDescription.push(`year: ${APP_STATE.specPagination.filterYear}`);
+  }
+  if (APP_STATE.specPagination.filterSampleId) {
+    filterDescription.push(
+      `sample: ${APP_STATE.specPagination.filterSampleId}`,
+    );
+  }
+  if (APP_STATE.specPagination.filterSampleType) {
+    filterDescription.push(
+      `type: ${APP_STATE.specPagination.filterSampleType}`,
+    );
+  }
+
+  const filterText =
+    filterDescription.length > 0
+      ? ` matching filters (${filterDescription.join(", ")})`
+      : "";
+
+  if (
+    confirm(
+      `Are you sure you want to delete ${count} specifications${filterText}?\n\nThis action cannot be undone.`,
+    )
+  ) {
+    const keysToDelete = new Set(
+      filteredSpecs.map(
+        (spec) =>
+          `${spec.customer}|${spec.event}|${spec.year}|${spec.sample_id}`,
+      ),
+    );
+
+    APP_STATE.customerSpecs = APP_STATE.customerSpecs.filter(
+      (spec) =>
+        !keysToDelete.has(
+          `${spec.customer}|${spec.event}|${spec.year}|${spec.sample_id}`,
+        ),
+    );
+
+    updateAllTables();
+    populateSpecFilters();
+    logActivity("Bulk deleted specifications", `${count} items deleted`);
+    persistState();
+    updateDashboard();
+    showAlert("success", `Deleted ${count} specifications`);
+  }
+}
+
+function deleteAllSpecifications_UNFILTERED() {
+  if (!APP_STATE.writeAccess) return;
+
+  if (!APP_STATE.customerSpecs || APP_STATE.customerSpecs.length === 0) {
+    showAlert("warning", "No specifications available to delete");
+    return;
+  }
+
+  if (
+    !confirm(
+      "WARNING: Are you sure you want to delete ALL historical specifications? This will remove all spec data permanently and cannot be undone.",
+    )
+  ) {
+    return;
+  }
+
+  const count = APP_STATE.customerSpecs.length;
+  APP_STATE.customerSpecs = [];
+
+  updateAllTables();
+  populateSpecFilters();
+  logActivity("Deleted all specifications");
+  persistState();
+  updateDashboard();
+  showAlert("success", `Deleted ${count} specifications`);
+}
+
+function updateSpecPaginationControls() {
+  const specs = APP_STATE.specPagination.filteredSpecs;
+  const pageSize =
+    APP_STATE.specPagination.pageSize === "all"
+      ? specs.length
+      : parseInt(APP_STATE.specPagination.pageSize);
+  const totalPages = Math.ceil(specs.length / pageSize);
+  const currentPage = APP_STATE.specPagination.currentPage;
+
+  // Update info text
+  const startIndex = Math.min((currentPage - 1) * pageSize + 1, specs.length);
+  const endIndex = Math.min(currentPage * pageSize, specs.length);
+  const infoEl = document.getElementById("spec-pagination-info");
+  if (infoEl) {
+    infoEl.textContent =
+      specs.length > 0
+        ? `Showing ${startIndex}-${endIndex} of ${specs.length} entries`
+        : "No entries";
+  }
+
+  // Update page numbers
+  const pageNumbersEl = document.getElementById("spec-page-numbers");
+  if (pageNumbersEl) {
+    let pageHTML = "";
+
+    // Show max 5 page numbers
+    let startPage = Math.max(1, currentPage - 2);
+    let endPage = Math.min(totalPages, startPage + 4);
+    if (endPage - startPage < 4) {
+      startPage = Math.max(1, endPage - 4);
+    }
+
+    if (startPage > 1) {
+      pageHTML += `<button class="btn btn-outline btn-sm" onclick="specGoToPage(1)">1</button>`;
+      if (startPage > 2) pageHTML += `<span>...</span>`;
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      const activeClass = i === currentPage ? "btn-primary" : "btn-outline";
+      pageHTML += `<button class="btn ${activeClass} btn-sm" onclick="specGoToPage(${i})">${i}</button>`;
+    }
+
+    if (endPage < totalPages) {
+      if (endPage < totalPages - 1) pageHTML += `<span>...</span>`;
+      pageHTML += `<button class="btn btn-outline btn-sm" onclick="specGoToPage(${totalPages})">${totalPages}</button>`;
+    }
+
+    pageNumbersEl.innerHTML = pageHTML;
+  }
+
+  // Enable/disable prev/next buttons
+  const prevBtn = document.querySelector(
+    "#spec-pagination-controls button:first-child",
+  );
+  const nextBtn = document.querySelector(
+    "#spec-pagination-controls button:last-child",
+  );
+  if (prevBtn) prevBtn.disabled = currentPage === 1;
+  if (nextBtn)
+    nextBtn.disabled = currentPage === totalPages || totalPages === 0;
+  // Update selected count display
+  const countEl = document.getElementById("spec-selected-count");
+  if (countEl) {
+    if (filterActive) {
+      countEl.textContent = `${specs.length} specifications match current filters`;
+      countEl.style.color = "var(--hemo-blue)";
+    } else {
+      countEl.textContent = `${specs.length} total specifications`;
+      countEl.style.color = "var(--gray)";
+    }
+  }
+}
+
+function filterSpecs() {
+  const filterCustomer =
+    document.getElementById("spec-filter-customer")?.value || "";
+  const filterEvent = document.getElementById("spec-filter-event").value;
+  const filterYear = document.getElementById("spec-filter-year").value;
+  const filterSampleId = document.getElementById("spec-filter-sample-id").value;
+  const filterSampleType = document.getElementById(
+    "spec-filter-sample-type",
+  ).value;
+
+  APP_STATE.specPagination.filterCustomer = filterCustomer;
+  APP_STATE.specPagination.filterEvent = filterEvent;
+  APP_STATE.specPagination.filterYear = filterYear;
+  APP_STATE.specPagination.filterSampleId = filterSampleId;
+  APP_STATE.specPagination.filterSampleType = filterSampleType;
+  APP_STATE.specPagination.currentPage = 1;
+
+  updateSpecTable();
+}
+
+function updateSpecPagination() {
+  const pageSize = document.getElementById("spec-page-size").value;
+  APP_STATE.specPagination.pageSize =
+    pageSize === "all" ? "all" : parseInt(pageSize);
+  APP_STATE.specPagination.currentPage = 1;
+  updateSpecTable();
+}
+
+function specChangePage(direction) {
+  const specs = APP_STATE.specPagination.filteredSpecs;
+  const pageSize =
+    APP_STATE.specPagination.pageSize === "all"
+      ? specs.length
+      : parseInt(APP_STATE.specPagination.pageSize);
+  const totalPages = Math.ceil(specs.length / pageSize);
+
+  if (direction === "prev" && APP_STATE.specPagination.currentPage > 1) {
+    APP_STATE.specPagination.currentPage--;
+  } else if (
+    direction === "next" &&
+    APP_STATE.specPagination.currentPage < totalPages
+  ) {
+    APP_STATE.specPagination.currentPage++;
+  }
+
+  updateSpecTable();
+}
+
+function specGoToPage(page) {
+  APP_STATE.specPagination.currentPage = page;
+  updateSpecTable();
+}
+
+function clearSpecFilters() {
+  const customerFilter = document.getElementById("spec-filter-customer");
+  if (customerFilter) customerFilter.value = "";
+  document.getElementById("spec-filter-event").value = "";
+  document.getElementById("spec-filter-year").value = "";
+  document.getElementById("spec-filter-sample-id").value = "";
+  document.getElementById("spec-filter-sample-type").value = "";
+
+  APP_STATE.specPagination.filterCustomer = "";
+  APP_STATE.specPagination.filterEvent = "";
+  APP_STATE.specPagination.filterYear = "";
+  APP_STATE.specPagination.filterSampleId = "";
+  APP_STATE.specPagination.filterSampleType = "";
+  APP_STATE.specPagination.currentPage = 1;
+
+  updateSpecTable();
+}
+
+// ===============================
+// Unit Management
+// ===============================
+
+function openUnitModal() {
+  showAlert("info", "Unit management - Coming soon");
+}
+
+// ===============================
+// Export/Import Functions
+// ===============================
+
+function exportDataToJSON() {
+  try {
+    const json = JSON.stringify(APP_STATE, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const now = new Date();
+    const pad = (value) => String(value).padStart(2, "0");
+    const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(
+      now.getHours(),
+    )}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    link.download = `blood_platform_data_backup_${timestamp}.json`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+
+    logActivity("Exported data to JSON");
+    showAlert("success", "Download started");
+  } catch (error) {
+    console.error("Failed to export data:", error);
+    showAlert("error", "Failed to export data");
+  }
+}
+
+function importDataFromJSON() {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json,application/json";
+  input.onchange = function (event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+
+    const confirmation = confirm(
+      "Importing data will overwrite all existing information in this browser. Continue?",
+    );
+    if (!confirmation) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onerror = function () {
+      showAlert("error", "Failed to read the selected file.");
+    };
+    reader.onload = async function (loadEvent) {
+      try {
+        const text = loadEvent.target?.result;
+        const parsed = JSON.parse(text);
+
+        if (!parsed || typeof parsed !== "object" || !parsed.version) {
+          throw new Error("Invalid data file");
+        }
+
+        parsed.lastSavedAt = new Date().toISOString();
+        parsed.writeAccess = !!parsed.instructionsAcknowledged;
+
+        if (parsed.currentUser) {
+          localStorage.setItem("current_user", parsed.currentUser);
+        }
+        if (parsed.setupComplete) {
+          localStorage.setItem("setup_complete", "true");
+        } else {
+          localStorage.removeItem("setup_complete");
+        }
+        if (parsed.instructionsAcknowledged) {
+          localStorage.setItem("instructions_acknowledged", "true");
+        } else {
+          localStorage.removeItem("instructions_acknowledged");
+        }
+
+        await saveStateToDB(parsed);
+        location.reload();
+      } catch (error) {
+        console.error("Import failed:", error);
+        showAlert("error", "Failed to import data: " + error.message);
+      }
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}
+
+// ===============================
+// Utility Functions
+// ===============================
+
+function showAlert(type, message) {
+  const alert = document.createElement("div");
+  alert.className = `alert alert-${type}`;
+  alert.textContent = message;
+
+  const activePanel = document.querySelector(".panel.active .content-body");
+  if (activePanel) {
+    activePanel.insertBefore(alert, activePanel.firstChild);
+
+    setTimeout(() => {
+      alert.remove();
+    }, 5000);
+  }
+}
+
+function initializeDragAndDrop() {
+  const uploadAreas = document.querySelectorAll(".upload-area");
+
+  uploadAreas.forEach((area) => {
+    area.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      area.classList.add("dragging");
+    });
+
+    area.addEventListener("dragleave", () => {
+      area.classList.remove("dragging");
+    });
+
+    area.addEventListener("drop", (e) => {
+      e.preventDefault();
+      area.classList.remove("dragging");
+
+      const input = area.querySelector('input[type="file"]');
+      input.files = e.dataTransfer.files;
+      input.dispatchEvent(new Event("change"));
+    });
+  });
+}
+
+// =======================================
+// Future Spec Optimization Engine
+// =======================================
+
+function runFutureSpecOptimization() {
+  console.log("Running Future Spec Optimization...");
+  const futureSpecs = APP_STATE.futureSpecs.entries;
+  if (!futureSpecs || futureSpecs.length === 0) {
+    console.log("No future specs to optimize.");
+    return;
+  }
+
+  // Clear previous suggestions
+  futureSpecs.forEach((spec) => {
+    spec.optimizationSuggestions = [];
+  });
+
+  // Process each future spec
+  for (const spec of futureSpecs) {
+    optimizeFutureSpecSample(spec);
+  }
+
+  console.log("Future Spec Optimization completed");
+}
+
+function optimizeFutureSpecSample(spec) {
+  if (!spec || spec.abo === "TBD" || spec.rh === "TBD") {
+    // Skip specs that don't have blood types assigned yet
+    return;
+  }
+
+  const fulfillmentWindow = calculateSpecFulfillmentWindow(spec);
+  if (!fulfillmentWindow) {
+    return;
+  }
+
+  // Search current inventory for compatible units
+  searchInventoryForSpec(spec, fulfillmentWindow);
+
+  // Search manufacturing calendar for standing orders
+  searchStandingOrdersForSpec(spec, fulfillmentWindow);
+
+  // Search other PT events for sharing opportunities
+  searchPTEventsForSpec(spec, fulfillmentWindow);
+}
+
+function calculateSpecFulfillmentWindow(spec) {
+  // For future specs, we need to estimate dates based on typical patterns
+  // In a real implementation, these dates would come from scheduling data
+
+  // Estimate ship date as beginning of the year + event quarter
+  const shipDate = new Date(
+    spec.year,
+    (parseInt(spec.event.replace(/\D/g, "")) - 1) * 3,
+    1,
+  );
+
+  // Estimate expiration date (typically 51 days after ship)
+  const expirationDate = new Date(shipDate);
+  expirationDate.setDate(expirationDate.getDate() + 51);
+
+  // Calculate acceptable window using 77-day rule
+  const earliestBleed = new Date(expirationDate);
+  earliestBleed.setDate(earliestBleed.getDate() - 77); // Max 77 days before expiration
+
+  const latestBleed = new Date(shipDate);
+  latestBleed.setDate(latestBleed.getDate() - 10); // Manufacturing buffer
+
+  return {
+    earliest: earliestBleed,
+    latest: latestBleed,
+    ship: shipDate,
+    expiration: expirationDate,
+  };
+}
+
+function searchInventoryForSpec(spec, window) {
+  if (!APP_STATE.bloodUnits || APP_STATE.bloodUnits.length === 0) {
+    return;
+  }
+
+  APP_STATE.bloodUnits.forEach((unit) => {
+    if (
+      isBloodUnitCompatible(spec, unit) &&
+      isDateInWindow(unit.bleed_date, window)
+    ) {
+      addOptimizationSuggestion(spec, {
+        sourceType: "Current Inventory",
+        sourceId: unit.id,
+        description: `Inventory Unit ${unit.id}`,
+        details: `Bleed: ${unit.bleed_date}, Type: ${unit.abo} ${unit.rh}`,
+        compatibility: "Exact Match",
+        volume: unit.volume || 180,
+        savings: calculateUnitSavings(unit),
+      });
+    }
+  });
+}
+
+function searchStandingOrdersForSpec(spec, window) {
+  // Check HQC standing orders
+  const hqcCompatibility = checkHQCCompatibility(spec);
+  if (hqcCompatibility.compatible) {
+    addOptimizationSuggestion(spec, {
+      sourceType: "Standing Order",
+      sourceId: `HQC-${hqcCompatibility.cellId}`,
+      description: `HQC-${hqcCompatibility.cellId} Standing Order`,
+      details: `${hqcCompatibility.description} - Overage available`,
+      compatibility: hqcCompatibility.exactMatch
+        ? "Exact Match"
+        : "Compatible with flexibility",
+      volume: 180, // Standard unit volume
+      savings: calculateStandingOrderSavings(),
+    });
+  }
+
+  // Check other standing orders (C3, Korea, MQC)
+  checkOtherStandingOrders(spec, window);
+}
+
+function searchPTEventsForSpec(spec, window) {
+  // Look for other PT events in the same timeframe that might have overage
+  const otherPTEvents = APP_STATE.futureSpecs.entries.filter(
+    (otherSpec) =>
+      otherSpec.customer !== spec.customer &&
+      otherSpec.abo !== "TBD" &&
+      isSpecCompatible(spec, otherSpec),
+  );
+
+  otherPTEvents.forEach((otherSpec) => {
+    const otherWindow = calculateSpecFulfillmentWindow(otherSpec);
+    if (otherWindow && isWindowOverlapping(window, otherWindow)) {
+      addOptimizationSuggestion(spec, {
+        sourceType: "PT Event Sharing",
+        sourceId: `${otherSpec.customer}_${otherSpec.event}_${otherSpec.year}`,
+        description: `${otherSpec.customer} ${otherSpec.event} ${otherSpec.year}`,
+        details: `Compatible PT event with potential overage`,
+        compatibility: "Cross-Event Compatible",
+        volume: 90, // Estimate half unit sharing
+        savings: calculatePTSharingSavings(),
+      });
+    }
+  });
+}
+
+// Helper functions for compatibility checking (reusing existing logic)
+function isBloodUnitCompatible(spec, unit) {
+  // Reuse existing compatibility logic
+  const specABO = spec.abo || "";
+  const specRh = spec.rh || "";
+  const unitABO = unit.abo || "";
+  const unitRh = unit.rh || "";
+
+  // Handle blank specs as "any type acceptable"
+  const isABOFlexible = !specABO || specABO === "";
+  const isRhFlexible = !specRh || specRh === "";
+
+  // Check ABO compatibility
+  const aboCompatible =
+    isABOFlexible ||
+    specABO === unitABO ||
+    specABO === "AB" || // AB can receive any
+    (specABO === "A" && unitABO === "O") || // A can receive O
+    (specABO === "B" && unitABO === "O"); // B can receive O
+
+  // Check Rh compatibility
+  const rhCompatible =
+    isRhFlexible || specRh === unitRh || specRh === "Positive"; // Pos can receive Neg
+
+  return aboCompatible && rhCompatible;
+}
+
+function checkHQCCompatibility(spec) {
+  const specABO = spec.abo || "";
+  const specRh = spec.rh || "";
+  const specAntigens = spec.antigens || [];
+
+  // Check HQC-1: AsubB Pos (RhD+ required; others flexible)
+  if (
+    (specABO === "AsubB" || specABO === "") &&
+    (specRh === "Positive" || specRh === "")
+  ) {
+    return {
+      compatible: true,
+      cellId: 1,
+      description: "AsubB Pos",
+      exactMatch: specABO === "AsubB",
+    };
+  }
+
+  // Check HQC-2: O Pos, R1r, Fya− (Rh fixed: D+, C+, E−, c+, e+; Fy(a−))
+  if (
+    (specABO === "O" || specABO === "") &&
+    (specRh === "Positive" || specRh === "")
+  ) {
+    const needsFyaNeg = specAntigens.some(
+      (ag) => ag.antigen === "Fya" && ag.status === "Negative",
+    );
+    if (needsFyaNeg || specAntigens.length === 0) {
+      return {
+        compatible: true,
+        cellId: 2,
+        description: "O Pos R1r Fya-",
+        exactMatch: specABO === "O",
+      };
+    }
+  }
+
+  // Check HQC-3: A1 Neg, rr (Rh fixed: D−, C−, E−, c+, e+)
+  if (
+    (specABO === "A1" || specABO === "A" || specABO === "") &&
+    (specRh === "Negative" || specRh === "")
+  ) {
+    return {
+      compatible: true,
+      cellId: 3,
+      description: "A1 Neg rr",
+      exactMatch: specABO === "A1",
+    };
+  }
+
+  return { compatible: false };
+}
+
+function checkOtherStandingOrders(spec, window) {
+  // Simplified check for other standing orders
+  // In production, this would check C3, Korea, and MQC compatibility
+}
+
+function isManufacturingCompatible(specA, specB) {
+  if (!specA || !specB) return false;
+  const aboA = normalizeAboValue(specA.abo);
+  const rhA = normalizeRhValue(specA.rh);
+  const aboB = normalizeAboValue(specB.abo);
+  const rhB = normalizeRhValue(specB.rh);
+  if (!aboA || !rhA || !aboB || !rhB) return false;
+  return aboA === aboB && rhA === rhB;
+}
+
+function formatBloodType(abo, rh) {
+  const normalizedAbo = normalizeAboValue(abo);
+  const normalizedRh = normalizeRhValue(rh);
+  if (!normalizedAbo || !normalizedRh) return "";
+  const rhLabel = normalizedRh === "Neg" ? "Negative" : "Positive";
+  return `${normalizedAbo} ${rhLabel}`;
+}
+
+function isSpecCompatible(spec1, spec2) {
+  return isBloodUnitCompatible(spec1, { abo: spec2.abo, rh: spec2.rh });
+}
+
+function isDateInWindow(dateStr, window) {
+  if (!dateStr || !window) return false;
+  const date = new Date(dateStr);
+  return date >= window.earliest && date <= window.latest;
+}
+
+function isWindowOverlapping(window1, window2) {
+  return (
+    window1.latest >= window2.earliest && window2.latest >= window1.earliest
+  );
+}
+
+function addOptimizationSuggestion(spec, suggestion) {
+  if (!spec.optimizationSuggestions) {
+    spec.optimizationSuggestions = [];
+  }
+  spec.optimizationSuggestions.push(suggestion);
+}
+
+function calculateUnitSavings(unit) {
+  return { cost: 450, description: "Avoids new unit purchase" };
+}
+
+function calculateStandingOrderSavings() {
+  return { cost: 350, description: "Uses existing overage" };
+}
+
+function calculatePTSharingSavings() {
+  return { cost: 300, description: "Cross-event sharing" };
+}
+
+function closeOptimizationPopover() {
+  if (currentOptimizationPopover) {
+    const suggestionIdsAttr = currentOptimizationPopover.getAttribute(
+      "data-suggestion-ids",
+    );
+    if (suggestionIdsAttr) {
+      suggestionIdsAttr.split(",").forEach((id) => {
+        if (id) delete optimizationSuggestionStore[id];
+      });
+    }
+    if (currentOptimizationPopover.parentNode) {
+      currentOptimizationPopover.parentNode.removeChild(
+        currentOptimizationPopover,
+      );
+    }
+  }
+  currentOptimizationPopover = null;
+  if (optimizationPopoverListener) {
+    document.removeEventListener("click", optimizationPopoverListener);
+    optimizationPopoverListener = null;
+  }
+}
+
+function normalizeAboValue(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = value.toString().toUpperCase();
+  if (!normalized || normalized === "TBD") return null;
+  if (normalized === "ASUBB") return "AB";
+  if (normalized === "A1") return "A";
+  if (normalized === "A1B") return "AB";
+  if (normalized === "FFS") return "O";
+  if (["O", "A", "B", "AB"].includes(normalized)) return normalized;
+  return null;
+}
+
+function normalizeRhValue(value) {
+  if (value === undefined || value === null) return null;
+  const str = value.toString();
+  if (!str || str === "TBD") return null;
+  if (/^pos/i.test(str)) return "Pos";
+  if (/^neg/i.test(str)) return "Neg";
+  return null;
+}
+
+function serializeAntigensForComparison(antigens) {
+  if (!Array.isArray(antigens) || antigens.length === 0) {
+    return "";
+  }
+
+  return antigens
+    .map((antigen) => {
+      if (!antigen) return "";
+      const name = (antigen.antigen || "").toString().toUpperCase();
+      if (!name) return "";
+      const status = (antigen.status || "")
+        .toString()
+        .toLowerCase()
+        .startsWith("neg")
+        ? "NEG"
+        : "POS";
+      return `${name}:${status}`;
+    })
+    .filter(Boolean)
+    .sort()
+    .join("|");
+}
+
+function formatDateKey(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "unscheduled";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeKeyPart(value, fallback = "Unknown") {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const str = value.toString().trim();
+  if (!str) return fallback;
+  return str.replace(/[^A-Za-z0-9]+/g, "_");
+}
+
+function buildStandingOrderSourceKey(productName, windowOrDate) {
+  if (!productName) return null;
+  const normalizedProduct = normalizeKeyPart(productName, "StandingOrder");
+
+  let date = null;
+  if (windowOrDate instanceof Date) {
+    date = windowOrDate;
+  } else if (windowOrDate && typeof windowOrDate === "object") {
+    if (windowOrDate.ship instanceof Date) {
+      date = windowOrDate.ship;
+    } else if (windowOrDate.latest instanceof Date) {
+      date = windowOrDate.latest;
+    } else if (windowOrDate.earliest instanceof Date) {
+      date = windowOrDate.earliest;
+    } else if (windowOrDate.targetDate instanceof Date) {
+      date = windowOrDate.targetDate;
+    }
+  }
+
+  const datePart = date ? formatDateKey(date) : "unscheduled";
+  return `${normalizedProduct}_Overage_${datePart}`;
+}
+
+function getStandingOrderByProduct(productName) {
+  if (!productName) return null;
+  return STANDING_ORDERS.find((order) => order.product === productName) || null;
+}
+
+function getStandingOrderTheoreticalVolume(order) {
+  if (!order) return 0;
+  let total = 0;
+  if (Array.isArray(order.units)) {
+    order.units.forEach((unit) => {
+      if (!unit) return;
+      const count = Number(unit.count);
+      const volume = Number(unit.volume);
+      const safeCount = Number.isFinite(count) && count > 0 ? count : 1;
+      const safeVolume =
+        Number.isFinite(volume) && volume > 0 ? volume : DEFAULT_UNIT_VOLUME;
+      total += safeCount * safeVolume;
+    });
+  }
+  if (order.bonus && order.bonus.volume) {
+    const bonusVolume = Number(order.bonus.volume);
+    total += Number.isFinite(bonusVolume) && bonusVolume > 0 ? bonusVolume : 0;
+  }
+  return total;
+}
+
+function buildPTEventSourceKey(spec) {
+  if (!spec) return null;
+  const customerPart = normalizeKeyPart(spec.customer, "PT");
+  const eventPart = normalizeKeyPart(spec.event, "Event");
+  const yearValue =
+    spec.year !== undefined && spec.year !== null
+      ? spec.year
+      : spec.sample_year !== undefined
+        ? spec.sample_year
+        : "TBD";
+  const yearPart = yearValue.toString().trim() || "TBD";
+  return `${customerPart}_${eventPart}_${yearPart}`;
+}
+
+function estimateSpecAllocationVolume(spec) {
+  if (!spec) return DEFAULT_UNIT_VOLUME;
+
+  const sampleDefinitions = APP_STATE.sampleDefinitions || [];
+  const sampleDef = sampleDefinitions.find(
+    (def) => def.sample_type_id === spec.sample_type_id,
+  );
+  const fillVolume = parseFloat(sampleDef?.fill_ml);
+  const hematocrit = parseFloat(sampleDef?.hct_percent);
+
+  const quantityCandidates = [
+    spec.quantity,
+    spec.expected_quantity,
+    spec.projected_quantity,
+    spec.projectedQuantity,
+    spec.forecast_quantity,
+  ];
+  const quantity = quantityCandidates
+    .map((value) => (Number.isFinite(Number(value)) ? Number(value) : null))
+    .find((value) => value && value > 0);
+
+  const safeQuantity = quantity || 100;
+  const volumePerSample =
+    Number.isFinite(fillVolume) && fillVolume > 0 ? fillVolume : 2;
+  const hctDecimal =
+    Number.isFinite(hematocrit) && hematocrit > 0 ? hematocrit / 100 : 0.04;
+
+  const baseVolume = safeQuantity * volumePerSample * hctDecimal;
+  const retentionVolume = RETENTION_SAMPLES * volumePerSample * hctDecimal;
+  const totalVolume = (baseVolume + retentionVolume) * 1.1;
+
+  const calculated =
+    Number.isFinite(totalVolume) && totalVolume > 0
+      ? totalVolume
+      : DEFAULT_UNIT_VOLUME;
+  return Math.max(Math.round(calculated), DEFAULT_UNIT_VOLUME);
+}
+
+function getCommittedVolumeForSource(sourceKey, excludedSpecKeys = new Set()) {
+  if (!sourceKey || !Array.isArray(APP_STATE.futureAllocations)) {
+    return 0;
+  }
+
+  const exclusionSet =
+    excludedSpecKeys instanceof Set
+      ? excludedSpecKeys
+      : Array.isArray(excludedSpecKeys)
+        ? new Set(excludedSpecKeys)
+        : new Set();
+
+  return APP_STATE.futureAllocations.reduce((sum, allocation) => {
+    if (!allocation || allocation.sourceKey !== sourceKey) {
+      return sum;
+    }
+    if (exclusionSet.has(allocation.specKey)) {
+      return sum;
+    }
+    const volume = Number(allocation.allocatedVolume);
+    return sum + (Number.isFinite(volume) ? volume : 0);
+  }, 0);
+}
+
+function calculateAvailableResourceVolume(
+  sourceKey,
+  theoreticalVolume,
+  excludedSpecKeys = new Set(),
+  alreadyPlanned = 0,
+) {
+  const committed = getCommittedVolumeForSource(sourceKey, excludedSpecKeys);
+  const planned = Number.isFinite(alreadyPlanned) ? alreadyPlanned : 0;
+  const total = Number.isFinite(theoreticalVolume) ? theoreticalVolume : 0;
+  return Math.max(total - committed - planned, 0);
+}
+
+function parseStandingOrderUnit(unit) {
+  if (!unit || !unit.type) return null;
+  let normalized = unit.type
+    .replace(/₁/g, "1")
+    .replace(/₀/g, "0")
+    .replace(/₊/g, "+")
+    .replace(/₋/g, "-")
+    .trim();
+  const parts = normalized.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const abo = normalizeAboValue(parts[0]);
+  if (!abo) return null;
+
+  let rh = "Pos";
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower.includes("either")) {
+      rh = "Either";
+      break;
+    }
+    if (lower.includes("neg")) {
+      rh = "Neg";
+      break;
+    }
+    if (lower.includes("pos")) {
+      rh = "Pos";
+    }
+  }
+
+  const antigens = [];
+  const lowerType = normalized.toLowerCase();
+  if (lowerType.includes("fya")) {
+    antigens.push({
+      antigen: "Fya",
+      status:
+        lowerType.includes("fya neg") || lowerType.includes("fya-")
+          ? "Negative"
+          : "Positive",
+    });
+  }
+  if (lowerType.includes("k pos") || lowerType.includes("k+")) {
+    antigens.push({ antigen: "K", status: "Positive" });
+  } else if (lowerType.includes("k neg") || lowerType.includes("k-")) {
+    antigens.push({ antigen: "K", status: "Negative" });
+  }
+
+  return { abo, rh, antigens, label: normalized };
+}
+
+function hasStandingOrderWithinWindow(productName, window) {
+  if (!productName || !window) return false;
+  if (
+    !APP_STATE.manufacturingCalendar ||
+    APP_STATE.manufacturingCalendar.length === 0
+  ) {
+    return true;
+  }
+
+  const lowerProduct = productName.toLowerCase();
+  const keywords = [lowerProduct];
+  if (lowerProduct.includes("hemo-qc")) keywords.push("hqc");
+  if (lowerProduct.includes("korea") || lowerProduct.includes("mirrscitech")) {
+    keywords.push("mirrscitech");
+    keywords.push("korea");
+  }
+  if (lowerProduct.includes("mqc")) keywords.push("mqc");
+  if (lowerProduct.includes("c3")) keywords.push("c3");
+
+  return APP_STATE.manufacturingCalendar.some((entry) => {
+    if (!entry || !entry.date) return false;
+    const description = (entry.description || "").toLowerCase();
+    const matchesKeyword = keywords.some(
+      (kw) => kw && description.includes(kw),
+    );
+    if (!matchesKeyword) return false;
+    return isDateInWindow(entry.date, window);
+  });
+}
+
+function findBestSuggestionForSample(spec) {
+  if (!spec) return [];
+
+  const fulfillmentWindow = calculateSpecFulfillmentWindow(spec);
+  if (!fulfillmentWindow) return [];
+
+  const sampleAbo = normalizeAboValue(spec.abo);
+  const sampleRh = normalizeRhValue(spec.rh);
+  if (!sampleAbo || !sampleRh) return [];
+
+  const requiredVolume = estimateSpecAllocationVolume(spec);
+  if (!Number.isFinite(requiredVolume) || requiredVolume <= 0) return [];
+
+  const baseAntigens = Array.isArray(spec.antigens)
+    ? spec.antigens.map((antigen) => ({
+        antigen: antigen.antigen,
+        status: antigen.status,
+      }))
+    : [];
+
+  const suggestions = [];
+  const usedSuggestionKeys = new Set();
+
+  const specKey =
+    spec.customer && spec.event && spec.year !== undefined
+      ? `${spec.customer}_${spec.event}_${spec.year}`
+      : null;
+  const exclusionSet = new Set();
+  if (specKey) {
+    exclusionSet.add(specKey);
+  }
+
+  const sampleSignature = { abo: sampleAbo, rh: sampleRh };
+  const sampleBloodType = formatBloodType(sampleAbo, sampleRh);
+
+  const cloneAntigens = (antigens) => {
+    if (!Array.isArray(antigens) || antigens.length === 0) {
+      return baseAntigens.map((antigen) => ({
+        antigen: antigen.antigen,
+        status: antigen.status,
+      }));
+    }
+    return antigens.map((antigen) => ({
+      antigen: antigen.antigen,
+      status: antigen.status,
+    }));
+  };
+
+  const pushSuggestion = (suggestion, keyParts = []) => {
+    if (!suggestion) return;
+    const normalizedAbo = normalizeAboValue(suggestion.abo);
+    const normalizedRh = normalizeRhValue(suggestion.rh);
+    if (!normalizedAbo || !normalizedRh) return;
+
+    const key =
+      keyParts.length > 0
+        ? keyParts.join("|")
+        : `${suggestion.sourceKey || ""}|${normalizedAbo}|${normalizedRh}|${suggestion.sampleId || ""}`;
+    if (usedSuggestionKeys.has(key)) return;
+    usedSuggestionKeys.add(key);
+
+    suggestions.push({
+      ...suggestion,
+      abo: normalizedAbo,
+      rh: normalizedRh,
+      antigens: cloneAntigens(suggestion.antigens),
+    });
+  };
+
+  const standingOrderSavings = calculateStandingOrderSavings() || {};
+
+  (STANDING_ORDERS || []).forEach((order) => {
+    if (!order?.product) return;
+    if (!hasStandingOrderWithinWindow(order.product, fulfillmentWindow)) return;
+
+    const sourceKey = buildStandingOrderSourceKey(
+      order.product,
+      fulfillmentWindow,
+    );
+    if (!sourceKey) return;
+
+    const theoreticalVolume = getStandingOrderTheoreticalVolume(order);
+    const committedVolume = getCommittedVolumeForSource(
+      sourceKey,
+      exclusionSet,
+    );
+    const remainingVolume = Math.max(theoreticalVolume - committedVolume, 0);
+    if (remainingVolume < requiredVolume) return;
+
+    const units = Array.isArray(order.units) ? order.units.slice() : [];
+    if (order.bonus && order.bonus.type) {
+      units.push({ ...order.bonus, isBonus: true });
+    }
+
+    units.forEach((unit, index) => {
+      let candidateAbo = null;
+      let candidateRh = null;
+      let candidateAntigens = [];
+
+      if (unit.isBonus && order.product === "C3 Control Cells") {
+        candidateAbo = normalizeAboValue(unit.type);
+        if (!candidateAbo || candidateAbo !== sampleAbo) return;
+
+        const allocations = (APP_STATE.futureAllocations || []).filter(
+          (allocation) => allocation && allocation.sourceKey === sourceKey,
+        );
+        let lockedRh = null;
+        if (allocations.length > 0) {
+          const existing = allocations[0];
+          lockedRh = normalizeRhValue(existing?.rh);
+          if (!lockedRh) {
+            const detailMatch = (existing?.details || "").match(
+              /(Positive|Negative)/i,
+            );
+            if (detailMatch) {
+              lockedRh = detailMatch[1].toLowerCase().startsWith("neg")
+                ? "Neg"
+                : "Pos";
+            }
+          }
+        }
+
+        if (lockedRh) {
+          if (lockedRh !== sampleRh) return;
+          candidateRh = lockedRh;
+        } else {
+          if (sampleAbo !== "O") return;
+          if (!["Pos", "Neg"].includes(sampleRh)) return;
+          candidateRh = sampleRh;
+        }
+      } else {
+        const parsed = parseStandingOrderUnit(unit);
+        if (!parsed) return;
+        candidateAbo = parsed.abo;
+        const parsedRh =
+          parsed.rh === "Either" ? sampleRh : normalizeRhValue(parsed.rh);
+        candidateRh = parsedRh;
+        candidateAntigens =
+          parsed.antigens && parsed.antigens.length > 0 ? parsed.antigens : [];
+      }
+
+      if (!candidateAbo || !candidateRh) return;
+
+      const candidateSignature = { abo: candidateAbo, rh: candidateRh };
+      if (!isManufacturingCompatible(sampleSignature, candidateSignature))
+        return;
+
+      const detailParts = [`Source: ${order.product} Standing Order`];
+      if (unit.isBonus) {
+        detailParts.push("Bonus allocation.");
+      }
+      if (standingOrderSavings.description) {
+        detailParts.push(standingOrderSavings.description);
+      }
+
+      pushSuggestion(
+        {
+          title: `Use ${formatBloodType(candidateAbo, candidateRh)} from ${order.product} (${Math.round(
+            remainingVolume,
+          )}mL available)`,
+          details: detailParts.join(" "),
+          abo: candidateAbo,
+          rh: candidateRh,
+          antigens: candidateAntigens,
+          sourceDescription: `${order.product} Standing Order`,
+          sourceKey,
+          sourceType: "Standing Order",
+          allocatedVolume: requiredVolume,
+          availableVolume: remainingVolume,
+          theoreticalVolume,
+          savingsDetails: standingOrderSavings.description || "",
+        },
+        [
+          sourceKey,
+          unit.isBonus ? "bonus" : `unit-${index}`,
+          candidateAbo,
+          candidateRh,
+        ],
+      );
+    });
+  });
+
+  const ptSavings = calculatePTSharingSavings() || {};
+
+  const considerSharingCandidate = (candidate, fallbackLabel) => {
+    if (!candidate) return;
+
+    if (
+      candidate.sample_id &&
+      spec.sample_id &&
+      candidate.sample_id === spec.sample_id
+    )
+      return;
+
+    const candidateAbo = normalizeAboValue(candidate.abo);
+    const candidateRh = normalizeRhValue(candidate.rh);
+    if (!candidateAbo || !candidateRh) return;
+
+    const candidateSignature = { abo: candidateAbo, rh: candidateRh };
+    if (!isManufacturingCompatible(sampleSignature, candidateSignature)) return;
+
+    const otherWindow = calculateSpecFulfillmentWindow(candidate);
+    if (!otherWindow || !isWindowOverlapping(fulfillmentWindow, otherWindow))
+      return;
+
+    const sourceKey = buildPTEventSourceKey(candidate);
+    if (!sourceKey) return;
+
+    const theoreticalVolume = estimateSpecAllocationVolume(candidate);
+    const committedVolume = getCommittedVolumeForSource(
+      sourceKey,
+      exclusionSet,
+    );
+    const remainingVolume = Math.max(theoreticalVolume - committedVolume, 0);
+    if (remainingVolume < requiredVolume) return;
+
+    const donorSampleId =
+      candidate.sample_id || candidate.sampleId || "Unknown";
+    const eventLabelParts = [
+      candidate.customer,
+      candidate.event,
+      candidate.year,
+    ]
+      .map((part) => (part !== undefined && part !== null ? part : ""))
+      .filter(Boolean);
+    const eventLabel = eventLabelParts.join(" ").trim() || fallbackLabel;
+
+    const detailsParts = [`Source: ${eventLabel}`];
+    if (ptSavings.description) {
+      detailsParts.push(ptSavings.description);
+    }
+
+    pushSuggestion(
+      {
+        title: `Share ${sampleBloodType} from sample ${donorSampleId}`,
+        details: detailsParts.join(" "),
+        abo: candidateAbo,
+        rh: candidateRh,
+        antigens:
+          Array.isArray(candidate.antigens) && candidate.antigens.length > 0
+            ? candidate.antigens
+            : baseAntigens,
+        sourceDescription: `${eventLabel} sample ${donorSampleId}`,
+        sourceKey,
+        sourceType: "PT Event Sharing",
+        allocatedVolume: requiredVolume,
+        availableVolume: remainingVolume,
+        theoreticalVolume,
+        savingsDetails: ptSavings.description || "",
+        sampleId: donorSampleId,
+      },
+      [sourceKey, donorSampleId],
+    );
+  };
+
+  (APP_STATE.futureSpecs?.entries || [])
+    .filter((candidate) => candidate && candidate.sample_id !== spec.sample_id)
+    .forEach((candidate) =>
+      considerSharingCandidate(candidate, "Future PT Event"),
+    );
+
+  (APP_STATE.customerSpecs || [])
+    .filter((candidate) => candidate && candidate.sample_id !== spec.sample_id)
+    .forEach((candidate) =>
+      considerSharingCandidate(candidate, "Historical PT Event"),
+    );
+
+  return suggestions;
+}
+
+function showOptimizationSuggestions(event) {
+  if (event) event.stopPropagation();
+  closeOptimizationPopover();
+
+  const button = event ? event.currentTarget : null;
+  if (!button) return;
+
+  const modal = document.getElementById("future-spec-edit-modal");
+  if (!modal) return;
+
+  const specKey = modal.dataset.specKey;
+  if (!specKey) return;
+
+  migrateFutureSpecsFormat();
+
+  const row = button.closest("tr");
+  const tbody = row ? row.parentElement : null;
+  const rowIndex =
+    row && tbody ? Array.prototype.indexOf.call(tbody.children, row) : -1;
+
+  const [customer, eventName, year] = specKey.split("_");
+  const relevantSpecs = APP_STATE.futureSpecs.entries
+    .filter(
+      (s) => s.customer === customer && s.event === eventName && s.year == year,
+    )
+    .slice()
+    .sort((a, b) => {
+      const aId = (a.sample_id || "").toString();
+      const bId = (b.sample_id || "").toString();
+      return aId.localeCompare(bId, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    });
+
+  let spec = null;
+  if (rowIndex >= 0) {
+    spec = relevantSpecs[rowIndex] || null;
+  }
+
+  if (!spec && row) {
+    const existingSpecMap = new Map();
+    relevantSpecs.forEach((entry) => {
+      if (entry && entry.sample_id) {
+        existingSpecMap.set(entry.sample_id, entry);
+      }
+    });
+    spec = collectFutureSpecDataFromRow(row, specKey, existingSpecMap) || null;
+  }
+
+  const popover = document.createElement("div");
+  popover.className = "optimization-popover";
+
+  const suggestionIds = [];
+
+  if (!spec || rowIndex < 0) {
+    popover.innerHTML =
+      '<p style="margin: 0;">Unable to locate sample details.</p>';
+  } else {
+    const suggestions = findBestSuggestionForSample(spec);
+    if (!suggestions || suggestions.length === 0) {
+      popover.innerHTML =
+        '<p style="margin: 0;">No optimization opportunities found.</p>';
+    } else {
+      let html = "";
+      suggestions.forEach((suggestion) => {
+        const suggestionId = generateElementId();
+        optimizationSuggestionStore[suggestionId] = suggestion;
+        suggestionIds.push(suggestionId);
+
+        const headerText =
+          suggestion.title ||
+          `${suggestion.abo || ""} ${suggestion.rh || ""}`.trim() ||
+          "Optimization Suggestion";
+
+        const detailSegments = [];
+        if (suggestion.sourceDescription) {
+          detailSegments.push(`Source: ${suggestion.sourceDescription}`);
+        }
+        if (suggestion.savingsDetails) {
+          detailSegments.push(suggestion.savingsDetails);
+        }
+        if (suggestion.antigens && suggestion.antigens.length > 0) {
+          detailSegments.push(
+            `Phenotype: ${formatAntigensDisplay(suggestion.antigens)}`,
+          );
+        }
+
+        const detailsText = detailSegments.join(" ");
+
+        html += `
+                <div class="optimization-suggestion">
+                  <div class="suggestion-header">${escapeHtml(headerText)}</div>
+                  <div class="suggestion-details">${escapeHtml(
+                    detailsText ||
+                      "Aligned with fulfillment window and compatibility rules.",
+                  )}</div>
+                  <button class="btn btn-success btn-sm" onclick="acceptSuggestion(event, ${rowIndex}, '${suggestionId}')">Accept</button>
+                </div>
+              `;
+      });
+      popover.innerHTML = html;
+    }
+  }
+
+  if (suggestionIds.length > 0) {
+    popover.setAttribute("data-suggestion-ids", suggestionIds.join(", "));
+  }
+
+  document.body.appendChild(popover);
+  popover.style.display = "block";
+
+  const rect = button.getBoundingClientRect();
+  const popoverWidth = popover.offsetWidth;
+  const popoverHeight = popover.offsetHeight;
+
+  let top = window.scrollY + rect.bottom + 8;
+  let left = window.scrollX + rect.left;
+
+  if (left + popoverWidth > window.scrollX + window.innerWidth - 16) {
+    left = window.scrollX + window.innerWidth - popoverWidth - 16;
+  }
+  if (left < window.scrollX + 16) {
+    left = window.scrollX + 16;
+  }
+
+  if (top + popoverHeight > window.scrollY + window.innerHeight - 16) {
+    top = window.scrollY + rect.top - popoverHeight - 8;
+  }
+  if (top < window.scrollY + 16) {
+    top = window.scrollY + 16;
+  }
+
+  popover.style.top = `${top}px`;
+  popover.style.left = `${left}px`;
+
+  popover.addEventListener("click", (evt) => evt.stopPropagation());
+
+  currentOptimizationPopover = popover;
+
+  optimizationPopoverListener = function (evt) {
+    if (
+      currentOptimizationPopover &&
+      !currentOptimizationPopover.contains(evt.target)
+    ) {
+      closeOptimizationPopover();
+    }
+  };
+
+  setTimeout(() => {
+    if (optimizationPopoverListener) {
+      document.addEventListener("click", optimizationPopoverListener);
+    }
+  }, 0);
+}
+
+function acceptSuggestion(event, rowIndex, suggestionId) {
+  if (event) event.stopPropagation();
+
+  const suggestion = optimizationSuggestionStore[suggestionId];
+  if (!suggestion) {
+    closeOptimizationPopover();
+    return;
+  }
+
+  const modal = document.getElementById("future-spec-edit-modal");
+  if (!modal) return;
+  const tbody = modal.querySelector("#future-spec-edit-table tbody");
+  if (!tbody) return;
+  const row = tbody.children[rowIndex];
+  if (!row) return;
+
+  const aboSelect = row.querySelector(".edit-abo");
+  if (aboSelect && suggestion.abo) {
+    const optionExists = Array.from(aboSelect.options).some(
+      (opt) => opt.value === suggestion.abo,
+    );
+    if (optionExists) {
+      aboSelect.value = suggestion.abo;
+    }
+  }
+
+  const rhSelect = row.querySelector(".edit-rh");
+  if (rhSelect && suggestion.rh) {
+    const optionExists = Array.from(rhSelect.options).some(
+      (opt) => opt.value === suggestion.rh,
+    );
+    if (optionExists) {
+      rhSelect.value = suggestion.rh;
+    }
+  }
+
+  if (Array.isArray(suggestion.antigens)) {
+    const containerId = row.dataset.antigenContainerId;
+    const container = containerId ? document.getElementById(containerId) : null;
+    if (container) {
+      container.innerHTML = "";
+      suggestion.antigens.forEach((antigenObj) => {
+        if (!antigenObj || !antigenObj.antigen) return;
+        const antigenRowId = generateElementId();
+        const antigenRow = document.createElement("div");
+        antigenRow.className = "antigen-row";
+        antigenRow.id = antigenRowId;
+        antigenRow.style.display = "flex";
+        antigenRow.style.gap = "0.5rem";
+        antigenRow.style.marginBottom = "0.5rem";
+
+        const antigenOptions = ANTIGEN_ORDER.map(
+          (a) =>
+            `<option value="${a}" ${a === antigenObj.antigen ? "selected" : ""}>${a}</option>`,
+        ).join("");
+        const statusOptions = `
+                <option value="Positive" ${antigenObj.status !== "Negative" ? "selected" : ""}>Positive</option>
+                <option value="Negative" ${antigenObj.status === "Negative" ? "selected" : ""}>Negative</option>
+              `;
+
+        antigenRow.innerHTML = `
+                <select class="form-select" style="width: 100px;" onchange="validateAntigenDuplicates('${containerId}')">
+                  ${antigenOptions}
+                </select>
+                <select class="form-select" style="width: 100px;">
+                  ${statusOptions}
+                </select>
+                <button class="btn btn-danger btn-sm" onclick="removeAntigenRow('${antigenRowId}')">×</button>
+              `;
+        container.appendChild(antigenRow);
+      });
+
+      validateAntigenDuplicates(containerId);
+    }
+  }
+
+  try {
+    row.dataset.provisionalAllocation = JSON.stringify(suggestion);
+  } catch (error) {
+    console.warn("Unable to store provisional allocation for row", error);
+  }
+
+  const suggestionsButton = row.querySelector("[data-suggestion-button]");
+  if (suggestionsButton) {
+    suggestionsButton.textContent = "✔️ Allocated";
+    suggestionsButton.classList.remove("btn-outline");
+    suggestionsButton.classList.add("btn-success");
+  }
+
+  delete optimizationSuggestionStore[suggestionId];
+  if (
+    currentOptimizationPopover &&
+    currentOptimizationPopover.hasAttribute("data-suggestion-ids")
+  ) {
+    const remainingIds = currentOptimizationPopover
+      .getAttribute("data-suggestion-ids")
+      .split(",")
+      .filter((id) => id && id !== suggestionId);
+    currentOptimizationPopover.setAttribute(
+      "data-suggestion-ids",
+      remainingIds.join(", "),
+    );
+  }
+
+  closeOptimizationPopover();
+
+  row.classList.remove("row-flash-success");
+  void row.offsetWidth;
+  row.classList.add("row-flash-success");
+  setTimeout(() => {
+    row.classList.remove("row-flash-success");
+  }, 1600);
+}
+
+// ===============================
+// Future Specifications Functions
+// ===============================
+
+function populateFutureSpecYearOptions(customer) {
+  const yearSelect = document.getElementById("future-spec-year");
+  if (!yearSelect) return;
+
+  const previousValue = yearSelect.value;
+  if (!customer) {
+    yearSelect.innerHTML = '<option value="">Select Year</option>';
+    yearSelect.value = "";
+    return;
+  }
+  const years = new Set();
+  let hasUnknown = false;
+
+  getScheduleEntriesForCustomer(customer).forEach((entry) => {
+    const entryYear = deriveScheduleYear(entry);
+    if (Number.isFinite(entryYear)) {
+      years.add(entryYear);
+    } else {
+      hasUnknown = true;
+    }
+  });
+
+  const specs = Array.isArray(APP_STATE.customerSpecs)
+    ? APP_STATE.customerSpecs
+    : [];
+  specs.forEach((spec) => {
+    if (!spec || (customer && spec.customer !== customer)) return;
+    const specYear = Number(spec.year);
+    if (Number.isFinite(specYear)) {
+      years.add(specYear);
+    } else if (spec.year) {
+      hasUnknown = true;
+    }
+  });
+
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  futureEntries.forEach((entry) => {
+    if (!entry || (customer && entry.customer !== customer)) return;
+    const entryYear = Number(entry.year);
+    if (Number.isFinite(entryYear)) {
+      years.add(entryYear);
+    } else if (entry.year) {
+      hasUnknown = true;
+    }
+  });
+
+  const sortedYears = Array.from(years).sort((a, b) => b - a);
+  const options = sortedYears.map((year) => `<option value="${year}">${year}</option>`);
+  if (hasUnknown) {
+    options.push('<option value="Unknown">Unknown</option>');
+  }
+
+  yearSelect.innerHTML = '<option value="">Select Year</option>' + options.join("");
+
+  if (
+    previousValue &&
+    (sortedYears.some((year) => String(year) === String(previousValue)) ||
+      (previousValue === "Unknown" && hasUnknown))
+  ) {
+    yearSelect.value = previousValue;
+  } else {
+    yearSelect.value = "";
+  }
+}
+
+function populateFutureSpecEventOptions(customer, year) {
+  const eventSelect = document.getElementById("future-spec-event");
+  if (!eventSelect) return;
+
+  const previousValue = eventSelect.value;
+  if (!customer) {
+    eventSelect.innerHTML = '<option value="">Select Event</option>';
+    eventSelect.value = "";
+    return;
+  }
+  const events = new Set();
+  const numericYear = Number(year);
+  const matchUnknownYear = year === "Unknown";
+
+  const normalizeYearValue = (value) => {
+    if (value === undefined || value === null || value === "") {
+      return NaN;
+    }
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : NaN;
+  };
+
+  const shouldInclude = (entryYearRaw) => {
+    if (!year) return true;
+    const entryYear = normalizeYearValue(entryYearRaw);
+    if (matchUnknownYear) {
+      return !Number.isFinite(entryYear);
+    }
+    if (!Number.isFinite(numericYear)) {
+      return false;
+    }
+    return Number.isFinite(entryYear) && entryYear === numericYear;
+  };
+
+  getScheduleEntriesForCustomer(customer).forEach((entry) => {
+    if (!entry || !entry.event) return;
+    if (!shouldInclude(deriveScheduleYear(entry))) return;
+    events.add(entry.event);
+  });
+
+  const specs = Array.isArray(APP_STATE.customerSpecs)
+    ? APP_STATE.customerSpecs
+    : [];
+  specs.forEach((spec) => {
+    if (!spec || !spec.event) return;
+    if (customer && spec.customer !== customer) return;
+    if (!shouldInclude(spec.year)) return;
+    events.add(spec.event);
+  });
+
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  futureEntries.forEach((entry) => {
+    if (!entry || !entry.event) return;
+    if (customer && entry.customer !== customer) return;
+    if (!shouldInclude(entry.year)) return;
+    events.add(entry.event);
+  });
+
+  const sortedEvents = Array.from(events).sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+
+  eventSelect.innerHTML =
+    '<option value="">Select Event</option>' +
+    sortedEvents.map((event) => `<option value="${event}">${event}</option>`).join("");
+
+  if (previousValue && sortedEvents.includes(previousValue)) {
+    eventSelect.value = previousValue;
+  } else {
+    eventSelect.value = "";
+  }
+}
+
+function handleFutureSpecCustomerChange() {
+  const customer = document.getElementById("future-spec-customer")?.value || "";
+  populateFutureSpecYearOptions(customer);
+  const year = document.getElementById("future-spec-year")?.value || "";
+  populateFutureSpecEventOptions(customer, year);
+  updateFutureCopyOptions();
+}
+
+function handleFutureSpecYearChange() {
+  const customer = document.getElementById("future-spec-customer")?.value || "";
+  const year = document.getElementById("future-spec-year")?.value || "";
+  populateFutureSpecEventOptions(customer, year);
+  updateFutureCopyOptions();
+}
+
+function handleFutureSpecEventChange() {
+  updateFutureCopyOptions();
+}
+
+function updateFutureCopyOptions() {
+  const customerCode = document.getElementById("future-spec-customer").value;
+  const selectedYear = document.getElementById("future-spec-year")?.value || "";
+  const selectedEvent = document.getElementById("future-spec-event")?.value || "";
+  const copySelect = document.getElementById("future-spec-copy-from");
+
+  if (!copySelect) {
+    return;
+  }
+
+  if (!customerCode) {
+    copySelect.innerHTML = '<option value="">Manual Entry</option>';
+    return;
+  }
+
+  const customerSpecs = Array.isArray(APP_STATE.customerSpecs)
+    ? APP_STATE.customerSpecs
+    : [];
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  const eventsByYear = {};
+
+  const addEvent = (yearValue, event) => {
+    const yearKey =
+      yearValue !== undefined && yearValue !== null && yearValue !== ""
+        ? `${yearValue}`.trim()
+        : "Unknown";
+    if (!eventsByYear[yearKey]) {
+      eventsByYear[yearKey] = new Set();
+    }
+    if (event) {
+      eventsByYear[yearKey].add(event);
+    }
+  };
+
+  customerSpecs
+    .filter((spec) => spec && spec.customer === customerCode)
+    .forEach((spec) => addEvent(spec.year, spec.event));
+
+  futureEntries
+    .filter((spec) => spec && spec.customer === customerCode)
+    .forEach((spec) => addEvent(spec.year, spec.event));
+
+  const sortedYears = Object.keys(eventsByYear).sort((a, b) => {
+    const yearA = parseInt(a, 10);
+    const yearB = parseInt(b, 10);
+
+    if (!Number.isNaN(yearA) && !Number.isNaN(yearB)) {
+      return yearB - yearA;
+    }
+    if (!Number.isNaN(yearA)) return -1;
+    if (!Number.isNaN(yearB)) return 1;
+    return a.localeCompare(b);
+  });
+
+  let optionsHtml = '<option value="">Manual Entry</option>';
+  let preferredOption = "";
+
+  sortedYears.forEach((year) => {
+    const events = Array.from(eventsByYear[year]).sort((a, b) =>
+      `${a}`.localeCompare(`${b}`, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    );
+
+    if (events.length === 0) {
+      return;
+    }
+
+    optionsHtml += `<optgroup label="${year}">`;
+    events.forEach((event) => {
+      const optionValue = `${customerCode} ${event} ${year}`;
+      const optionText = `${customerCode} ${event} ${year}`;
+      optionsHtml += `<option value="${optionValue}">${optionText}</option>`;
+      if (
+        !preferredOption &&
+        selectedYear &&
+        selectedEvent &&
+        String(year) === String(selectedYear) &&
+        event === selectedEvent
+      ) {
+        preferredOption = optionValue;
+      }
+    });
+    optionsHtml += "</optgroup>";
+  });
+
+  copySelect.innerHTML = optionsHtml;
+  if (preferredOption) {
+    copySelect.value = preferredOption;
+  } else {
+    copySelect.value = "";
+  }
+}
+
+function calculateForecastedQuantity(customer, sampleIdToForecast, targetYear) {
+  if (!customer || !sampleIdToForecast) {
+    return 0;
+  }
+
+  let numericYear = Number(targetYear);
+  if (!Number.isFinite(numericYear)) {
+    const currentYear = new Date().getFullYear();
+    numericYear = currentYear;
+  }
+
+  const result = calculateForecast({
+    customer,
+    sampleId: sampleIdToForecast,
+    targetYear: numericYear,
+  });
+
+  if (result.method === "invalid-input" || result.method === "normalization-failed") {
+    return 0;
+  }
+
+  return Number.isFinite(result.value) ? result.value : 0;
+}
+
+function createFutureSpec() {
+  const customer = document.getElementById("future-spec-customer").value;
+  const event = document.getElementById("future-spec-event").value;
+  const year = document.getElementById("future-spec-year").value;
+  const copyFrom = document.getElementById("future-spec-copy-from").value;
+  const quantityInput = document.getElementById("future-spec-quantity");
+  const overrideQuantityValue =
+    quantityInput && quantityInput.value !== ""
+      ? Number(quantityInput.value)
+      : null;
+
+  if (!customer || !event || !year) {
+    showAlert("error", "Please fill in all required fields");
+    return;
+  }
+
+  const specKey = `${customer}_${event}_${year}`;
+
+  // Initialize futureSpecs if it doesn't exist
+  if (!APP_STATE.futureSpecs) {
+    APP_STATE.futureSpecs = {
+      entries: [],
+      versions: {},
+      metadata: {},
+    };
+  }
+
+  // Check if already exists
+  if (APP_STATE.futureSpecs.metadata[specKey]) {
+    showAlert("error", "This specification already exists");
+    return;
+  }
+
+  let samples = [];
+
+  if (copyFrom) {
+    // Parse the copyFrom string correctly
+    // Format is "Customer Event Year" e.g. "OneWorld 4th 2025"
+    const copyParts = copyFrom.split(" ");
+    let copyCustomer = "";
+    let copyEvent = "";
+    let copyYear = "";
+
+    // Handle multi-word customer names (shouldn't be an issue with current customers but good practice)
+    // Since we know the format ends with year, work backwards
+    copyYear = copyParts[copyParts.length - 1];
+
+    // Everything between customer and year is the event
+    // For "OneWorld 4th 2025", we know OneWorld is single word
+    if (
+      customer === "OneWorld" ||
+      customer === "WSLH" ||
+      customer === "ISLA" ||
+      customer === "Aurevia" ||
+      customer === "AABB"
+    ) {
+      copyEvent = copyParts.slice(1, -1).join(" "); // Join in case event has spaces
+    }
+
+    console.log(
+      `Copying from: customer=${customer}, event=${copyEvent}, year=${copyYear}`,
+    );
+
+    // Filter source specs with correct criteria
+    const sourceSpecs = APP_STATE.customerSpecs.filter((spec) => {
+      const match =
+        spec.customer === customer &&
+        spec.event === copyEvent &&
+        String(spec.year) === String(copyYear);
+      if (match) {
+        console.log("Found matching spec:", spec);
+      }
+      return match;
+    });
+
+    console.log(`Found ${sourceSpecs.length} source specs to copy`);
+
+    if (sourceSpecs.length === 0) {
+      showAlert(
+        "warning",
+        `No specifications found for ${customer} ${copyEvent} ${copyYear}`,
+      );
+      // Still create empty structure
+      samples = [];
+    } else {
+      // Create new samples with updated year and TBD blood types
+      samples = sourceSpecs.map((spec) => {
+        const forecast = calculateForecastedQuantity(customer, spec.sample_id, year);
+        const updatedSampleId = spec.sample_id
+          ? spec.sample_id.replace(copyYear, year)
+          : spec.sample_id;
+
+        return {
+          customer: customer,
+          event: event,
+          year: parseInt(year),
+          sample_id: updatedSampleId,
+          sample_type_id: spec.sample_type_id,
+          abo: "TBD",
+          rh: "TBD",
+          antigens: [], // Changed from empty string to empty array
+          antibodies: [], // Changed from antibody_1/antibody_2 to single array
+          dat_status: "Negative", // Changed from is_dat_positive to dat_status
+          status: "draft",
+          forecasted_quantity: forecast,
+        };
+      });
+    }
+  } else {
+    // Manual entry - create empty structure
+    showAlert("info", "Manual entry mode - add samples individually");
+    samples = [];
+  }
+
+  const totalForecastQuantity = samples.reduce((sum, sample) => {
+    const qty = Number(sample.forecasted_quantity);
+    return sum + (Number.isFinite(qty) ? qty : 0);
+  }, 0);
+
+  const metadataQuantity =
+    overrideQuantityValue !== null && Number.isFinite(overrideQuantityValue)
+      ? Math.round(overrideQuantityValue)
+      : samples.length > 0
+        ? Math.round(totalForecastQuantity)
+        : 100;
+
+  const now = new Date().toISOString();
+
+  // Add to futureSpecs
+  APP_STATE.futureSpecs.entries.push(...samples);
+  APP_STATE.futureSpecs.metadata[specKey] = {
+    created: now,
+    lastModified: now,
+    currentVersion: 1,
+    status: "draft",
+    quantity: metadataQuantity,
+    samples: JSON.parse(JSON.stringify(samples)),
+  };
+
+  // Save initial version
+  APP_STATE.futureSpecs.versions[`${specKey}_v1`] = {
+    timestamp: now,
+    samples: JSON.parse(JSON.stringify(samples)),
+  };
+
+  logActivity("Created future specification", `${customer} ${event} ${year}`);
+  showAlert(
+    "success",
+    `Created ${customer} ${event} ${year} with ${samples.length} samples`,
+  );
+  updateFutureSpecsList();
+  persistState();
+
+  // Clear the form after successful creation
+  document.getElementById("future-spec-event").value = "";
+  document.getElementById("future-spec-year").value = "";
+  document.getElementById("future-spec-copy-from").value = "";
+  document.getElementById("future-spec-quantity").value = "";
+  populateFutureSpecYearOptions(customer);
+  populateFutureSpecEventOptions(customer, "");
+  updateFutureCopyOptions();
+}
+
+function updateFutureSpecsList() {
+  const listDiv = document.getElementById("future-specs-list");
+
+  const metadataEntries =
+    (APP_STATE.futureSpecs && APP_STATE.futureSpecs.metadata) || {};
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+
+  const metadataKeys = Object.keys(metadataEntries);
+  const entryOnlyKeys = [];
+
+  futureEntries.forEach((entry) => {
+    if (!entry) {
+      return;
+    }
+
+    const entryKey = `${entry.customer}_${entry.event}_${entry.year}`;
+    if (
+      entryKey &&
+      !metadataEntries[entryKey] &&
+      !entryOnlyKeys.includes(entryKey)
+    ) {
+      entryOnlyKeys.push(entryKey);
+    }
+  });
+
+  const allKeys = [...metadataKeys, ...entryOnlyKeys];
+
+  if (allKeys.length === 0) {
+    listDiv.innerHTML =
+      '<p class="text-center" style="color: var(--gray);">No future specifications created yet</p>';
+    populateMigrationYearOptions();
+    return;
+  }
+
+  let html = "";
+  allKeys.forEach((key) => {
+    if (!key) {
+      return;
+    }
+
+    const metadata = metadataEntries[key] || {};
+    const [customer, event, year] = key.split("_");
+
+    const specs = futureEntries.filter((spec) => {
+      if (!spec) {
+        return false;
+      }
+
+      const specKey = `${spec.customer}_${spec.event}_${spec.year}`;
+      return specKey === key;
+    });
+
+    // Count assigned vs TBD
+    const assigned = specs.filter((s) => s.abo && s.abo !== "TBD").length;
+    const total = specs.length;
+
+    html += `
+      <div class="card mb-2" style="background: var(--light); border: 1px solid var(--border);">
+        <div class="card-header">
+          <h4>${customer} ${event} ${year}</h4>
+          <span class="status-tag ${metadata.status === "approved" ? "available" : "limited"}">
+            ${metadata.status || "draft"}
+          </span>
+        </div>
+        <div style="padding: 1rem;">
+          <p>Samples: ${total} (${assigned} assigned, ${total - assigned} TBD)</p>
+          <p>Quantity: ${metadata.quantity || "Not set"}</p>
+          <p>Version: v${metadata.currentVersion || 1}</p>`;
+
+    // Add optimization suggestions if they exist
+    const specsWithSuggestions = specs.filter(
+      (s) => s.optimizationSuggestions && s.optimizationSuggestions.length > 0,
+    );
+    if (specsWithSuggestions.length > 0) {
+      const totalSuggestions = specsWithSuggestions.reduce(
+        (sum, s) => sum + s.optimizationSuggestions.length,
+        0,
+      );
+      html += `
+            <div class="alert alert-info" style="margin: 0.5rem 0; padding: 0.75rem; background: #e3f2fd; border: 1px solid #1976d2; border-radius: 4px;">
+              <strong>💡 ${totalSuggestions} Optimization Opportunities Found!</strong><br>
+              <small>Compatible blood sources identified for ${specsWithSuggestions.length} samples</small>
+              <details style="margin-top: 0.5rem;">
+                <summary style="cursor: pointer; font-weight: 500;">View Suggestions</summary>
+                <div style="margin-top: 0.5rem;">`;
+
+      specsWithSuggestions.forEach((spec) => {
+        html += `<div style="margin: 0.5rem 0; padding: 0.5rem; background: white; border-radius: 3px;">
+                <strong>Sample ${spec.sample_id} (${spec.abo} ${spec.rh}):</strong><br>`;
+
+        spec.optimizationSuggestions.forEach((suggestion) => {
+          html += `<div style="margin-left: 1rem; margin-top: 0.25rem;">
+                  • <strong>${suggestion.sourceType}:</strong> ${suggestion.description}<br>
+                  <small style="color: #666;">${suggestion.details} | ${suggestion.compatibility}</small>
+                </div>`;
+        });
+        html += "</div>";
+      });
+
+      html += `</div></details>
+            </div>`;
+    }
+
+    html += `<div class="btn-group mt-2">
+            <button class="btn btn-primary btn-sm" onclick="viewFutureSpec('${key}')">
+              View/Edit
+            </button>
+            <button class="btn btn-outline btn-sm" onclick="cloneFutureSpec('${key}')">
+              Clone
+            </button>
+            <button class="btn btn-outline btn-sm" onclick="approveFutureSpec('${key}')">
+              ${metadata.status === "approved" ? "Unapprove" : "Approve"}
+            </button>
+            <button class="btn btn-danger btn-sm" onclick="deleteFutureSpec('${key}')">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  });
+
+  listDiv.innerHTML = html;
+  populateMigrationYearOptions();
+}
+
+function buildSampleTypeOptions(selectedValue) {
+  const definitions = Array.isArray(APP_STATE.sampleDefinitions)
+    ? APP_STATE.sampleDefinitions
+    : [];
+  const seen = new Set();
+  let optionsHtml = '<option value="">Select Type</option>';
+
+  definitions.forEach((definition) => {
+    if (!definition || !definition.sample_type_id) {
+      return;
+    }
+    const typeId = definition.sample_type_id;
+    if (seen.has(typeId)) {
+      return;
+    }
+    seen.add(typeId);
+    const isSelected = typeId === selectedValue;
+    const safeValue = escapeHtml(String(typeId));
+    optionsHtml += `<option value="${safeValue}" ${isSelected ? "selected" : ""}>${safeValue}</option>`;
+  });
+
+  if (selectedValue && !seen.has(selectedValue)) {
+    const safeValue = escapeHtml(String(selectedValue));
+    optionsHtml += `<option value="${safeValue}" selected>${safeValue}</option>`;
+  }
+
+  return optionsHtml;
+}
+
+function createFutureSpecEditRow(spec = {}) {
+  const row = document.createElement("tr");
+  const rowKey = generateElementId();
+  const antigenContainerId = `antigens-${rowKey}`;
+  const antibodyContainerId = `antibodies-${rowKey}`;
+
+  row.dataset.sampleId = spec.sample_id || "";
+  row.dataset.originalSampleId = spec.sample_id || "";
+  row.dataset.antigenContainerId = antigenContainerId;
+  row.dataset.antibodyContainerId = antibodyContainerId;
+
+  const sampleIdValue = escapeHtml(spec.sample_id || "");
+  const aboValue = spec.abo || "TBD";
+  const rhValue = spec.rh || "TBD";
+  const datValue = spec.dat_status === "Positive" ? "Positive" : "Negative";
+
+  const aboOptions = ["TBD", "O", "A", "B", "AB"]
+    .map(
+      (value) =>
+        `<option value="${value}" ${value === aboValue ? "selected" : ""}>${value}</option>`,
+    )
+    .join("");
+
+  const rhOptions = ["TBD", "Pos", "Neg"]
+    .map(
+      (value) =>
+        `<option value="${value}" ${value === rhValue ? "selected" : ""}>${value}</option>`,
+    )
+    .join("");
+
+  const datOptions = ["Negative", "Positive"]
+    .map(
+      (value) =>
+        `<option value="${value}" ${value === datValue ? "selected" : ""}>${value}</option>`,
+    )
+    .join("");
+
+  row.innerHTML = `
+          <td>
+            <input
+              type="text"
+              class="form-input edit-sample-id"
+              value="${sampleIdValue}"
+              placeholder="Enter Sample ID"
+            />
+          </td>
+          <td>
+            <select class="form-select edit-sample-type">
+              ${buildSampleTypeOptions(spec.sample_type_id || "")}
+            </select>
+          </td>
+          <td>
+            <select class="form-select edit-abo" style="width: 90px;">
+              ${aboOptions}
+            </select>
+          </td>
+          <td>
+            <select class="form-select edit-rh" style="width: 90px;">
+              ${rhOptions}
+            </select>
+          </td>
+          <td style="min-width: 250px;">
+            <div class="antigen-container" id="${antigenContainerId}"></div>
+            <button class="btn btn-outline btn-sm" onclick="addAntigenRow('${antigenContainerId}')">+ Add Antigen</button>
+          </td>
+          <td style="min-width: 220px;">
+            <div class="antibody-container" id="${antibodyContainerId}"></div>
+            <button class="btn btn-outline btn-sm" onclick="addAntibodyRow('${antibodyContainerId}')">+ Add Antibody</button>
+          </td>
+          <td>
+            <select class="form-select edit-dat" style="width: 120px;">
+              ${datOptions}
+            </select>
+          </td>
+          <td>
+            <button class="btn btn-outline btn-sm" data-suggestion-button="true" onclick="showOptimizationSuggestions(event)">
+              💡 Suggestions
+            </button>
+          </td>
+          <td>
+            <button class="btn btn-danger btn-sm" onclick="removeFutureSpecRow(this)">Delete</button>
+          </td>
+        `;
+
+  const antigenContainer = row.querySelector(`#${antigenContainerId}`);
+  if (antigenContainer) {
+    antigenContainer.innerHTML = "";
+    if (Array.isArray(spec.antigens)) {
+      spec.antigens.forEach((antigenObj) => {
+        if (!antigenObj || !antigenObj.antigen) return;
+        const elemId = generateElementId();
+        const antigenRow = document.createElement("div");
+        antigenRow.className = "antigen-row";
+        antigenRow.id = elemId;
+        antigenRow.style.display = "flex";
+        antigenRow.style.gap = "0.5rem";
+        antigenRow.style.marginBottom = "0.5rem";
+        antigenRow.innerHTML = `
+                <select class="form-select" style="width: 100px;" onchange="validateAntigenDuplicates('${antigenContainerId}')">
+                  ${ANTIGEN_ORDER.map(
+                    (a) =>
+                      `<option value="${a}" ${a === antigenObj.antigen ? "selected" : ""}>${a}</option>`,
+                  ).join("")}
+                </select>
+                <select class="form-select" style="width: 100px;">
+                  <option value="Positive" ${antigenObj.status === "Positive" ? "selected" : ""}>Positive</option>
+                  <option value="Negative" ${antigenObj.status === "Negative" ? "selected" : ""}>Negative</option>
+                </select>
+                <button class="btn btn-danger btn-sm" onclick="removeAntigenRow('${elemId}')">×</button>
+              `;
+        antigenContainer.appendChild(antigenRow);
+      });
+    }
+  }
+
+  const antibodyContainer = row.querySelector(`#${antibodyContainerId}`);
+  if (antibodyContainer) {
+    antibodyContainer.innerHTML = "";
+    if (Array.isArray(spec.antibodies)) {
+      spec.antibodies.forEach((antibody) => {
+        if (!antibody) return;
+        const elemId = generateElementId();
+        const antibodyRow = document.createElement("div");
+        antibodyRow.className = "antibody-row";
+        antibodyRow.id = elemId;
+        antibodyRow.style.display = "flex";
+        antibodyRow.style.gap = "0.5rem";
+        antibodyRow.style.marginBottom = "0.5rem";
+        antibodyRow.innerHTML = `
+                <select class="form-select" style="width: 150px;" onchange="validateAntibodyDuplicates('${antibodyContainerId}')">
+                  ${AVAILABLE_ANTIBODIES.map(
+                    (a) =>
+                      `<option value="${a}" ${a === antibody ? "selected" : ""}>${a}</option>`,
+                  ).join("")}
+                </select>
+                <button class="btn btn-danger btn-sm" onclick="removeAntibodyRow('${elemId}')">×</button>
+              `;
+        antibodyContainer.appendChild(antibodyRow);
+      });
+    }
+  }
+
+  return row;
+}
+
+function addFutureSpecSampleRow() {
+  const modal = document.getElementById("future-spec-edit-modal");
+  const tbody = modal
+    ? modal.querySelector("#future-spec-edit-table tbody")
+    : null;
+  if (!tbody) {
+    return;
+  }
+
+  const newRow = createFutureSpecEditRow({});
+  tbody.appendChild(newRow);
+}
+function removeFutureSpecRow(button) {
+  if (!button) return;
+  const row = button.closest("tr");
+  if (row) {
+    row.remove();
+  }
+}
+
+function collectFutureSpecDataFromRow(
+  row,
+  specKey,
+  existingSpecMap = new Map(),
+) {
+  if (!row) {
+    return null;
+  }
+
+  const effectiveKey = specKey || "";
+  const [customer = "", eventName = "", yearValue = ""] =
+    effectiveKey.split("_");
+  const sampleIdInput = row.querySelector(".edit-sample-id");
+  const sampleTypeSelect = row.querySelector(".edit-sample-type");
+  const sampleId = sampleIdInput ? sampleIdInput.value.trim() : "";
+
+  if (!sampleId) {
+    return null;
+  }
+
+  const originalSampleId =
+    row.dataset.originalSampleId || row.dataset.sampleId || sampleId;
+  const baseSpec =
+    existingSpecMap.get(originalSampleId) ||
+    existingSpecMap.get(sampleId) ||
+    {};
+  const numericYear = Number(yearValue);
+  const resolvedYear = !Number.isNaN(numericYear) ? numericYear : yearValue;
+
+  const spec = {
+    ...baseSpec,
+    customer: customer || baseSpec.customer || "",
+    event: eventName || baseSpec.event || "",
+    year: resolvedYear !== "" ? resolvedYear : baseSpec.year,
+    sample_id: sampleId,
+    sample_type_id: sampleTypeSelect
+      ? sampleTypeSelect.value
+      : baseSpec.sample_type_id || "",
+  };
+
+  const aboSelect = row.querySelector(".edit-abo");
+  spec.abo = aboSelect ? aboSelect.value || "TBD" : spec.abo || "TBD";
+
+  const rhSelect = row.querySelector(".edit-rh");
+  spec.rh = rhSelect ? rhSelect.value || "TBD" : spec.rh || "TBD";
+
+  const datSelect = row.querySelector(".edit-dat");
+  spec.dat_status = datSelect
+    ? datSelect.value || "Negative"
+    : spec.dat_status || "Negative";
+
+  const antigenContainerId = row.dataset.antigenContainerId;
+  const antigenContainer = antigenContainerId
+    ? document.getElementById(antigenContainerId)
+    : null;
+  spec.antigens = [];
+  if (antigenContainer) {
+    antigenContainer.querySelectorAll(".antigen-row").forEach((antigenRow) => {
+      const selects = antigenRow.querySelectorAll("select");
+      if (selects.length >= 2) {
+        const [antigenSelect, statusSelect] = selects;
+        if (antigenSelect && antigenSelect.value) {
+          spec.antigens.push({
+            antigen: antigenSelect.value,
+            status: statusSelect ? statusSelect.value : "Positive",
+          });
+        }
+      }
+    });
+  }
+
+  const antibodyContainerId = row.dataset.antibodyContainerId;
+  const antibodyContainer = antibodyContainerId
+    ? document.getElementById(antibodyContainerId)
+    : null;
+  spec.antibodies = [];
+  if (antibodyContainer) {
+    antibodyContainer
+      .querySelectorAll(".antibody-row select")
+      .forEach((sel) => {
+        if (sel && sel.value) {
+          spec.antibodies.push(sel.value);
+        }
+      });
+  }
+
+  if (
+    spec.forecasted_quantity === undefined ||
+    spec.forecasted_quantity === null ||
+    Number.isNaN(Number(spec.forecasted_quantity))
+  ) {
+    spec.forecasted_quantity = calculateForecastedQuantity(
+      customer,
+      sampleId,
+      spec.year,
+    );
+  }
+
+  if (!spec.status) {
+    spec.status = "draft";
+  }
+
+  row.dataset.sampleId = sampleId;
+
+  return spec;
+}
+
+function populateQuantityMigrationOptions() {
+  const yearSelect = document.getElementById("migration-qty-year-select");
+  const migrateButton = document.getElementById("migrate-qty-btn");
+
+  if (!yearSelect || !migrateButton) {
+    return;
+  }
+
+  const previousValue = yearSelect.value;
+  const quantities = APP_STATE.confirmedQuantities || [];
+  const years = [
+    ...new Set(
+      quantities
+        .map((qty) => qty.year)
+        .filter(
+          (year) =>
+            year !== undefined && year !== null && `${year}`.trim() !== "",
+        )
+        .map((year) => `${year}`.trim()),
+    ),
+  ].sort((a, b) => {
+    const yearA = parseInt(a, 10);
+    const yearB = parseInt(b, 10);
+
+    if (!isNaN(yearA) && !isNaN(yearB)) {
+      return yearB - yearA;
+    }
+
+    return `${a}`.localeCompare(`${b}`);
+  });
+
+  yearSelect.innerHTML = "";
+
+  if (years.length === 0) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "No order quantities available";
+    option.disabled = true;
+    option.selected = true;
+    yearSelect.appendChild(option);
+    yearSelect.disabled = true;
+    migrateButton.disabled = true;
+    return;
+  }
+
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "Select a year...";
+  defaultOption.disabled = true;
+  defaultOption.selected = true;
+  yearSelect.appendChild(defaultOption);
+
+  years.forEach((year) => {
+    const option = document.createElement("option");
+    option.value = year;
+    option.textContent = year;
+    yearSelect.appendChild(option);
+  });
+
+  yearSelect.disabled = false;
+  migrateButton.disabled = true;
+
+  yearSelect.onchange = () => {
+    migrateButton.disabled = !yearSelect.value;
+  };
+
+  if (previousValue && years.includes(previousValue)) {
+    yearSelect.value = previousValue;
+    migrateButton.disabled = !yearSelect.value;
+  }
+}
+
+function populateMigrationYearOptions() {
+  const yearSelect = document.getElementById("migration-year-select");
+  const migrateButton = document.getElementById("migrate-specs-btn");
+
+  if (!yearSelect || !migrateButton) {
+    return;
+  }
+
+  const futureEntries =
+    (APP_STATE.futureSpecs && APP_STATE.futureSpecs.entries) || [];
+  const years = [
+    ...new Set(
+      futureEntries
+        .map((spec) => spec.year)
+        .filter(
+          (year) =>
+            year !== undefined && year !== null && `${year}`.trim() !== "",
+        )
+        .map((year) => `${year}`.trim()),
+    ),
+  ].sort((a, b) => {
+    const yearA = parseInt(a, 10);
+    const yearB = parseInt(b, 10);
+
+    if (!isNaN(yearA) && !isNaN(yearB)) {
+      return yearB - yearA;
+    }
+
+    return `${a}`.localeCompare(`${b}`);
+  });
+
+  yearSelect.innerHTML = "";
+
+  if (years.length === 0) {
+    const emptyOption = document.createElement("option");
+    emptyOption.value = "";
+    emptyOption.textContent = "No future specs available";
+    emptyOption.disabled = true;
+    emptyOption.selected = true;
+    yearSelect.appendChild(emptyOption);
+    yearSelect.disabled = true;
+    migrateButton.disabled = true;
+    return;
+  }
+
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "Select a year...";
+  defaultOption.disabled = true;
+  defaultOption.selected = true;
+  yearSelect.appendChild(defaultOption);
+
+  years.forEach((year) => {
+    const option = document.createElement("option");
+    option.value = year;
+    option.textContent = year;
+    yearSelect.appendChild(option);
+  });
+
+  yearSelect.disabled = false;
+  migrateButton.disabled = true;
+
+  yearSelect.onchange = () => {
+    migrateButton.disabled = !yearSelect.value;
+  };
+}
+
+function initiateQuantityMigration() {
+  if (!APP_STATE.writeAccess) {
+    showAlert(
+      "warning",
+      "Write access is required to migrate order quantities.",
+    );
+    return;
+  }
+
+  const yearSelect = document.getElementById("migration-qty-year-select");
+  const migrateButton = document.getElementById("migrate-qty-btn");
+
+  if (!yearSelect || !migrateButton) {
+    return;
+  }
+
+  const selectedYear = yearSelect.value;
+  if (!selectedYear) {
+    return;
+  }
+
+  if (
+    !confirm(
+      `Are you sure you want to migrate all order quantities from ${selectedYear} into historical storage?`,
+    )
+  ) {
+    return;
+  }
+
+  if (
+    !confirm(
+      `FINAL CONFIRMATION: This will move ${selectedYear} order quantities out of the active list. Proceed?`,
+    )
+  ) {
+    return;
+  }
+
+  const quantitiesToMigrate = (APP_STATE.confirmedQuantities || []).filter(
+    (qty) => String(qty.year) === String(selectedYear),
+  );
+
+  if (quantitiesToMigrate.length === 0) {
+    showAlert("warning", `No order quantities found for ${selectedYear}.`);
+    return;
+  }
+
+  const timestamp = Date.now();
+  const migratedRecords = quantitiesToMigrate.map((qty, index) => {
+    const quantityValue = parseInt(qty.quantity, 10);
+    return {
+      ...qty,
+      id: `hqty_${timestamp}_${index}`,
+      quantity: Number.isNaN(quantityValue) ? qty.quantity : quantityValue,
+    };
+  });
+
+  APP_STATE.historicalQuantities.push(...migratedRecords);
+
+  const idsToRemove = new Set(
+    quantitiesToMigrate.map((qty) => qty.id).filter((id) => id),
+  );
+  APP_STATE.confirmedQuantities = APP_STATE.confirmedQuantities.filter((qty) => {
+    if (qty.id && idsToRemove.has(qty.id)) {
+      return false;
+    }
+    if (!qty.id) {
+      return String(qty.year) !== String(selectedYear);
+    }
+    return true;
+  });
+
+  updateQuantitiesTable();
+  populateQuantityFilters();
+  updateHistoricalQuantitiesTable();
+  populateHistoricalQuantityFilters();
+  populateQuantityMigrationOptions();
+  populateMigrationYearOptions();
+
+  logActivity(
+    "Migrated order quantities",
+    `${migratedRecords.length} records from ${selectedYear}`,
+  );
+  showAlert(
+    "success",
+    `Migrated ${migratedRecords.length} order quantity records from ${selectedYear}`,
+  );
+
+  yearSelect.value = "";
+  migrateButton.disabled = true;
+
+  persistState();
+}
+
+function initiateSpecMigration() {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Write access is required to migrate specifications.");
+    return;
+  }
+
+  const yearSelect = document.getElementById("migration-year-select");
+  const migrateButton = document.getElementById("migrate-specs-btn");
+
+  if (!yearSelect || !migrateButton) {
+    return;
+  }
+
+  const selectedYear = yearSelect.value;
+  if (!selectedYear) {
+    return;
+  }
+
+  if (
+    !confirm(
+      `Are you sure you want to migrate all future specs from ${selectedYear} to historical specs? This action cannot be undone.`,
+    )
+  ) {
+    return;
+  }
+
+  if (
+    !confirm(
+      `FINAL CONFIRMATION: This will permanently move the data for ${selectedYear}. Proceed?`,
+    )
+  ) {
+    return;
+  }
+
+  const futureEntries =
+    (APP_STATE.futureSpecs && APP_STATE.futureSpecs.entries) || [];
+  const specsToMigrate = futureEntries.filter(
+    (spec) => String(spec.year) === String(selectedYear),
+  );
+
+  if (specsToMigrate.length === 0) {
+    showAlert("warning", `No future specifications found for ${selectedYear}.`);
+    return;
+  }
+
+  const migratedSpecs = specsToMigrate.map((futureSpec) => {
+    const historicalSpec = {
+      customer: futureSpec.customer,
+      event: futureSpec.event,
+      year:
+        typeof futureSpec.year === "number"
+          ? futureSpec.year
+          : parseInt(futureSpec.year, 10) ||
+            parseInt(selectedYear, 10) ||
+            futureSpec.year,
+      sample_id: futureSpec.sample_id,
+      sample_type_id: futureSpec.sample_type_id,
+      abo: futureSpec.abo || "TBD",
+      rh: futureSpec.rh || "TBD",
+      antigens: Array.isArray(futureSpec.antigens)
+        ? futureSpec.antigens.map((antigen) => ({ ...antigen }))
+        : [],
+      antibodies: Array.isArray(futureSpec.antibodies)
+        ? futureSpec.antibodies.map((antibody) =>
+            typeof antibody === "object" && antibody !== null
+              ? { ...antibody }
+              : antibody,
+          )
+        : [],
+      dat_status: futureSpec.dat_status || "Negative",
+      status: futureSpec.status || "draft",
+    };
+
+    if (historicalSpec.antibodies[0]) {
+      historicalSpec.antibody_1 = historicalSpec.antibodies[0];
+    }
+    if (historicalSpec.antibodies[1]) {
+      historicalSpec.antibody_2 = historicalSpec.antibodies[1];
+    }
+
+    const preservedFields = Object.keys(futureSpec || {}).filter(
+      (key) =>
+        ![
+          "customer",
+          "event",
+          "year",
+          "sample_id",
+          "sample_type_id",
+          "abo",
+          "rh",
+          "antigens",
+          "antibodies",
+          "dat_status",
+          "status",
+        ].includes(key),
+    );
+
+    preservedFields.forEach((field) => {
+      const value = futureSpec[field];
+
+      if (Array.isArray(value)) {
+        historicalSpec[field] = value.map((item) =>
+          typeof item === "object" && item !== null ? { ...item } : item,
+        );
+      } else if (value && typeof value === "object") {
+        historicalSpec[field] = { ...value };
+      } else {
+        historicalSpec[field] = value;
+      }
+    });
+
+    return historicalSpec;
+  });
+
+  APP_STATE.customerSpecs.push(...migratedSpecs);
+
+  APP_STATE.futureSpecs.entries = futureEntries.filter(
+    (spec) => String(spec.year) !== String(selectedYear),
+  );
+
+  const keysToRemove = new Set(
+    specsToMigrate.map((spec) => `${spec.customer}_${spec.event}_${spec.year}`),
+  );
+
+  keysToRemove.forEach((key) => {
+    delete APP_STATE.futureSpecs.metadata[key];
+  });
+
+  const versionKeys = Object.keys(APP_STATE.futureSpecs.versions || {});
+  versionKeys.forEach((versionKey) => {
+    for (const specKey of keysToRemove) {
+      if (versionKey.startsWith(`${specKey}_v`)) {
+        delete APP_STATE.futureSpecs.versions[versionKey];
+        break;
+      }
+    }
+  });
+
+  logActivity(
+    `Migrated ${migratedSpecs.length} specifications from ${selectedYear} to historical data.`,
+  );
+
+  showAlert(
+    "success",
+    `Migrated ${migratedSpecs.length} specifications from ${selectedYear} to historical data.`,
+  );
+
+  updateSpecTable();
+  populateSpecFilters();
+  updateFutureSpecsList();
+  updateDashboard();
+  populateMigrationYearOptions();
+
+  migrateButton.disabled = true;
+  yearSelect.value = "";
+
+  persistState();
+}
+
+function findAvailableBlood(customer, event, year) {
+  // This is a simplified version - you'd expand this with real calendar data
+  const scheduleEntry = APP_STATE.manufacturingCalendar.find(
+    (e) =>
+      e.description &&
+      e.description.includes(customer) &&
+      e.description.includes(event),
+  );
+
+  // Mock data for testing WSLH 1st 2026
+  return {
+    window: {
+      start: "2026-09-15",
+      end: "2026-10-05",
+    },
+    sources: [
+      {
+        type: "HQC-1",
+        abo: "AsubB",
+        rh: "Pos",
+        volume: 77,
+        date: "2026-09-28",
+      },
+      { type: "HQC-2", abo: "O", rh: "Pos", volume: 77, date: "2026-09-28" },
+      { type: "HQC-3", abo: "A", rh: "Neg", volume: 77, date: "2026-09-28" },
+      { type: "Korea-1", abo: "A1", rh: "Pos", volume: 22, date: "2026-09-15" },
+      { type: "Korea-2", abo: "B", rh: "Pos", volume: 22, date: "2026-09-15" },
+      { type: "Korea-3", abo: "O", rh: "Neg", volume: 22, date: "2026-09-15" },
+    ],
+  };
+}
+
+function runOptimization(specs, available) {
+  const metadata =
+    APP_STATE.futureSpecs.metadata[
+      `${specs[0].customer}_${specs[0].event}_${specs[0].year}`
+    ];
+  const quantity = metadata?.quantity || 150;
+
+  const assignments = [];
+  const sourcesUsed = new Set();
+  let totalVolume = 0;
+  let sharedVolume = 0;
+
+  // Copy available sources to track usage
+  const availableCopy = JSON.parse(JSON.stringify(available.sources));
+
+  specs.forEach((spec) => {
+    // Get sample definition for volume calculation
+    const sampleDef = APP_STATE.sampleDefinitions.find(
+      (def) => def.sample_type_id === spec.sample_type_id,
+    );
+
+    const volume = parseFloat(sampleDef?.fill_ml) || 2;
+    const hct = parseFloat(sampleDef?.hct_percent) || 4;
+    const volumeNeeded = quantity * volume * (hct / 100) * 1.1; // 10% overage
+
+    totalVolume += volumeNeeded;
+
+    // Find best match from available sources
+    let bestMatch = null;
+    let bestSource = null;
+
+    for (let source of availableCopy) {
+      if (source.volume >= volumeNeeded) {
+        bestMatch = { abo: source.abo, rh: source.rh };
+        bestSource = source.type;
+        source.volume -= volumeNeeded;
+        sharedVolume += volumeNeeded;
+        sourcesUsed.add(source.type);
+        break;
+      }
+    }
+
+    assignments.push({
+      sample_id: spec.sample_id,
+      sample_type_id: spec.sample_type_id,
+      volumeNeeded: volumeNeeded,
+      currentAbo: spec.abo,
+      currentRh: spec.rh,
+      suggestedAbo: bestMatch?.abo || "TBD",
+      suggestedRh: bestMatch?.rh || "TBD",
+      source: bestSource || "NEW ORDER",
+    });
+  });
+
+  const unitsWithoutSharing = Math.ceil(totalVolume / 180);
+  const unitsToOrder = Math.ceil((totalVolume - sharedVolume) / 180);
+  const savings = (unitsWithoutSharing - unitsToOrder) * 450;
+
+  return {
+    assignments,
+    sourcesUsed: Array.from(sourcesUsed),
+    unitsToOrder,
+    unitsWithoutSharing,
+    savings,
+    totalVolume,
+    sharedVolume,
+  };
+}
+
+function acceptOptimization(specKey, index) {
+  const abo = document.getElementById(`opt-abo-${index}`).value;
+  const rh = document.getElementById(`opt-rh-${index}`).value;
+  const antigens = document
+    .getElementById(`opt-antigens-${index}`)
+    .value.trim();
+  const assignment = APP_STATE.lastOptimization.assignments[index];
+
+  // Update the spec
+  const spec = APP_STATE.futureSpecs.entries.find(
+    (s) => s.sample_id === assignment.sample_id,
+  );
+
+  if (spec) {
+    spec.abo = abo;
+    spec.rh = rh;
+    spec.antigens = antigens; // Add this line
+
+    // Update metadata
+    const metadata = APP_STATE.futureSpecs.metadata[specKey];
+    metadata.lastModified = new Date().toISOString();
+
+    showAlert(
+      "success",
+      `Updated ${assignment.sample_id} to ${abo} ${rh} ${
+        antigens ? "with antigens: " + antigens : ""
+      }`,
+    );
+    updateFutureSpecsList();
+    persistState();
+  }
+}
+
+function acceptAllOptimizations(specKey) {
+  if (!APP_STATE.lastOptimization) return;
+
+  APP_STATE.lastOptimization.assignments.forEach((assignment, idx) => {
+    const spec = APP_STATE.futureSpecs.entries.find(
+      (s) => s.sample_id === assignment.sample_id,
+    );
+
+    if (spec && assignment.suggestedAbo !== "TBD") {
+      spec.abo = assignment.suggestedAbo;
+      spec.rh = assignment.suggestedRh;
+    }
+  });
+
+  // Update version
+  const metadata = APP_STATE.futureSpecs.metadata[specKey];
+  metadata.currentVersion++;
+  metadata.lastModified = new Date().toISOString();
+
+  // Save new version
+  APP_STATE.futureSpecs.versions[`${specKey}_v${metadata.currentVersion}`] = {
+    timestamp: new Date().toISOString(),
+    samples: JSON.parse(
+      JSON.stringify(
+        APP_STATE.futureSpecs.entries.filter((s) => {
+          const [customer, event, year] = specKey.split("_");
+          return s.customer === customer && s.event === event && s.year == year;
+        }),
+      ),
+    ),
+  };
+
+  showAlert(
+    "success",
+    "All optimizations applied and saved as version " + metadata.currentVersion,
+  );
+  updateFutureSpecsList();
+  document.getElementById("optimization-results").style.display = "none";
+  persistState();
+}
+
+function closeOptimization() {
+  document.getElementById("optimization-results").style.display = "none";
+}
+
+function viewFutureSpec(specKey) {
+  if (!specKey) {
+    showAlert("error", "Unable to load this specification");
+    return;
+  }
+
+  migrateFutureSpecsFormat();
+
+  closeOptimizationPopover();
+
+  const [customer, event, year] = specKey.split("_");
+  const modal = document.getElementById("future-spec-edit-modal");
+  const tbody = document.querySelector("#future-spec-edit-table tbody");
+  if (!modal || !tbody) {
+    console.error("Future spec edit modal structure missing");
+    return;
+  }
+
+  const metadata = APP_STATE.futureSpecs.metadata[specKey] || {};
+  const titleEl = document.getElementById("future-spec-edit-title");
+  const statusEl = document.getElementById("future-spec-edit-status");
+  const versionEl = document.getElementById("future-spec-edit-version");
+
+  if (titleEl) {
+    titleEl.textContent = `Edit Future Specification: ${customer} ${event} ${year}`;
+  }
+  if (statusEl) {
+    statusEl.textContent = metadata.status || "draft";
+  }
+  if (versionEl) {
+    versionEl.textContent = `v${metadata.currentVersion || 1}`;
+  }
+
+  modal.dataset.specKey = specKey;
+  tbody.innerHTML = "";
+
+  const currentSpecs = APP_STATE.futureSpecs.entries
+    .filter(
+      (s) => s.customer === customer && s.event === event && s.year == year,
+    )
+    .slice();
+  const metadataSamples = Array.isArray(metadata.samples)
+    ? metadata.samples.slice()
+    : [];
+
+  const displaySpecs = (
+    currentSpecs.length > 0 ? currentSpecs : metadataSamples
+  ).sort((a, b) => {
+    const aId = (a?.sample_id || "").toString();
+    const bId = (b?.sample_id || "").toString();
+    return aId.localeCompare(bId, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
+  });
+
+  if (displaySpecs.length === 0) {
+    showAlert(
+      "info",
+      "No samples defined yet. Use Add Sample to begin building this specification.",
+    );
+  }
+
+  displaySpecs.forEach((spec) => {
+    const row = createFutureSpecEditRow(spec || {});
+    tbody.appendChild(row);
+  });
+
+  modal.classList.add("active");
+}
+
+function cloneFutureSpec(specKey) {
+  if (!specKey) {
+    showAlert("error", "Unable to clone this specification");
+    return;
+  }
+
+  const [sourceCustomer = "", sourceEvent = "", sourceYear = ""] =
+    specKey.split("_");
+
+  const customerInput = prompt("New Customer", sourceCustomer);
+  if (customerInput === null) return;
+  const customer = customerInput.trim();
+  if (!customer) {
+    showAlert("error", "Customer is required to clone a specification");
+    return;
+  }
+
+  const eventInput = prompt("New Event", sourceEvent);
+  if (eventInput === null) return;
+  const event = eventInput.trim();
+  if (!event) {
+    showAlert("error", "Event is required to clone a specification");
+    return;
+  }
+
+  const yearInput = prompt("New Year", sourceYear);
+  if (yearInput === null) return;
+  const year = yearInput.trim();
+  if (!year || !/^\d{4}$/.test(year)) {
+    showAlert("error", "Please provide a valid 4-digit year");
+    return;
+  }
+
+  const normalizedYear = parseInt(year, 10);
+  const newSpecKey = `${customer}_${event}_${year}`;
+
+  if (APP_STATE.futureSpecs.metadata[newSpecKey]) {
+    showAlert(
+      "error",
+      "A specification with that customer, event, and year already exists",
+    );
+    return;
+  }
+
+  const sourceSpecs = APP_STATE.futureSpecs.entries.filter(
+    (s) =>
+      s.customer === sourceCustomer &&
+      s.event === sourceEvent &&
+      s.year == sourceYear,
+  );
+
+  if (sourceSpecs.length === 0) {
+    showAlert("error", "No samples found to clone");
+    return;
+  }
+
+  const clonedSamples = sourceSpecs.map((spec) => {
+    const cloned = JSON.parse(JSON.stringify(spec));
+    cloned.customer = customer;
+    cloned.event = event;
+    cloned.year = Number.isNaN(normalizedYear) ? year : normalizedYear;
+    return cloned;
+  });
+
+  const now = new Date().toISOString();
+  APP_STATE.futureSpecs.entries.push(...clonedSamples);
+
+  const sourceMetadata = APP_STATE.futureSpecs.metadata[specKey] || {};
+  APP_STATE.futureSpecs.metadata[newSpecKey] = {
+    status: "draft",
+    created: now,
+    lastModified: now,
+    currentVersion: 1,
+    quantity: sourceMetadata.quantity || clonedSamples.length,
+    samples: JSON.parse(JSON.stringify(clonedSamples)),
+  };
+
+  APP_STATE.futureSpecs.versions[`${newSpecKey}_v1`] = {
+    timestamp: now,
+    samples: JSON.parse(JSON.stringify(clonedSamples)),
+  };
+
+  updateFutureSpecsList();
+  logActivity("Cloned future specification", `${customer} ${event} ${year}`);
+  persistState();
+  showAlert("success", `Cloned specification to ${customer} ${event} ${year}`);
+}
+
+function addAntigenRow(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  // Check for duplicates
+  const existingAntigens = [];
+  container
+    .querySelectorAll(".antigen-row select:first-child")
+    .forEach((sel) => {
+      existingAntigens.push(sel.value);
+    });
+
+  // Find first unused antigen
+  let newAntigen = ANTIGEN_ORDER.find((a) => !existingAntigens.includes(a));
+  if (!newAntigen) {
+    showAlert("warning", "All antigens have been added");
+    return;
+  }
+
+  const elemId = generateElementId();
+  const newRow = document.createElement("div");
+  newRow.className = "antigen-row";
+  newRow.id = elemId;
+  newRow.style = "display: flex; gap: 0.5rem; margin-bottom: 0.5rem;";
+  newRow.innerHTML = `
+    <select class="form-select" style="width: 100px;" onchange="validateAntigenDuplicates('${containerId}')">
+      ${ANTIGEN_ORDER.map(
+        (a) =>
+          `<option value="${a}" ${a === newAntigen ? "selected" : ""}>${a}</option>`,
+      ).join("")}
+    </select>
+    <select class="form-select" style="width: 100px;">
+      <option value="Positive">Positive</option>
+      <option value="Negative">Negative</option>
+    </select>
+    <button class="btn btn-danger btn-sm" onclick="removeAntigenRow('${elemId}')">×</button>
+  `;
+  container.appendChild(newRow);
+}
+
+function removeAntigenRow(elemId) {
+  const elem = document.getElementById(elemId);
+  if (elem) elem.remove();
+}
+
+function addAntibodyRow(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  // Check for duplicates
+  const existingAntibodies = [];
+  container.querySelectorAll(".antibody-row select").forEach((sel) => {
+    existingAntibodies.push(sel.value);
+  });
+
+  // Find first unused antibody
+  let newAntibody = AVAILABLE_ANTIBODIES.find(
+    (a) => !existingAntibodies.includes(a),
+  );
+  if (!newAntibody) {
+    showAlert("warning", "All antibodies have been added");
+    return;
+  }
+
+  const elemId = generateElementId();
+  const newRow = document.createElement("div");
+  newRow.className = "antibody-row";
+  newRow.id = elemId;
+  newRow.style = "display: flex; gap: 0.5rem; margin-bottom: 0.5rem;";
+  newRow.innerHTML = `
+    <select class="form-select" style="width: 150px;" onchange="validateAntibodyDuplicates('${containerId}')">
+      ${AVAILABLE_ANTIBODIES.map(
+        (a) =>
+          `<option value="${a}" ${a === newAntibody ? "selected" : ""}>${a}</option>`,
+      ).join("")}
+    </select>
+    <button class="btn btn-danger btn-sm" onclick="removeAntibodyRow('${elemId}')">×</button>
+  `;
+  container.appendChild(newRow);
+}
+
+function removeAntibodyRow(elemId) {
+  const elem = document.getElementById(elemId);
+  if (elem) elem.remove();
+}
+
+function validateAntigenDuplicates(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  const antigens = [];
+  const selects = container.querySelectorAll(".antigen-row select:first-child");
+
+  selects.forEach((sel) => {
+    if (antigens.includes(sel.value)) {
+      showAlert(
+        "warning",
+        `Duplicate antigen ${sel.value} detected. Please remove or change one.`,
+      );
+      // Find first unused antigen
+      const unused = ANTIGEN_ORDER.find((a) => !antigens.includes(a));
+      if (unused) sel.value = unused;
+    } else {
+      antigens.push(sel.value);
+    }
+  });
+}
+
+function validateAntibodyDuplicates(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  const antibodies = [];
+  const selects = container.querySelectorAll(".antibody-row select");
+
+  selects.forEach((sel) => {
+    if (antibodies.includes(sel.value)) {
+      showAlert(
+        "warning",
+        `Duplicate antibody ${sel.value} detected. Please remove or change one.`,
+      );
+      // Find first unused antibody
+      const unused = AVAILABLE_ANTIBODIES.find((a) => !antibodies.includes(a));
+      if (unused) sel.value = unused;
+    } else {
+      antibodies.push(sel.value);
+    }
+  });
+}
+
+function closeFutureSpecModal() {
+  const modal = document.getElementById("future-spec-edit-modal");
+  if (!modal) {
+    return;
+  }
+
+  closeOptimizationPopover();
+
+  modal.classList.remove("active");
+  delete modal.dataset.specKey;
+
+  const tbody = modal.querySelector("#future-spec-edit-table tbody");
+  if (tbody) {
+    tbody.innerHTML = "";
+  }
+
+  const titleEl = document.getElementById("future-spec-edit-title");
+  if (titleEl) {
+    titleEl.textContent = "Future Specification";
+  }
+
+  const statusEl = document.getElementById("future-spec-edit-status");
+  if (statusEl) {
+    statusEl.textContent = "-";
+  }
+
+  const versionEl = document.getElementById("future-spec-edit-version");
+  if (versionEl) {
+    versionEl.textContent = "-";
+  }
+}
+
+function saveFutureSpecEdits(specKey) {
+  const modal = document.getElementById("future-spec-edit-modal");
+  const tbody = modal
+    ? modal.querySelector("#future-spec-edit-table tbody")
+    : null;
+  if (!modal || !tbody) {
+    showAlert("error", "Edit interface is unavailable");
+    return;
+  }
+
+  const effectiveKey = specKey || modal.dataset.specKey;
+  if (!effectiveKey) {
+    showAlert("error", "Unable to determine which specification to save");
+    return;
+  }
+
+  const rows = Array.from(tbody.querySelectorAll("tr"));
+  const updatedSamples = [];
+  const futureEntries = Array.isArray(APP_STATE.futureSpecs?.entries)
+    ? APP_STATE.futureSpecs.entries
+    : [];
+  const [customer = "", event = "", year = ""] = effectiveKey.split("_");
+
+  const existingSpecMap = new Map();
+  futureEntries
+    .filter(
+      (entry) =>
+        `${entry.customer}_${entry.event}_${entry.year}` === effectiveKey,
+    )
+    .forEach((entry) => {
+      if (entry && entry.sample_id) {
+        existingSpecMap.set(entry.sample_id, entry);
+      }
+    });
+
+  rows.forEach((row) => {
+    const sampleData = collectFutureSpecDataFromRow(
+      row,
+      effectiveKey,
+      existingSpecMap,
+    );
+    if (sampleData) {
+      updatedSamples.push(sampleData);
+    }
+  });
+
+  APP_STATE.futureSpecs.entries = futureEntries.filter((entry) => {
+    const key = `${entry.customer}_${entry.event}_${entry.year}`;
+    return key !== effectiveKey;
+  });
+  APP_STATE.futureSpecs.entries.push(...updatedSamples);
+
+  if (!APP_STATE.futureSpecs.metadata) {
+    APP_STATE.futureSpecs.metadata = {};
+  }
+
+  const now = new Date().toISOString();
+  const metadata = APP_STATE.futureSpecs.metadata[effectiveKey] || {
+    created: now,
+    status: "draft",
+    currentVersion: 0,
+  };
+  metadata.lastModified = now;
+  metadata.currentVersion = (Number(metadata.currentVersion) || 0) + 1;
+  metadata.samples = JSON.parse(JSON.stringify(updatedSamples));
+  APP_STATE.futureSpecs.metadata[effectiveKey] = metadata;
+
+  if (!APP_STATE.futureSpecs.versions) {
+    APP_STATE.futureSpecs.versions = {};
+  }
+  APP_STATE.futureSpecs.versions[
+    `${effectiveKey}_v${metadata.currentVersion}`
+  ] = {
+    timestamp: now,
+    samples: JSON.parse(JSON.stringify(updatedSamples)),
+  };
+
+  closeFutureSpecModal();
+  updateFutureSpecsList();
+  logActivity(
+    "Updated future specification",
+    `${customer} ${event} ${year} (v${metadata.currentVersion})`,
+  );
+  populateMigrationYearOptions();
+  persistState();
+  showAlert(
+    "success",
+    `Saved changes to ${customer} ${event} ${year} (Version ${metadata.currentVersion})`,
+  );
+}
+function approveFutureSpec(specKey) {
+  const metadata = APP_STATE.futureSpecs.metadata[specKey];
+
+  if (metadata.status === "approved") {
+    if (
+      confirm(
+        "This spec was already approved. Are you sure you want to unapprove it?",
+      )
+    ) {
+      metadata.status = "draft";
+      showAlert("warning", "Specification unapproved");
+    }
+  } else {
+    metadata.status = "approved";
+    showAlert("success", "Specification approved for production");
+  }
+
+  updateFutureSpecsList();
+  persistState();
+}
+
+function deleteFutureSpec(specKey) {
+  if (!confirm("Are you sure you want to delete this future specification?")) {
+    return;
+  }
+
+  const [customer, event, year] = specKey.split("_");
+
+  // Remove entries
+  APP_STATE.futureSpecs.entries = APP_STATE.futureSpecs.entries.filter(
+    (s) => !(s.customer === customer && s.event === event && s.year == year),
+  );
+
+  // Remove metadata
+  delete APP_STATE.futureSpecs.metadata[specKey];
+
+  // Keep versions for history
+
+  showAlert("success", "Future specification deleted");
+  updateFutureSpecsList();
+  persistState();
+}
+
+function saveVersion(specKey) {
+  const metadata = APP_STATE.futureSpecs.metadata[specKey];
+  metadata.currentVersion++;
+
+  const [customer, event, year] = specKey.split("_");
+  const currentSpecs = APP_STATE.futureSpecs.entries.filter(
+    (s) => s.customer === customer && s.event === event && s.year == year,
+  );
+
+  APP_STATE.futureSpecs.versions[`${specKey}_v${metadata.currentVersion}`] = {
+    timestamp: new Date().toISOString(),
+    samples: JSON.parse(JSON.stringify(currentSpecs)),
+  };
+
+  showAlert("success", `Saved as version ${metadata.currentVersion}`);
+  updateFutureSpecsList();
+  persistState();
+}
+function updateAntibodyView() {
+  migrateAntibodiesToLotStructure();
+
+  const tableBody = document.querySelector("#antibody-specificity-table tbody");
+  if (!tableBody) return;
+
+  if (
+    !Array.isArray(APP_STATE.antibodies) ||
+    APP_STATE.antibodies.length === 0
+  ) {
+    tableBody.innerHTML = `
+            <tr>
+              <td colspan="4" style="padding: 2rem; text-align: center; color: var(--gray);">
+                No antibody specificities tracked yet. Click "Add Specificity" to get started.
+              </td>
+            </tr>`;
+    updateAntibodyAlerts();
+    return;
+  }
+
+  tableBody.innerHTML = "";
+
+  APP_STATE.antibodies.forEach((specificity) => {
+    const row = document.createElement("tr");
+    row.dataset.specificityId = specificity.id;
+
+    const manufacturerSummary = getManufacturerSummary(specificity);
+    const inventoryCount =
+      (specificity.inventory && specificity.inventory.length) || 0;
+
+    row.innerHTML = `
+            <td>
+              <div style="display: flex; align-items: center; gap: 0.5rem;">
+                <span class="expand-indicator">▶</span>
+                <div>
+                  <div style="font-weight: 600;">${escapeHtml(
+                    specificity.specificity || "Unnamed Specificity",
+                  )}</div>
+                  <div class="specificity-summary">
+                    <span>${escapeHtml(
+                      `${specificity.type || "Monoclonal"} • ${specificity.class || "IgG"}`,
+                    )}</span>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td>${manufacturerSummary}</td>
+            <td>${inventoryCount}</td>
+            <td>
+              <div class="row-actions">
+                <button class="btn btn-outline btn-sm" onclick="event.stopPropagation(); openLotModal('${
+                  specificity.id
+                }')">+ Add Lot</button>
+                <button class="btn btn-outline btn-sm" onclick="event.stopPropagation(); openSpecificityModal('${
+                  specificity.id
+                }')">Edit</button>
+                <button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); deleteSpecificity('${
+                  specificity.id
+                }')">Delete</button>
+              </div>
+            </td>`;
+
+    row.addEventListener("click", (event) => {
+      if (event.target.closest(".row-actions")) return;
+      toggleLotDetailRow(row, specificity);
+    });
+
+    tableBody.appendChild(row);
+  });
+
+  updateAntibodyAlerts();
+}
+
+function getManufacturerSummary(specificity) {
+  const names = (specificity.inventory || [])
+    .map((lot) => lot.manufacturer)
+    .filter((name) => name && name.trim());
+  if (names.length === 0) return "N/A";
+  const unique = [...new Set(names.map((name) => name.trim()))];
+  return escapeHtml(unique.join(", "));
+}
+
+function toggleLotDetailRow(row, specificity) {
+  const tbody = row.parentElement;
+  const existingDetail = row.nextElementSibling;
+  const indicator = row.querySelector(".expand-indicator");
+
+  if (existingDetail && existingDetail.classList.contains("lot-detail-row")) {
+    existingDetail.remove();
+    row.classList.remove("expanded");
+    if (indicator) indicator.textContent = "▶";
+    return;
+  }
+
+  tbody
+    .querySelectorAll(".lot-detail-row")
+    .forEach((detail) => detail.remove());
+  tbody.querySelectorAll("tr.expanded").forEach((expandedRow) => {
+    expandedRow.classList.remove("expanded");
+    const expandedIndicator = expandedRow.querySelector(".expand-indicator");
+    if (expandedIndicator) expandedIndicator.textContent = "▶";
+  });
+
+  row.classList.add("expanded");
+  if (indicator) indicator.textContent = "▼";
+
+  const detailRow = document.createElement("tr");
+  detailRow.className = "lot-detail-row";
+  detailRow.dataset.detailFor = specificity.id;
+
+  const detailCell = document.createElement("td");
+  detailCell.colSpan = 4;
+  detailCell.className = "lot-detail-cell";
+  detailCell.innerHTML = buildLotDetailContent(specificity);
+
+  detailRow.appendChild(detailCell);
+  tbody.insertBefore(detailRow, row.nextSibling);
+}
+
+function buildLotDetailContent(specificity) {
+  if (!specificity.inventory || specificity.inventory.length === 0) {
+    return `
+            <div class="lot-table-wrapper">
+              <div class="alert alert-info">No inventory lots recorded for this specificity.</div>
+              <button class="btn btn-primary btn-sm" onclick="event.stopPropagation(); openLotModal('${
+                specificity.id
+              }')">+ Add Lot</button>
+            </div>`;
+  }
+
+  const parseDilution =
+    window.__parseDilution ||
+    function (t) {
+      if (!t) return null;
+      const value = String(t).trim();
+      const match = value.match(/^1\s*[:/]\s*(\d+)$/i);
+      if (match) {
+        const parsed = Number(match[1]);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+      }
+      const numeric = Number(value);
+      return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+    };
+
+  const fmtPrice = (n) =>
+    n == null || !Number.isFinite(n) ? "—" : `$${n.toFixed(4)}`;
+
+  const rows = specificity.inventory
+    .map((lot) => {
+      const purchasePrice = Number(lot.purchasePrice);
+      const purchaseQuantity = Number(lot.purchaseQuantity);
+      const basePrice =
+        Number.isFinite(purchasePrice) && purchaseQuantity > 0
+          ? purchasePrice / purchaseQuantity
+          : null;
+      const dilSerum = parseDilution(lot.optimalDilutionSerum);
+      const dilDAT = parseDilution(lot.optimalDilutionDAT);
+      const dilutionFactor = dilSerum || dilDAT || null;
+      const optimalPrice =
+        basePrice != null && dilutionFactor ? basePrice / dilutionFactor : null;
+      const requalification = lot.requalificationDate
+        ? escapeHtml(lot.requalificationDate)
+        : "N/A";
+      const currentVolume = Number(lot.currentQuantity || 0).toFixed(1);
+      const manufacturer = lot.manufacturer
+        ? escapeHtml(lot.manufacturer)
+        : "N/A";
+      const lotLabel = lot.lotNumber
+        ? escapeHtml(lot.lotNumber)
+        : escapeHtml(lot.inventoryId);
+
+      return `
+              <tr>
+                <td>${lotLabel}</td>
+                <td>${manufacturer}</td>
+                <td>${currentVolume} mL</td>
+                <td>${requalification}</td>
+                <td>${fmtPrice(basePrice)}</td>
+                <td>${fmtPrice(optimalPrice)}</td>
+                <td>
+                  <div class="lot-actions">
+                    <button class="btn btn-outline btn-sm" onclick="event.stopPropagation(); openLotModal('${
+                      specificity.id
+                    }','${lot.inventoryId}')">Edit</button>
+                    <button class="btn btn-outline btn-sm" onclick="event.stopPropagation(); openLogUsageModal('${
+                      specificity.id
+                    }','${lot.inventoryId}')">Log Usage</button>
+                    <button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); deleteLot('${
+                      specificity.id
+                    }','${lot.inventoryId}')">Delete</button>
+                  </div>
+                </td>
+              </tr>`;
+    })
+    .join("");
+
+  const historySections = specificity.inventory
+    .filter((lot) => Array.isArray(lot.history) && lot.history.length)
+    .map((lot) => {
+      const items = lot.history
+        .slice(0, 5)
+        .map((entry) => formatLotHistoryEntry(entry))
+        .join("");
+      return `
+              <div class="history-list">
+                <h4>Usage History — Lot ${escapeHtml(lot.lotNumber || lot.inventoryId)}</h4>
+                <ul>${items}</ul>
+              </div>`;
+    })
+    .join("");
+
+  return `
+          <div class="lot-table-wrapper">
+            <table class="table lot-table">
+              <thead>
+                <tr>
+                  <th>Lot Number</th>
+                  <th>Manufacturer</th>
+                  <th>Current Volume</th>
+                  <th>Requal. Date</th>
+                  <th>Price/mL</th>
+                  <th>Price/mL (Optimal)</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${rows}
+              </tbody>
+            </table>
+            ${historySections}
+          </div>`;
+}
+
+function formatLotHistoryEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return "<li>Usage logged</li>";
+  }
+  const date = entry.date
+    ? new Date(entry.date).toLocaleDateString()
+    : "Unknown date";
+  const volumeNumber = parseFloat(entry.volume);
+  const volumeLabel = !Number.isNaN(volumeNumber)
+    ? `${volumeNumber.toFixed(1)} mL`
+    : "";
+  const notes = entry.notes ? ` — ${escapeHtml(entry.notes)}` : "";
+  const user = entry.user ? ` (${escapeHtml(entry.user)})` : "";
+  const details = volumeLabel ? `: ${volumeLabel}` : "";
+  return `<li>${escapeHtml(date)}${details}${notes}${user}</li>`;
+}
+
+function openSpecificityModal(specificityId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const modal = document.getElementById("specificity-modal");
+  const title = document.getElementById("specificity-modal-title");
+
+  if (specificityId) {
+    const specificity = APP_STATE.antibodies.find(
+      (item) => item.id === specificityId,
+    );
+    if (!specificity) {
+      showAlert("error", "Unable to find the selected specificity");
+      return;
+    }
+    APP_STATE.editingSpecificityId = specificityId;
+    title.textContent = "Edit Specificity";
+    document.getElementById("specificity-name").value =
+      specificity.specificity || "";
+    document.getElementById("specificity-type").value =
+      specificity.type || "Monoclonal";
+    document.getElementById("specificity-class").value =
+      specificity.class || "IgG";
+  } else {
+    APP_STATE.editingSpecificityId = null;
+    title.textContent = "Add Specificity";
+    resetSpecificityForm();
+  }
+
+  modal.classList.add("active");
+}
+
+function closeSpecificityModal() {
+  const modal = document.getElementById("specificity-modal");
+  modal.classList.remove("active");
+  resetSpecificityForm();
+  APP_STATE.editingSpecificityId = null;
+}
+
+function resetSpecificityForm() {
+  document.getElementById("specificity-name").value = "";
+  document.getElementById("specificity-type").value = "Monoclonal";
+  document.getElementById("specificity-class").value = "IgG";
+}
+
+function saveSpecificity() {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const name = document.getElementById("specificity-name").value.trim();
+  const type = document.getElementById("specificity-type").value;
+  const classValue = document.getElementById("specificity-class").value;
+
+  if (!name) {
+    showAlert("error", "Specificity name is required");
+    return;
+  }
+
+  if (APP_STATE.editingSpecificityId) {
+    const specificity = APP_STATE.antibodies.find(
+      (item) => item.id === APP_STATE.editingSpecificityId,
+    );
+    if (!specificity) {
+      showAlert("error", "Unable to find specificity to update");
+      return;
+    }
+    specificity.specificity = name;
+    specificity.type = type;
+    specificity.class = classValue;
+    logActivity("Updated antibody specificity", name);
+  } else {
+    APP_STATE.antibodies.push({
+      id: createId("ab"),
+      specificity: name,
+      type,
+      class: classValue,
+      inventory: [],
+    });
+    logActivity("Added antibody specificity", name);
+  }
+
+  updateAntibodyView();
+  updateDashboard();
+  persistState();
+  closeSpecificityModal();
+}
+
+function deleteSpecificity(specificityId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const specificityIndex = APP_STATE.antibodies.findIndex(
+    (item) => item.id === specificityId,
+  );
+  if (specificityIndex === -1) {
+    showAlert("error", "Unable to find specificity to delete");
+    return;
+  }
+
+  const specificity = APP_STATE.antibodies[specificityIndex];
+  if (
+    confirm(
+      `Are you sure you want to delete ${specificity.specificity}? All associated lots will be removed.`,
+    )
+  ) {
+    APP_STATE.antibodies.splice(specificityIndex, 1);
+    logActivity("Deleted antibody specificity", specificity.specificity);
+    updateAntibodyView();
+    updateDashboard();
+    persistState();
+    showAlert("success", "Specificity removed");
+  }
+}
+
+function openLotModal(specificityId, lotId = null) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const specificity = APP_STATE.antibodies.find(
+    (item) => item.id === specificityId,
+  );
+  if (!specificity) {
+    showAlert("error", "Unable to find the selected specificity");
+    return;
+  }
+
+  APP_STATE.lotModalState = {
+    specificityId,
+    lotId,
+    mode: lotId ? "edit" : "add",
+  };
+
+  const modal = document.getElementById("inventory-lot-modal");
+  const title = document.getElementById("inventory-lot-modal-title");
+  const saveBtn = document.getElementById("lot-modal-save-btn");
+
+  document.getElementById("lot-form-fields").style.display = "block";
+  document.getElementById("lot-usage-fields").style.display = "none";
+
+  const lot = lotId
+    ? specificity.inventory.find((item) => item.inventoryId === lotId)
+    : null;
+
+  title.textContent = lot
+    ? "Edit Inventory Lot"
+    : `Add Lot — ${specificity.specificity}`;
+  saveBtn.textContent = lot ? "Update Lot" : "Save Lot";
+  saveBtn.onclick = saveLot;
+
+  document.getElementById("lot-manufacturer").value = lot?.manufacturer || "";
+  document.getElementById("lot-number").value = lot?.lotNumber || "";
+  document.getElementById("lot-clone").value = lot?.clone || "";
+  document.getElementById("lot-type").value =
+    lot?.type || specificity.type || "Monoclonal";
+  document.getElementById("lot-class").value =
+    lot?.class || specificity.class || "IgG";
+  document.getElementById("lot-purchase-price").value =
+    lot?.purchasePrice !== undefined ? lot.purchasePrice : "";
+  document.getElementById("lot-purchase-quantity").value =
+    lot?.purchaseQuantity !== undefined ? lot.purchaseQuantity : "";
+  document.getElementById("lot-current-quantity").value =
+    lot?.currentQuantity !== undefined ? lot.currentQuantity : "";
+  document.getElementById("lot-qualification-date").value =
+    lot?.qualificationDate || "";
+  document.getElementById("lot-requalification-date").value =
+    lot?.requalificationDate ||
+    (lot?.qualificationDate
+      ? calculateRequalificationDate(lot.qualificationDate)
+      : "");
+  document.getElementById("lot-optimal-dilution-serum").value =
+    lot && lot.optimalDilutionSerum !== "N/A" ? lot.optimalDilutionSerum : "";
+  document.getElementById("lot-optimal-dilution-dat").value =
+    lot && lot.optimalDilutionDAT !== "N/A" ? lot.optimalDilutionDAT : "";
+
+  modal.classList.add("active");
+}
+
+function openLogUsageModal(specificityId, lotId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const specificity = APP_STATE.antibodies.find(
+    (item) => item.id === specificityId,
+  );
+  if (!specificity) {
+    showAlert("error", "Unable to find the selected specificity");
+    return;
+  }
+
+  const lot = specificity.inventory.find((item) => item.inventoryId === lotId);
+  if (!lot) {
+    showAlert("error", "Unable to find the selected lot");
+    return;
+  }
+
+  APP_STATE.lotModalState = {
+    specificityId,
+    lotId,
+    mode: "usage",
+  };
+
+  const modal = document.getElementById("inventory-lot-modal");
+  const title = document.getElementById("inventory-lot-modal-title");
+  const saveBtn = document.getElementById("lot-modal-save-btn");
+
+  document.getElementById("lot-form-fields").style.display = "none";
+  document.getElementById("lot-usage-fields").style.display = "block";
+
+  title.textContent = "Log Lot Usage";
+  saveBtn.textContent = "Log Usage";
+  saveBtn.onclick = saveUsage;
+
+  document.getElementById("usage-specificity-name").textContent =
+    specificity.specificity || "Specificity";
+  document.getElementById("usage-lot-number").textContent =
+    lot.lotNumber || lot.inventoryId;
+  document.getElementById("lot-usage-volume").value = "";
+  document.getElementById("lot-usage-notes").value = "";
+
+  modal.classList.add("active");
+}
+
+function closeLotModal() {
+  const modal = document.getElementById("inventory-lot-modal");
+  modal.classList.remove("active");
+  resetLotForm();
+  APP_STATE.lotModalState = {
+    specificityId: null,
+    lotId: null,
+    mode: "add",
+  };
+}
+
+function resetLotForm() {
+  const fields = [
+    "lot-manufacturer",
+    "lot-number",
+    "lot-clone",
+    "lot-purchase-price",
+    "lot-purchase-quantity",
+    "lot-current-quantity",
+    "lot-qualification-date",
+    "lot-requalification-date",
+    "lot-optimal-dilution-serum",
+    "lot-optimal-dilution-dat",
+    "lot-usage-volume",
+    "lot-usage-notes",
+  ];
+  fields.forEach((id) => {
+    const element = document.getElementById(id);
+    if (element) element.value = "";
+  });
+  document.getElementById("usage-specificity-name").textContent = "";
+  document.getElementById("usage-lot-number").textContent = "";
+  document.getElementById("lot-form-fields").style.display = "block";
+  document.getElementById("lot-usage-fields").style.display = "none";
+  const saveBtn = document.getElementById("lot-modal-save-btn");
+  saveBtn.textContent = "Save Lot";
+  saveBtn.onclick = saveLot;
+}
+
+function saveLot() {
+  const { specificityId, lotId } = APP_STATE.lotModalState;
+  const specificity = APP_STATE.antibodies.find(
+    (item) => item.id === specificityId,
+  );
+  if (!specificity) {
+    showAlert("error", "Unable to find the selected specificity");
+    return;
+  }
+
+  const lotNumber = document.getElementById("lot-number").value.trim();
+  if (!lotNumber) {
+    showAlert("error", "Lot number is required");
+    return;
+  }
+
+  const manufacturer = document.getElementById("lot-manufacturer").value.trim();
+  const clone = document.getElementById("lot-clone").value.trim();
+  const type = document.getElementById("lot-type").value;
+  const classValue = document.getElementById("lot-class").value;
+  const purchasePrice =
+    parseFloat(document.getElementById("lot-purchase-price").value) || 0;
+  const purchaseQuantity =
+    parseFloat(document.getElementById("lot-purchase-quantity").value) || 0;
+  const currentQuantityInput = parseFloat(
+    document.getElementById("lot-current-quantity").value,
+  );
+  const currentQuantity = Number.isNaN(currentQuantityInput)
+    ? purchaseQuantity
+    : currentQuantityInput;
+  const qualificationDate = document.getElementById(
+    "lot-qualification-date",
+  ).value;
+  let requalificationDate = document.getElementById(
+    "lot-requalification-date",
+  ).value;
+  if (!requalificationDate && qualificationDate) {
+    requalificationDate = calculateRequalificationDate(qualificationDate);
+  }
+  const optimalDilutionSerum =
+    document.getElementById("lot-optimal-dilution-serum").value.trim() || "N/A";
+  const optimalDilutionDAT =
+    document.getElementById("lot-optimal-dilution-dat").value.trim() || "N/A";
+
+  const existingLot = lotId
+    ? specificity.inventory.find((item) => item.inventoryId === lotId)
+    : null;
+
+  const normalized = normalizeLot(
+    {
+      inventoryId: existingLot ? existingLot.inventoryId : createId("lot"),
+      manufacturer,
+      lotNumber,
+      clone,
+      type,
+      class: classValue,
+      purchasePrice,
+      purchaseQuantity,
+      currentQuantity,
+      qualificationDate,
+      requalificationDate,
+      optimalDilutionSerum,
+      optimalDilutionDAT,
+      history:
+        existingLot && Array.isArray(existingLot.history)
+          ? existingLot.history.slice()
+          : [],
+      lowStockThreshold: existingLot?.lowStockThreshold || null,
+      status: existingLot?.status || "Available",
+    },
+    specificity,
+  );
+  normalized.lowStockThreshold = getLotLowStockThreshold(normalized);
+
+  if (existingLot) {
+    Object.assign(existingLot, normalized);
+    logActivity(
+      "Updated antibody lot",
+      `${specificity.specificity} • ${lotNumber}`,
+    );
+  } else {
+    specificity.inventory.push(normalized);
+    logActivity(
+      "Added antibody lot",
+      `${specificity.specificity} • ${lotNumber}`,
+    );
+  }
+
+  updateAntibodyView();
+  updateDashboard();
+  persistState();
+  closeLotModal();
+}
+
+function deleteLot(specificityId, lotId) {
+  if (!APP_STATE.writeAccess) {
+    showAlert("warning", "Please complete setup to manage antibodies");
+    return;
+  }
+
+  const specificity = APP_STATE.antibodies.find(
+    (item) => item.id === specificityId,
+  );
+  if (!specificity) {
+    showAlert("error", "Unable to find the selected specificity");
+    return;
+  }
+
+  const lotIndex = specificity.inventory.findIndex(
+    (item) => item.inventoryId === lotId,
+  );
+  if (lotIndex === -1) {
+    showAlert("error", "Unable to find the selected lot");
+    return;
+  }
+
+  const lot = specificity.inventory[lotIndex];
+  if (
+    confirm(
+      `Delete lot ${lot.lotNumber || lot.inventoryId} for ${specificity.specificity}?`,
+    )
+  ) {
+    specificity.inventory.splice(lotIndex, 1);
+    logActivity(
+      "Deleted antibody lot",
+      `${specificity.specificity} • ${lot.lotNumber || lot.inventoryId}`,
+    );
+    updateAntibodyView();
+    updateDashboard();
+    persistState();
+    showAlert("success", "Inventory lot removed");
+  }
+}
+
+function saveUsage() {
+  const { specificityId, lotId } = APP_STATE.lotModalState;
+  const specificity = APP_STATE.antibodies.find(
+    (item) => item.id === specificityId,
+  );
+  if (!specificity) {
+    showAlert("error", "Unable to find the selected specificity");
+    return;
+  }
+
+  const lot = specificity.inventory.find((item) => item.inventoryId === lotId);
+  if (!lot) {
+    showAlert("error", "Unable to find the selected lot");
+    return;
+  }
+
+  const volume = parseFloat(document.getElementById("lot-usage-volume").value);
+  if (Number.isNaN(volume) || volume <= 0) {
+    showAlert("error", "Volume to use must be greater than zero");
+    return;
+  }
+
+  if (volume > lot.currentQuantity) {
+    showAlert("error", "Cannot use more volume than is currently available");
+    return;
+  }
+
+  const notes = document.getElementById("lot-usage-notes").value.trim();
+  lot.currentQuantity = Math.max(0, lot.currentQuantity - volume);
+  lot.history = Array.isArray(lot.history) ? lot.history : [];
+  lot.history.unshift({
+    id: createId("usage"),
+    date: new Date().toISOString(),
+    volume,
+    notes,
+    user: APP_STATE.currentUser || "Unknown",
+  });
+
+  logActivity(
+    "Logged antibody usage",
+    `${specificity.specificity} • ${lot.lotNumber || lot.inventoryId} (${volume.toFixed(1)} mL)`,
+  );
+
+  updateAntibodyView();
+  updateDashboard();
+  persistState();
+  closeLotModal();
+}
+
+function updateAntibodyAlerts() {
+  const alertsDiv = document.getElementById("antibody-alerts");
+  if (!alertsDiv) return;
+
+  if (!APP_STATE.antibodies || APP_STATE.antibodies.length === 0) {
+    alertsDiv.innerHTML =
+      '<div class="alert alert-info">No antibody alerts at this time</div>';
+    const lowStockEl = document.getElementById("low-stock-count");
+    if (lowStockEl) {
+      lowStockEl.textContent = "0";
+    }
+    return;
+  }
+
+  const alerts = [];
+  let lowStockCount = 0;
+
+  APP_STATE.antibodies.forEach((specificity) => {
+    (specificity.inventory || []).forEach((lot) => {
+      const threshold = getLotLowStockThreshold(lot);
+      if (threshold && lot.currentQuantity <= threshold) {
+        lowStockCount += 1;
+        const alertType =
+          lot.currentQuantity <= threshold / 2 ? "error" : "warning";
+        const remaining = Number(lot.currentQuantity || 0).toFixed(1);
+        alerts.push({
+          type: alertType,
+          message: `${specificity.specificity} lot ${lot.lotNumber || lot.inventoryId}: ${remaining} mL remaining (low stock)`,
+        });
+      }
+
+      if (lot.requalificationDate) {
+        const requalDate = new Date(lot.requalificationDate);
+        if (!Number.isNaN(requalDate.getTime())) {
+          const daysUntil = Math.round(
+            (requalDate - new Date()) / (1000 * 60 * 60 * 24),
+          );
+          if (daysUntil <= 30) {
+            alerts.push({
+              type: daysUntil <= 0 ? "error" : "warning",
+              message: `${specificity.specificity} lot ${lot.lotNumber || lot.inventoryId}: requalification ${
+                daysUntil <= 0 ? "overdue" : `due in ${daysUntil} days`
+              }`,
+            });
+          }
+        }
+      }
+    });
+  });
+
+  const lowStockEl = document.getElementById("low-stock-count");
+  if (lowStockEl) {
+    lowStockEl.textContent = String(lowStockCount);
+  }
+
+  if (alerts.length === 0) {
+    alertsDiv.innerHTML =
+      '<div class="alert alert-info">No antibody alerts at this time</div>';
+  } else {
+    alertsDiv.innerHTML = alerts
+      .map(
+        (alert) => `
+                <div class="alert alert-${alert.type}">${escapeHtml(alert.message)}</div>
+              `,
+      )
+      .join("");
+  }
+}
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add rule-based sample ID normalization with logging and create a regression-based forecasting routine with explicit fallbacks
- refactor the calculator and BUP workflows to use the new forecast logic, gate forecast mode to future events, and surface fallback messaging in the UI
- upgrade table pagination controls with reusable handlers and accessibility improvements while bumping the app version to v1.0.1

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfe9caeb50832db10fa5a6ef6b5c56